### PR TITLE
Adding Cerritos and Protostar NCC #s

### DIFF
--- a/WebTools/src/components/registryNumberGenerator.tsx
+++ b/WebTools/src/components/registryNumberGenerator.tsx
@@ -30,6 +30,8 @@ class RegistryNumberGenerator {
         74205: "Defiant",
         74656: "Voyager",
         74913: "Prometheus",
+        75567: "Cerritos",
+        76884: "Protostar",
         80102: "Titan",
         82893: "Stargazer",
         86505: "Zheng He"


### PR DESCRIPTION
Adding two of the latest "hero ships" to the list. (Protostar is an NX.) Obviously an exhaustive list of verified numbers from Memory Alpha would be impractical, but the main ships from every series should be included, I think.