### PR TITLE
ModifierBreadcrumb and careerstep fix

### DIFF
--- a/WebTools/src/helpers/marshaller.ts
+++ b/WebTools/src/helpers/marshaller.ts
@@ -158,7 +158,7 @@ class Marshaller {
         if (character.careerStep != null) {
             if (character.careerStep.career != null) {
                 sheet["career"] = {
-                    "length": Career[character.careerStep.value]
+                    "length": Career[character.careerStep.career]
                 }
             }
             if (character.careerStep.value) {
@@ -308,6 +308,7 @@ class Marshaller {
 
             sheet["role"] = role;
         }
+
         return sheet;
     }
 
@@ -822,7 +823,7 @@ class Marshaller {
             } else {
                 let length = temp.length;
                 if (length != null) {
-                    let career = CareersHelper.instance.getCareerByTypeName(temp, result.type);
+                    let career = CareersHelper.instance.getCareerByTypeName(temp.length, result.type);
                     if (result.careerStep != null) {
                         result.careerStep.career = career?.id;
                     } else {

--- a/WebTools/src/helpers/marshaller.ts
+++ b/WebTools/src/helpers/marshaller.ts
@@ -823,7 +823,7 @@ class Marshaller {
             } else {
                 let length = temp.length;
                 if (length != null) {
-                    let career = CareersHelper.instance.getCareerByTypeName(temp.length, result.type);
+                    let career = CareersHelper.instance.getCareerByTypeName(length, result.type);
                     if (result.careerStep != null) {
                         result.careerStep.career = career?.id;
                     } else {

--- a/WebTools/src/helpers/ranks.ts
+++ b/WebTools/src/helpers/ranks.ts
@@ -1050,25 +1050,7 @@ export class RanksHelper {
         ];
 
     getRanks(character: Character, ignorePrerequisites?: boolean) {
-        let ranks: RankModel[] = [];
-
-        for (let rank in this._ranks) {
-            let r = this._ranks[rank];
-            let valid = true;
-
-            if (ignorePrerequisites === undefined || ignorePrerequisites === false) {
-                r.prerequisites.forEach(req => {
-                    if (!req.isPrerequisiteFulfilled(character)) {
-                        valid = false;
-                    }
-                });
-            }
-
-            if (valid) {
-                ranks.push(r);
-            }
-        }
-        return ranks;
+        return !ignorePrerequisites ? this._ranks.filter(r => r.prerequisites.every(p => p.isPrerequisiteFulfilled(character))) : [...this._ranks];
     }
 
     getSortedRanks(character: Character, ignorePrerequisites?: boolean) {

--- a/WebTools/src/helpers/sheets.ts
+++ b/WebTools/src/helpers/sheets.ts
@@ -912,6 +912,7 @@ class BaseTextCharacterSheet extends BasicFullCharacterSheet {
         );
     }
 
+    /* eslint-disable no-loop-func */
     createTextBlocks(text: string, fontSpec: FontSpecification, symbolStyle: FontSpecification, line: Line, page: PDFPage) {
         let result: Line[] = [];
         if (line) {
@@ -992,6 +993,7 @@ class BaseTextCharacterSheet extends BasicFullCharacterSheet {
         }
         return result;
     }
+    /* eslint-enable no-loop-func */
 
     containsDelta(word: string) {
         return word.indexOf("[D]") >= 0;

--- a/WebTools/src/modify/modifyBreadcrumb.tsx
+++ b/WebTools/src/modify/modifyBreadcrumb.tsx
@@ -1,0 +1,69 @@
+import { t } from "i18next";
+import { navigateTo } from "../common/navigator";
+import { makeKey } from "../common/translationKey";
+import { PageIdentity } from "../pages/pageIdentity";
+import { MilestoneType } from "./model/milestoneType";
+import { NavigateFunction, useNavigate } from "react-router";
+import { ModificationType } from "./model/modificationType";
+
+export interface IModifyBreadcrumbProperties {
+  modificationType?: ModificationType;
+  milestoneType?: MilestoneType;
+  isComplete?: boolean;
+}
+
+const goToHome = (
+  e: React.MouseEvent<HTMLAnchorElement>,
+  navigate: NavigateFunction
+) => {
+  e.preventDefault();
+  e.stopPropagation();
+
+  navigate("/");
+};
+
+export const ModifyBreadcrumb = (props: IModifyBreadcrumbProperties) => {
+  const { modificationType, milestoneType, isComplete } = props;
+  const navigate = useNavigate();
+
+  // Default is Type Selection
+  let activePageTitle = "modificationTypeSelection";
+
+  if (isComplete) activePageTitle = "modificationComplete";
+  // It's a numeric enum, we can't do the regular falsy here with a 0.
+  else if (milestoneType > -1) activePageTitle = MilestoneType[milestoneType];
+  else {
+    switch (modificationType) {
+      case ModificationType.Promotion:
+        activePageTitle = "promotion";
+        break;
+      case ModificationType.Reputation:
+        activePageTitle = "reputationChange";
+        break;
+    }
+  }
+
+  activePageTitle = makeKey("Page.title.", activePageTitle);
+
+  return (
+    <nav aria-label="breadcrumb">
+      <ol className="breadcrumb">
+        <li className="breadcrumb-item">
+          <a href="/index.html" onClick={(e) => goToHome(e, navigate)}>
+            {t("Page.title.home")}
+          </a>
+        </li>
+        {(() => {
+          if (milestoneType) {
+            return (
+              <li className="breadcrumb-item"><a href="/index.html" onClick={(e) => navigateTo(e, PageIdentity.ModificationTypeSelection)}>
+                  {t("Page.title.modificationTypeSelection")}
+                </a></li>
+            );
+          }
+          return (<li className="breadcrumb-item active" aria-current="page">{t(activePageTitle)}</li>);
+        })()}
+      </ol>
+    </nav>
+  );
+};

--- a/WebTools/src/modify/modifyBreadcrumb.tsx
+++ b/WebTools/src/modify/modifyBreadcrumb.tsx
@@ -34,9 +34,6 @@ export const ModifyBreadcrumb = (props: IModifyBreadcrumbProperties) => {
   else if (milestoneType > -1) activePageTitle = MilestoneType[milestoneType];
   else {
     switch (modificationType) {
-      case ModificationType.Freeform:
-        activePageTitle = "modificationFreeform";
-        break;
       case ModificationType.Promotion:
         activePageTitle = "promotion";
         break;

--- a/WebTools/src/modify/modifyBreadcrumb.tsx
+++ b/WebTools/src/modify/modifyBreadcrumb.tsx
@@ -34,6 +34,9 @@ export const ModifyBreadcrumb = (props: IModifyBreadcrumbProperties) => {
   else if (milestoneType > -1) activePageTitle = MilestoneType[milestoneType];
   else {
     switch (modificationType) {
+      case ModificationType.Freeform:
+        activePageTitle = "modificationFreeform";
+        break;
       case ModificationType.Promotion:
         activePageTitle = "promotion";
         break;
@@ -48,21 +51,14 @@ export const ModifyBreadcrumb = (props: IModifyBreadcrumbProperties) => {
   return (
     <nav aria-label="breadcrumb">
       <ol className="breadcrumb">
-        <li className="breadcrumb-item">
-          <a href="/index.html" onClick={(e) => goToHome(e, navigate)}>
-            {t("Page.title.home")}
-          </a>
-        </li>
-        {(() => {
-          if (milestoneType) {
-            return (
-              <li className="breadcrumb-item"><a href="/index.html" onClick={(e) => navigateTo(e, PageIdentity.ModificationTypeSelection)}>
-                  {t("Page.title.modificationTypeSelection")}
-                </a></li>
-            );
-          }
-          return (<li className="breadcrumb-item active" aria-current="page">{t(activePageTitle)}</li>);
-        })()}
+        <li className="breadcrumb-item"><a href="/index.html" onClick={(e) => goToHome(e, navigate)}>{t("Page.title.home")}</a></li>
+        { milestoneType > -1 ? (
+            <li className="breadcrumb-item"><a href="/index.html" onClick={(e) => navigateTo(e, PageIdentity.ModificationTypeSelection)}>
+                {t("Page.title.modificationTypeSelection")}
+              </a></li>
+          ) : null
+        }
+        <li className="breadcrumb-item active" aria-current="page">{t(activePageTitle)}</li>
       </ol>
     </nav>
   );

--- a/WebTools/src/modify/page/milestonePage.tsx
+++ b/WebTools/src/modify/page/milestonePage.tsx
@@ -17,7 +17,8 @@ import { applyNormalMilestoneDiscipline, applyNormalMilestoneFocus } from "../..
 import { CheckBox } from "../../components/checkBox";
 import { InputFieldAndLabel } from "../../common/inputFieldAndLabel";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router";
+import { ModifyBreadcrumb } from "../modifyBreadcrumb";
+import { ModificationType } from "../model/modificationType";
 
 interface IMilestonePageProperties {
     milestoneType: MilestoneType,
@@ -33,7 +34,6 @@ const MilestonePage: React.FC<IMilestonePageProperties> = ({character, milestone
     const [ normalAddedFocus, setNormalAddedFocus ] = useState(null);
 
     const { t } = useTranslation();
-    const navigate = useNavigate();
 
     function renderNormalMilestoneAdjustment() {
         if (normalOption === 0) {
@@ -202,21 +202,9 @@ const MilestonePage: React.FC<IMilestonePageProperties> = ({character, milestone
         }
     }
 
-    const goToHome = (e: React.MouseEvent<HTMLAnchorElement>) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        navigate("/");
-    }
 
     return (<div className="page container ms-0">
-        <nav aria-label="breadcrumb">
-            <ol className="breadcrumb">
-                <li className="breadcrumb-item"><a href="/index.html" onClick={(e) => goToHome(e)}>{t('Page.title.home')}</a></li>
-                <li className="breadcrumb-item"><a href="/index.html" onClick={(e) => navigateTo(e, PageIdentity.ModificationTypeSelection)}>{t('Page.title.modificationTypeSelection')}</a></li>
-                <li className="breadcrumb-item active" aria-current="page">{t(makeKey('Page.title.', MilestoneType[milestoneType]))}</li>
-            </ol>
-        </nav>
+        <ModifyBreadcrumb milestoneType={milestoneType} modificationType={ModificationType.Milestone} />
 
         <Header>{t(makeKey('Page.title.', MilestoneType[milestoneType]))}</Header>
         <p>{t('MilestonePage.instruction')}</p>

--- a/WebTools/src/modify/page/modificationCompletePage.tsx
+++ b/WebTools/src/modify/page/modificationCompletePage.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { connect } from "react-redux";
-import { useNavigate } from "react-router";
 import { useTranslation } from 'react-i18next';
 import { Character } from "../../common/character";
 import { Header } from "../../components/header";
@@ -9,22 +8,14 @@ import { navigateTo } from "../../common/navigator";
 import { PageIdentity } from "../../pages/pageIdentity";
 import { marshaller } from "../../helpers/marshaller";
 import InstructionText from "../../components/instructionText";
+import { ModifyBreadcrumb } from "../modifyBreadcrumb";
 
 interface ModificationCompletePageProperties {
     character?: Character;
 }
 
 const ModificationCompletePage: React.FC<ModificationCompletePageProperties> = ({character}) => {
-
     const { t } = useTranslation();
-    const navigate = useNavigate();
-
-    const goToHome = (e: React.MouseEvent<HTMLAnchorElement>) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        navigate("/");
-    }
 
     const showViewPage = () => {
         const value = marshaller.encodeMainCharacter(character);
@@ -32,12 +23,7 @@ const ModificationCompletePage: React.FC<ModificationCompletePageProperties> = (
     }
 
     return (<div className="page container ms-0">
-        <nav aria-label="breadcrumb">
-            <ol className="breadcrumb">
-                <li className="breadcrumb-item"><a href="/index.html" onClick={(e) => goToHome(e)}>{t('Page.title.home')}</a></li>
-                <li className="breadcrumb-item active" aria-current="page">{t('Page.title.modificationComplete')}</li>
-            </ol>
-        </nav>
+        <ModifyBreadcrumb isComplete />
 
         <Header>{t('Page.title.modificationComplete')}</Header>
         <InstructionText text={t('ModificationCompletePage.instruction')} />

--- a/WebTools/src/modify/page/modificationTypeSelectionPage.tsx
+++ b/WebTools/src/modify/page/modificationTypeSelectionPage.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { connect } from "react-redux";
-import { useNavigate } from "react-router";
 import { useTranslation } from 'react-i18next';
 import { Character } from "../../common/character";
 import { Header } from "../../components/header";
@@ -10,6 +9,7 @@ import Modifications, { ModificationType } from "../model/modificationType";
 import Milestones, { MilestoneType } from "../model/milestoneType";
 import { navigateTo } from "../../common/navigator";
 import { PageIdentity } from "../../pages/pageIdentity";
+import { ModifyBreadcrumb } from "../modifyBreadcrumb";
 
 interface ModificationTypeSelectionPageProperties {
     character?: Character;
@@ -21,7 +21,6 @@ const ModificationTypeSelectionPage: React.FC<ModificationTypeSelectionPagePrope
     const [modificationType, setModificationType ] = useState(ModificationType.Reputation);
     const [milestoneType, setMilestoneType ] = useState(MilestoneType.NormalMilestone);
     const { t } = useTranslation();
-    const navigate = useNavigate();
 
     const getModificationTypes = () => {
         return Modifications.instance.getItems().map(t => new DropDownElement(t.type, t.localizedName));
@@ -41,21 +40,8 @@ const ModificationTypeSelectionPage: React.FC<ModificationTypeSelectionPagePrope
         }
     }
 
-    const goToHome = (e: React.MouseEvent<HTMLAnchorElement>) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        navigate("/");
-    }
-
-
     return (<div className="page container ms-0">
-                <nav aria-label="breadcrumb">
-                    <ol className="breadcrumb">
-                        <li className="breadcrumb-item"><a href="/index.html" onClick={(e) => goToHome(e)}>{t('Page.title.home')}</a></li>
-                        <li className="breadcrumb-item active" aria-current="page">{t('Page.title.modificationTypeSelection')}</li>
-                    </ol>
-                </nav>
+                <ModifyBreadcrumb />
 
                 <Header>{t('Page.title.modificationTypeSelection')}</Header>
                 <p>{t('ModificationTypeSelectionPage.instruction')}</p>

--- a/WebTools/src/modify/page/promotionPage.tsx
+++ b/WebTools/src/modify/page/promotionPage.tsx
@@ -10,7 +10,8 @@ import { modifyCharacterRank } from "../../state/characterActions";
 import { RanksHelper } from "../../helpers/ranks";
 import { DropDownElement, DropDownSelect } from "../../components/dropDownInput";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router";
+import { ModifyBreadcrumb } from "../modifyBreadcrumb";
+import { ModificationType } from "../model/modificationType";
 
 interface IPromotionPageProperties {
     character?: Character;
@@ -20,7 +21,6 @@ const PromotionPage: React.FC<IPromotionPageProperties> = ({character}) => {
 
     const [ rank, setRank ] = useState(character?.rank?.id);
     const [ rankName, setRankName ] = useState(character?.rank?.name);
-    const navigate = useNavigate();
 
     const getRanks = () => {
         return RanksHelper.instance().getRanks(character, false).map(r => new DropDownElement(r.id, r.name));
@@ -31,22 +31,10 @@ const PromotionPage: React.FC<IPromotionPageProperties> = ({character}) => {
         navigateTo(null, PageIdentity.ModificationCompletePage);
     }
 
-    const goToHome = (e: React.MouseEvent<HTMLAnchorElement>) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        navigate("/");
-    }
 
     const { t } = useTranslation();
     return (<div className="page container ms-0">
-        <nav aria-label="breadcrumb">
-            <ol className="breadcrumb">
-                <li className="breadcrumb-item"><a href="/index.html" onClick={(e) => goToHome(e)}>{t('Page.title.home')}</a></li>
-                <li className="breadcrumb-item"><a href="/index.html" onClick={(e) => navigateTo(e, PageIdentity.ModificationTypeSelection)}>{t('Page.title.modificationTypeSelection')}</a></li>
-                <li className="breadcrumb-item active" aria-current="page">{t('Page.title.promotion')}</li>
-            </ol>
-        </nav>
+        <ModifyBreadcrumb modificationType={ModificationType.Promotion} />
 
         <Header>{t('Page.title.promotion')}</Header>
         <p>{t('PromotionPage.instruction')}</p>

--- a/WebTools/src/modify/page/reputationChangePage.tsx
+++ b/WebTools/src/modify/page/reputationChangePage.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { connect } from "react-redux";
-import { useNavigate } from "react-router";
 import { useTranslation } from 'react-i18next';
 import { Header } from "../../components/header";
 import { Character } from "../../common/character";
@@ -10,6 +9,8 @@ import { StatControl } from "../../starship/view/statControl";
 import { Button } from "../../components/button";
 import store from "../../state/store";
 import { modifyCharacterReputation } from "../../state/characterActions";
+import { ModifyBreadcrumb } from "../modifyBreadcrumb";
+import { ModificationType } from "../model/modificationType";
 
 interface ReputationChangePageProperties {
     character?: Character;
@@ -19,29 +20,15 @@ const ReputationChangePage: React.FC<ReputationChangePageProperties> = ({charact
 
     const [delta, setDelta] = useState(0);
     const { t } = useTranslation();
-    const navigate = useNavigate()
 
     const nextPage = () => {
         store.dispatch(modifyCharacterReputation(delta));
         navigateTo(null, PageIdentity.ModificationCompletePage);
     }
 
-    const goToHome = (e: React.MouseEvent<HTMLAnchorElement>) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        navigate("/");
-    }
-
     const value = (character?.reputation ?? 0) + delta;
     return (<div className="page container ms-0">
-        <nav aria-label="breadcrumb">
-            <ol className="breadcrumb">
-                <li className="breadcrumb-item"><a href="/index.html" onClick={(e) => goToHome(e)}>{t('Page.title.home')}</a></li>
-                <li className="breadcrumb-item"><a href="/index.html" onClick={(e) => navigateTo(e, PageIdentity.ModificationTypeSelection)}>{t('Page.title.modificationTypeSelection')}</a></li>
-                <li className="breadcrumb-item active" aria-current="page">{t('Page.title.reputationChange')}</li>
-            </ol>
-        </nav>
+        <ModifyBreadcrumb modificationType={ModificationType.Reputation} />
 
         <Header>{t('Page.title.reputationChange')}</Header>
         <p>{t('ReputationChangePage.instruction')}</p>


### PR DESCRIPTION
This consolidates the breadcrumb controls that were spread out between all of the modify pages into a single ModifierBreadcrumb control.

Additionally, fixes a small bug with the encode and decode logic that was losing the career value from CareerStep, making Promotion logic fail.