### PR TITLE
Correct California class launch year

### DIFF
--- a/WebTools/src/helpers/spaceframes.ts
+++ b/WebTools/src/helpers/spaceframes.ts
@@ -2050,7 +2050,7 @@ export class SpaceframeHelper {
             Spaceframe.California,
             CharacterType.Starfleet,
             "California Class",
-            2370, // not really specified
+            2358,
             [ Source.LowerDecksCampaign, Source.Core2ndEdition ],
             [10, 10, 8, 9, 10, 8],
             [0, 0, 0, 1, 1, 1],


### PR DESCRIPTION
The year was not specified in the 1st edition Lower Decks supplement, but the 2nd edition Core Rulebook does on page 201.