### PR TITLE
Adding Dominion allied military and government types

### DIFF
--- a/WebTools/src/helpers/alliedMilitary.ts
+++ b/WebTools/src/helpers/alliedMilitary.ts
@@ -9,6 +9,7 @@ export enum AlliedMilitaryType {
     ROMULAN_STAR_EMPIRE,
     BAJORAN_MILITIA,
     CARDASSIAN_UNION,
+    DOMINION,
     OTHER
 }
 
@@ -34,6 +35,7 @@ class _AllyHelper {
                 Era.NextGeneration),
         new AlliedMilitary("Cardassian Union", AlliedMilitaryType.CARDASSIAN_UNION, [Species.Cardassian], 
                 Era.NextGeneration),
+        new AlliedMilitary("Dominion", AlliedMilitaryType.Dominion, [Species.JemHadar], Era.NextGeneration),
         new AlliedMilitary("Klingon Defence Force",AlliedMilitaryType.KLINGON_DEFENCE_FORCE, [Species.KlingonExt, Species.Klingon, Species.KlingonQuchHa], 
                 Era.Enterprise, Era.OriginalSeries, Era.NextGeneration),
         new AlliedMilitary("MACO", AlliedMilitaryType.MACO, [Species.Human], Era.Enterprise),

--- a/WebTools/src/helpers/alliedMilitary.ts
+++ b/WebTools/src/helpers/alliedMilitary.ts
@@ -35,7 +35,7 @@ class _AllyHelper {
                 Era.NextGeneration),
         new AlliedMilitary("Cardassian Union", AlliedMilitaryType.CARDASSIAN_UNION, [Species.Cardassian], 
                 Era.NextGeneration),
-        new AlliedMilitary("Dominion", AlliedMilitaryType.Dominion, [Species.JemHadar], Era.NextGeneration),
+        new AlliedMilitary("Dominion", AlliedMilitaryType.DOMINION, [Species.JemHadar], Era.NextGeneration),
         new AlliedMilitary("Klingon Defence Force",AlliedMilitaryType.KLINGON_DEFENCE_FORCE, [Species.KlingonExt, Species.Klingon, Species.KlingonQuchHa], 
                 Era.Enterprise, Era.OriginalSeries, Era.NextGeneration),
         new AlliedMilitary("MACO", AlliedMilitaryType.MACO, [Species.Human], Era.Enterprise),

--- a/WebTools/src/helpers/governments.ts
+++ b/WebTools/src/helpers/governments.ts
@@ -9,6 +9,7 @@ export enum GovernmentType {
     ROMULAN,
     BAJORAN,
     CARDASSIAN,
+    DOMINION,
     OTHER
 }
 
@@ -29,6 +30,7 @@ class _Governments {
         new Government("Andorian",GovernmentType.ANDORIAN, Era.Enterprise),
         new Government("Bajoran", GovernmentType.BAJORAN, Era.NextGeneration),
         new Government("Cardassian", GovernmentType.CARDASSIAN, Era.NextGeneration),
+        new Government("Dominion", GovernmentType.DOMINION, Era.NextGeneration),
         new Government("Federation", GovernmentType.FEDERATION, Era.Enterprise, Era.OriginalSeries, Era.NextGeneration),
         new Government("Klingon",GovernmentType.KLINGON, Era.Enterprise, Era.OriginalSeries, Era.NextGeneration),
         new Government("Romulan", GovernmentType.ROMULAN, Era.OriginalSeries, Era.NextGeneration),


### PR DESCRIPTION
Per individual commits, adding Dominion so people can experience DS9-type adventures, or for people coming from STO's playable Jem'Hadar. As far as I can tell, these two docs are where this thing is added, and shouldn't mess other stuff up.