### PR TITLE
Update package-lock.json (version number)

### DIFF
--- a/WebTools/package-lock.json
+++ b/WebTools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "startrek",
-  "version": "1.230507",
+  "version": "1.230820",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "startrek",
-      "version": "1.230507",
+      "version": "1.230820",
       "license": "ISC",
       "dependencies": {
         "@pdf-lib/fontkit": "1.1.1",


### PR DESCRIPTION
Finally doing the node.js stuff under 'get started', git desktop told me this file had changed... the only change was the version number updating to match the one in package.json. I have no idea why it changed this, but it seems like a good change?