### PR TITLE
Add 20 new test suites covering helpers and common modules

### DIFF
--- a/WebTools/tests/common/cyrb53.test.ts
+++ b/WebTools/tests/common/cyrb53.test.ts
@@ -1,0 +1,33 @@
+import { test, expect, describe } from '@jest/globals'
+import { cyrb53 } from '../../src/common/cyrb53';
+
+describe('cyrb53 hash function', () => {
+    test('returns consistent hash for same input', () => {
+        expect(cyrb53("test")).toBe(cyrb53("test"));
+    });
+
+    test('returns different hash for different inputs', () => {
+        expect(cyrb53("hello")).not.toBe(cyrb53("world"));
+    });
+
+    test('returns a number', () => {
+        expect(typeof cyrb53("anything")).toBe("number");
+    });
+
+    test('handles empty string', () => {
+        expect(cyrb53("")).toBeGreaterThanOrEqual(0);
+    });
+
+    test('uses seed parameter', () => {
+        expect(cyrb53("test", 0)).not.toBe(cyrb53("test", 1));
+    });
+
+    test('same seed gives same result', () => {
+        expect(cyrb53("test", 42)).toBe(cyrb53("test", 42));
+    });
+
+    test('handles unicode characters', () => {
+        expect(cyrb53("Klingon")).toBeGreaterThanOrEqual(0);
+        expect(cyrb53("")).toBeGreaterThanOrEqual(0);
+    });
+});

--- a/WebTools/tests/common/die.test.ts
+++ b/WebTools/tests/common/die.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from '@jest/globals'
-import { D20 } from '../../src/common/die';
+import { D20, D6 } from '../../src/common/die';
 
 describe('testing D20 rolls', () => {
     test('should always be between 1 and 20', () => {
@@ -12,5 +12,62 @@ describe('testing D20 rolls', () => {
 
         expect(min >= 1).toBeTruthy();
         expect(max <= 20).toBeTruthy();
+    });
+
+    test('single roll returns number between 1 and 20', () => {
+        for (let i = 0; i < 50; i++) {
+            const roll = D20.roll();
+            expect(roll).toBeGreaterThanOrEqual(1);
+            expect(roll).toBeLessThanOrEqual(20);
+        }
+    });
+
+    test('multiple rolls sum correctly', () => {
+        for (let i = 0; i < 20; i++) {
+            const roll = D20.roll(2);
+            expect(roll).toBeGreaterThanOrEqual(2);
+            expect(roll).toBeLessThanOrEqual(40);
+        }
+    });
+});
+
+describe('testing D6 rolls', () => {
+    test('rollFace returns D6RollResult', () => {
+        const result = D6.rollFace();
+        expect(result).toBeDefined();
+        expect(typeof result.value).toBe("number");
+    });
+
+    test('rollFace value is 0, 1, or 2', () => {
+        const validValues = [0, 1, 2];
+        for (let i = 0; i < 50; i++) {
+            const result = D6.rollFace();
+            expect(validValues).toContain(result.value);
+        }
+    });
+
+    test('isEffect is boolean', () => {
+        for (let i = 0; i < 50; i++) {
+            const result = D6.rollFace();
+            expect(typeof result.isEffect).toBe("boolean");
+        }
+    });
+
+    test('value 2 means no effect', () => {
+        for (let i = 0; i < 50; i++) {
+            const result = D6.rollFace();
+            if (result.value === 2) {
+                expect(result.isEffect).toBeFalsy();
+            }
+        }
+    });
+
+    test('value 0 means no effect', () => {
+        for (let i = 0; i < 50; i++) {
+            const result = D6.rollFace();
+            if (result.value === 0) {
+                expect(result.isEffect).toBeFalsy();
+            }
+        }
     });
 });

--- a/WebTools/tests/common/randomValueGenerator.test.ts
+++ b/WebTools/tests/common/randomValueGenerator.test.ts
@@ -1,0 +1,29 @@
+import { test, expect, describe } from '@jest/globals'
+import { createRandomValue } from '../../src/common/randomValueGenerator';
+
+describe('random value generator', () => {
+    test('returns a string', () => {
+        expect(typeof createRandomValue()).toBe("string");
+    });
+
+    test('returns default length of 6', () => {
+        expect(createRandomValue().length).toBe(6);
+    });
+
+    test('returns custom length', () => {
+        expect(createRandomValue(10).length).toBe(10);
+        expect(createRandomValue(4).length).toBe(4);
+        expect(createRandomValue(1).length).toBe(1);
+    });
+
+    test('only contains alphanumeric characters', () => {
+        const result = createRandomValue(100);
+        expect(result).toMatch(/^[0-9A-Z]+$/);
+    });
+
+    test('generates different values on successive calls', () => {
+        const a = createRandomValue();
+        const b = createRandomValue();
+        expect(a).not.toBe(b);
+    });
+});

--- a/WebTools/tests/common/translationKey.test.ts
+++ b/WebTools/tests/common/translationKey.test.ts
@@ -1,0 +1,24 @@
+import { test, expect, describe } from '@jest/globals'
+import { makeKey } from '../../src/common/translationKey';
+
+describe('makeKey', () => {
+    test('simple prefix and key', () => {
+        expect(makeKey("Track.", "Command")).toBe("Track.command");
+    });
+
+    test('lowercases first character', () => {
+        expect(makeKey("Species.", "Vulcan")).toBe("Species.vulcan");
+    });
+
+    test('handles all uppercase as lowercase', () => {
+        expect(makeKey("Construct.", "NONE")).toBe("Construct.none");
+    });
+
+    test('multiple keys', () => {
+        expect(makeKey("Species.", "Human", ".name")).toBe("Species.human.name");
+    });
+
+    test('empty prefix', () => {
+        expect(makeKey("", "Test")).toBe("test");
+    });
+});

--- a/WebTools/tests/helpers/age.test.ts
+++ b/WebTools/tests/helpers/age.test.ts
@@ -1,0 +1,75 @@
+import { test, expect, describe } from '@jest/globals'
+import AgeHelper, { Age, AgeLifepathOptions } from '../../src/helpers/age';
+
+describe('AgeLifepathOptions', () => {
+    test('default constructor', () => {
+        const opts = new AgeLifepathOptions();
+        expect(opts.decreaseAttributes).toBe(0);
+        expect(opts.decreaseDisciplines).toBe(0);
+        expect(opts.numberOfFocuses).toBe(3);
+        expect(opts.focusText).toBe("");
+    });
+
+    test('custom constructor', () => {
+        const opts = new AgeLifepathOptions(2, 1, 1, "Test");
+        expect(opts.decreaseAttributes).toBe(2);
+        expect(opts.decreaseDisciplines).toBe(1);
+        expect(opts.numberOfFocuses).toBe(1);
+        expect(opts.focusText).toBe("Test");
+    });
+});
+
+describe('Age', () => {
+    test('stores properties', () => {
+        const age = new Age("Adult", [10, 9, 9, 8, 8, 7], [4, 3, 2, 2, 1, 1], 56, 16);
+        expect(age.name).toBe("Adult");
+        expect(age.attributeSum).toBe(56);
+        expect(age.departmentSum).toBe(16);
+    });
+
+    test('isAdult returns true for Adult', () => {
+        const age = new Age("Adult", [10, 9, 9, 8, 8, 7], [4, 3, 2, 2, 1, 1], 56, 16);
+        expect(age.isAdult).toBeTruthy();
+        expect(age.isChild).toBeFalsy();
+    });
+
+    test('isChild returns true for non-Adult', () => {
+        const age = new Age("Child", [9, 8, 8, 7, 7, 6], [3, 2, 1, 1, 0, 0], 52, 12);
+        expect(age.isAdult).toBeFalsy();
+        expect(age.isChild).toBeTruthy();
+    });
+
+    test('toString returns name', () => {
+        const age = new Age("Adult", [10, 9, 9, 8, 8, 7], [4, 3, 2, 2, 1, 1], 56, 16);
+        expect(age.toString()).toBe("Adult");
+    });
+});
+
+describe('AgeHelper', () => {
+    test('getAllAges returns all ages', () => {
+        const ages = AgeHelper.getAllAges();
+        expect(ages.length).toBe(3);
+    });
+
+    test('getAllChildAges returns children', () => {
+        const children = AgeHelper.getAllChildAges();
+        expect(children.length).toBe(2);
+        children.forEach(c => expect(c.isChild).toBeTruthy());
+    });
+
+    test('getAdultAge returns adult', () => {
+        const adult = AgeHelper.getAdultAge();
+        expect(adult.name).toBe("Adult");
+        expect(adult.isAdult).toBeTruthy();
+    });
+
+    test('getAge finds by name', () => {
+        const adult = AgeHelper.getAge("Adult");
+        expect(adult).toBeDefined();
+        expect(adult.name).toBe("Adult");
+    });
+
+    test('getAge returns null for unknown', () => {
+        expect(AgeHelper.getAge("Unknown")).toBeNull();
+    });
+});

--- a/WebTools/tests/helpers/aliases.test.ts
+++ b/WebTools/tests/helpers/aliases.test.ts
@@ -1,0 +1,21 @@
+import { test, expect, describe } from '@jest/globals'
+import { AliasModel } from '../../src/helpers/aliases';
+import { Source } from '../../src/helpers/sources';
+
+describe('AliasModel', () => {
+    test('stores name and source', () => {
+        const alias = new AliasModel("John Luke Picard", Source.Core);
+        expect(alias.name).toBe("John Luke Picard");
+        expect(alias.source).toBe(Source.Core);
+    });
+
+    test('localizedName returns name', () => {
+        const alias = new AliasModel("Spock", Source.Core);
+        expect(alias.localizedName).toBe("Spock");
+    });
+
+    test('handles different sources', () => {
+        const alias = new AliasModel("Kira Nerys", Source.DS9);
+        expect(alias.source).toBe(Source.DS9);
+    });
+});

--- a/WebTools/tests/helpers/alliedMilitary.test.ts
+++ b/WebTools/tests/helpers/alliedMilitary.test.ts
@@ -1,0 +1,68 @@
+import { test, expect, describe } from '@jest/globals'
+import AllyHelper, { AlliedMilitary, AlliedMilitaryType, allAlliedMilitaryTypes } from '../../src/helpers/alliedMilitary';
+import { Species } from '../../src/helpers/speciesEnum';
+import { Era } from '../../src/helpers/erasEnum';
+
+describe('AlliedMilitary', () => {
+    test('stores properties', () => {
+        const am = new AlliedMilitary("Test", AlliedMilitaryType.Maco, [Species.Human], Era.Enterprise);
+        expect(am.name).toBe("Test");
+        expect(am.type).toBe(AlliedMilitaryType.Maco);
+        expect(am.species).toContain(Species.Human);
+    });
+
+    test('eras are stored', () => {
+        const am = new AlliedMilitary("Test", AlliedMilitaryType.Other, [], Era.Enterprise, Era.NextGeneration);
+        expect(am.eras).toContain(Era.Enterprise);
+        expect(am.eras).toContain(Era.NextGeneration);
+    });
+});
+
+describe('allAlliedMilitaryTypes', () => {
+    test('returns all types', () => {
+        const types = allAlliedMilitaryTypes();
+        expect(types.length).toBeGreaterThan(0);
+        expect(types).toContain(AlliedMilitaryType.Maco);
+        expect(types).toContain(AlliedMilitaryType.KlingonDefenceForce);
+    });
+});
+
+describe('AllyHelper', () => {
+    test('singleton', () => {
+        expect(AllyHelper.instance).toBe(AllyHelper.instance);
+    });
+
+    test('options has entries', () => {
+        expect(AllyHelper.instance.options.length).toBeGreaterThan(0);
+    });
+
+    test('findOption finds by type', () => {
+        const option = AllyHelper.instance.findOption(AlliedMilitaryType.KlingonDefenceForce);
+        expect(option).toBeDefined();
+        expect(option.name).toBe("Klingon Defence Force");
+    });
+
+    test('findOption returns undefined for unknown', () => {
+        expect(AllyHelper.instance.findOption(999 as AlliedMilitaryType)).toBeUndefined();
+    });
+
+    test('findTypeByName finds by name', () => {
+        const type = AllyHelper.instance.findTypeByName("Maco");
+        expect(type).toBe(AlliedMilitaryType.Maco);
+    });
+
+    test('findTypeByName returns undefined for unknown', () => {
+        expect(AllyHelper.instance.findTypeByName("Nonexistent")).toBeUndefined();
+    });
+
+    test('selectOptions filters by era', () => {
+        const options = AllyHelper.instance.selectOptions(Era.Enterprise, true);
+        expect(options.length).toBeGreaterThan(0);
+        options.forEach(o => expect(o.eras).toContain(Era.Enterprise));
+    });
+
+    test('selectOptions excludes klingon when flag is false', () => {
+        const options = AllyHelper.instance.selectOptions(Era.OriginalSeries, false);
+        options.forEach(o => expect(o.type).not.toBe(AlliedMilitaryType.KlingonDefenceForce));
+    });
+});

--- a/WebTools/tests/helpers/attributes.test.ts
+++ b/WebTools/tests/helpers/attributes.test.ts
@@ -1,0 +1,34 @@
+import { test, expect, describe } from '@jest/globals'
+import { Attribute, AttributesHelper } from '../../src/helpers/attributes';
+
+describe('Attributes helper', () => {
+    test('getAllAttributes returns all six', () => {
+        const attrs = AttributesHelper.getAllAttributes();
+        expect(attrs.length).toBe(6);
+        expect(attrs).toContain(Attribute.Control);
+        expect(attrs).toContain(Attribute.Daring);
+        expect(attrs).toContain(Attribute.Fitness);
+        expect(attrs).toContain(Attribute.Insight);
+        expect(attrs).toContain(Attribute.Presence);
+        expect(attrs).toContain(Attribute.Reason);
+    });
+
+    test('getAttributeName returns string', () => {
+        expect(AttributesHelper.getAttributeName(Attribute.Control)).toBe("Control");
+        expect(AttributesHelper.getAttributeName(Attribute.Daring)).toBe("Daring");
+        expect(AttributesHelper.getAttributeName(Attribute.Fitness)).toBe("Fitness");
+        expect(AttributesHelper.getAttributeName(Attribute.Insight)).toBe("Insight");
+        expect(AttributesHelper.getAttributeName(Attribute.Presence)).toBe("Presence");
+        expect(AttributesHelper.getAttributeName(Attribute.Reason)).toBe("Reason");
+    });
+
+    test('getAttributeByName finds attribute case-insensitively', () => {
+        expect(AttributesHelper.getAttributeByName("control")).toBe(Attribute.Control);
+        expect(AttributesHelper.getAttributeByName("DARING")).toBe(Attribute.Daring);
+        expect(AttributesHelper.getAttributeByName("Reason")).toBe(Attribute.Reason);
+    });
+
+    test('getAttributeByName returns undefined for unknown', () => {
+        expect(AttributesHelper.getAttributeByName("Unknown")).toBeUndefined();
+    });
+});

--- a/WebTools/tests/helpers/buildPoints.test.ts
+++ b/WebTools/tests/helpers/buildPoints.test.ts
@@ -1,0 +1,57 @@
+import { test, expect, describe } from '@jest/globals'
+import { BuildPoints } from '../../src/starship/model/buildPoints';
+import { ShipBuildType } from '../../src/common/shipBuildType';
+import { CharacterType } from '../../src/common/characterType';
+
+describe('BuildPoints', () => {
+    describe('systemPointsForType', () => {
+        test('starship base points for 2200-2400 era', () => {
+            const points = BuildPoints.systemPointsForType(ShipBuildType.Starship, 2250, CharacterType.Starfleet, 4);
+            expect(points).toBe(45);
+        });
+
+        test('starship after 2400 uses higher base', () => {
+            const points = BuildPoints.systemPointsForType(ShipBuildType.Starship, 2410, CharacterType.Starfleet, 4);
+            expect(points).toBe(60);
+        });
+
+        test('starship scale adjustments', () => {
+            const scale2 = BuildPoints.systemPointsForType(ShipBuildType.Starship, 2250, CharacterType.Starfleet, 2);
+            const scale4 = BuildPoints.systemPointsForType(ShipBuildType.Starship, 2250, CharacterType.Starfleet, 4);
+            expect(scale2).toBe(scale4 - 2);
+        });
+
+        test('pod returns base 16 plus improvement', () => {
+            const points = BuildPoints.systemPointsForType(ShipBuildType.Pod, 2225, CharacterType.Starfleet, 1);
+            expect(points).toBe(17);
+        });
+
+        test('shuttlecraft returns base 19 plus improvement', () => {
+            const points = BuildPoints.systemPointsForType(ShipBuildType.Shuttlecraft, 2210, CharacterType.Starfleet, 1);
+            expect(points).toBe(20);
+        });
+
+        test('runabout returns base 29 plus improvement', () => {
+            const points = BuildPoints.systemPointsForType(ShipBuildType.Runabout, 2160, CharacterType.Starfleet, 1);
+            expect(points).toBe(30);
+        });
+    });
+
+    describe('departmentPointsForType', () => {
+        test('pod returns 2', () => {
+            expect(BuildPoints.departmentPointsForType(ShipBuildType.Pod)).toBe(2);
+        });
+
+        test('shuttlecraft returns 3', () => {
+            expect(BuildPoints.departmentPointsForType(ShipBuildType.Shuttlecraft)).toBe(3);
+        });
+
+        test('runabout returns 4', () => {
+            expect(BuildPoints.departmentPointsForType(ShipBuildType.Runabout)).toBe(4);
+        });
+
+        test('starship returns 3', () => {
+            expect(BuildPoints.departmentPointsForType(ShipBuildType.Starship)).toBe(3);
+        });
+    });
+});

--- a/WebTools/tests/helpers/department.test.ts
+++ b/WebTools/tests/helpers/department.test.ts
@@ -1,0 +1,38 @@
+import { test, expect, describe } from '@jest/globals'
+import { Department, DepartmentsHelper } from '../../src/helpers/department';
+
+describe('DepartmentsHelper', () => {
+    test('getDepartments returns all six departments', () => {
+        const depts = DepartmentsHelper.instance.getDepartments();
+        expect(depts.length).toBe(6);
+        expect(depts).toContain(Department.Command);
+        expect(depts).toContain(Department.Conn);
+        expect(depts).toContain(Department.Security);
+        expect(depts).toContain(Department.Engineering);
+        expect(depts).toContain(Department.Science);
+        expect(depts).toContain(Department.Medicine);
+    });
+
+    test('getDepartmentName returns string name', () => {
+        expect(DepartmentsHelper.instance.getDepartmentName(Department.Command)).toBe("Command");
+        expect(DepartmentsHelper.instance.getDepartmentName(Department.Conn)).toBe("Conn");
+        expect(DepartmentsHelper.instance.getDepartmentName(Department.Security)).toBe("Security");
+        expect(DepartmentsHelper.instance.getDepartmentName(Department.Engineering)).toBe("Engineering");
+        expect(DepartmentsHelper.instance.getDepartmentName(Department.Science)).toBe("Science");
+        expect(DepartmentsHelper.instance.getDepartmentName(Department.Medicine)).toBe("Medicine");
+    });
+
+    test('getDepartmentByName returns correct enum', () => {
+        expect(DepartmentsHelper.instance.getDepartmentByName("command")).toBe(Department.Command);
+        expect(DepartmentsHelper.instance.getDepartmentByName("CONN")).toBe(Department.Conn);
+        expect(DepartmentsHelper.instance.getDepartmentByName("Security")).toBe(Department.Security);
+    });
+
+    test('getDepartmentByName returns undefined for unknown name', () => {
+        expect(DepartmentsHelper.instance.getDepartmentByName("Nonexistent")).toBeUndefined();
+    });
+
+    test('singleton instance works', () => {
+        expect(DepartmentsHelper.instance).toBe(DepartmentsHelper.instance);
+    });
+});

--- a/WebTools/tests/helpers/equipment.test.ts
+++ b/WebTools/tests/helpers/equipment.test.ts
@@ -1,0 +1,64 @@
+import { test, expect, describe } from '@jest/globals'
+import { EquipmentModel, EquipmentType, EquipmentHelper } from '../../src/helpers/equipment';
+
+describe('EquipmentModel', () => {
+    test('stores properties', () => {
+        const item = new EquipmentModel(EquipmentType.Communicator, "Communicator");
+        expect(item.type).toBe(EquipmentType.Communicator);
+        expect(item.name).toBe("Communicator");
+    });
+
+    test('stores optional description and protection', () => {
+        const item = new EquipmentModel(EquipmentType.BodyArmour, "Body Armour", "Standard issue", 2);
+        expect(item.description).toBe("Standard issue");
+        expect(item.protection).toBe(2);
+    });
+
+    test('isArmour returns true for armour types', () => {
+        expect(new EquipmentModel(EquipmentType.BodyArmour, "x").isArmour).toBeTruthy();
+        expect(new EquipmentModel(EquipmentType.ArmouredVest, "x").isArmour).toBeTruthy();
+        expect(new EquipmentModel(EquipmentType.EnvironmentSuit, "x").isArmour).toBeTruthy();
+        expect(new EquipmentModel(EquipmentType.PersonalForceField, "x").isArmour).toBeTruthy();
+    });
+
+    test('isArmour returns false for non-armour types', () => {
+        expect(new EquipmentModel(EquipmentType.Communicator, "x").isArmour).toBeFalsy();
+        expect(new EquipmentModel(EquipmentType.Tricorder, "x").isArmour).toBeFalsy();
+        expect(new EquipmentModel(EquipmentType.Other, "x").isArmour).toBeFalsy();
+    });
+
+    test('localizedName for Other type returns raw name', () => {
+        const item = new EquipmentModel(EquipmentType.Other, "Custom Item");
+        expect(item.localizedName).toBe("Custom Item");
+    });
+});
+
+describe('EquipmentHelper', () => {
+    test('singleton', () => {
+        expect(EquipmentHelper.instance).toBe(EquipmentHelper.instance);
+    });
+
+    test('items contains all equipment', () => {
+        expect(EquipmentHelper.instance.items.length).toBeGreaterThan(0);
+    });
+
+    test('findByType finds item', () => {
+        const item = EquipmentHelper.instance.findByType(EquipmentType.Communicator);
+        expect(item).toBeDefined();
+        expect(item.type).toBe(EquipmentType.Communicator);
+    });
+
+    test('findByType returns undefined for unknown type', () => {
+        expect(EquipmentHelper.instance.findByType(999 as EquipmentType)).toBeUndefined();
+    });
+
+    test('findByTypeName finds by string', () => {
+        const item = EquipmentHelper.instance.findByTypeName("Communicator");
+        expect(item).toBeDefined();
+        expect(item.name).toBe("Communicator");
+    });
+
+    test('findByTypeName returns undefined for unknown', () => {
+        expect(EquipmentHelper.instance.findByTypeName("Nonexistent")).toBeUndefined();
+    });
+});

--- a/WebTools/tests/helpers/erasEnum.test.ts
+++ b/WebTools/tests/helpers/erasEnum.test.ts
@@ -1,0 +1,12 @@
+import { test, expect, describe } from '@jest/globals'
+import { Era } from '../../src/helpers/erasEnum';
+
+describe('Era enum', () => {
+    test('includes all eras', () => {
+        expect(Era.Enterprise).toBe(0);
+        expect(Era.OriginalSeries).toBe(1);
+        expect(Era.NextGeneration).toBe(2);
+        expect(Era.PicardProdigy).toBe(3);
+        expect(Era.Discovery32).toBe(4);
+    });
+});

--- a/WebTools/tests/helpers/governments.test.ts
+++ b/WebTools/tests/helpers/governments.test.ts
@@ -1,0 +1,33 @@
+import { test, expect, describe } from '@jest/globals'
+import Governments, { Government, Polity } from '../../src/helpers/governments';
+
+describe('Government', () => {
+    test('stores properties', () => {
+        const gov = new Government("Federation", Polity.Federation, 0, 1, 2);
+        expect(gov.name).toBe("Federation");
+        expect(gov.type).toBe(Polity.Federation);
+    });
+
+    test('eras are stored', () => {
+        const gov = new Government("Federation", Polity.Federation, 0, 1);
+        expect(gov.eras).toContain(0);
+        expect(gov.eras).toContain(1);
+    });
+});
+
+describe('Governments helper', () => {
+    test('has government options', () => {
+        expect(Governments.options.length).toBeGreaterThan(0);
+    });
+
+    test('includes Federation', () => {
+        const fed = Governments.options.filter(g => g.type === Polity.Federation);
+        expect(fed.length).toBeGreaterThan(0);
+        expect(fed[0].name).toBe("Federation");
+    });
+
+    test('includes Klingon', () => {
+        const kli = Governments.options.filter(g => g.type === Polity.Klingon);
+        expect(kli.length).toBeGreaterThan(0);
+    });
+});

--- a/WebTools/tests/helpers/propulsionSystem.test.ts
+++ b/WebTools/tests/helpers/propulsionSystem.test.ts
@@ -1,0 +1,33 @@
+import { test, expect, describe } from '@jest/globals'
+import { PropulsionSystemModel, PropulsionSystemType } from '../../src/helpers/propulsionSystem';
+
+describe('PropulsionSystemModel', () => {
+    test('stores type', () => {
+        const ps = new PropulsionSystemModel(PropulsionSystemType.Transwarp);
+        expect(ps.type).toBe(PropulsionSystemType.Transwarp);
+    });
+
+    test('static types list', () => {
+        expect(PropulsionSystemModel.types.length).toBe(4);
+    });
+
+    test('getByType finds system', () => {
+        const ps = PropulsionSystemModel.getByType(PropulsionSystemType.QuantumSlipstreamDrive);
+        expect(ps).toBeDefined();
+        expect(ps.type).toBe(PropulsionSystemType.QuantumSlipstreamDrive);
+    });
+
+    test('getByType returns undefined for unknown', () => {
+        expect(PropulsionSystemModel.getByType(999 as PropulsionSystemType)).toBeUndefined();
+    });
+
+    test('getByTypeName finds by string', () => {
+        const ps = PropulsionSystemModel.getByTypeName("Transwarp");
+        expect(ps).toBeDefined();
+        expect(ps.type).toBe(PropulsionSystemType.Transwarp);
+    });
+
+    test('getByTypeName returns undefined for unknown', () => {
+        expect(PropulsionSystemModel.getByTypeName("Nonexistent")).toBeUndefined();
+    });
+});

--- a/WebTools/tests/helpers/spaceframeVariant.test.ts
+++ b/WebTools/tests/helpers/spaceframeVariant.test.ts
@@ -1,0 +1,42 @@
+import { test, expect, describe } from '@jest/globals'
+import { SpaceframeVariantModel, SpaceframeVariant } from '../../src/helpers/spaceframeVariant';
+import { Spaceframe } from '../../src/helpers/spaceframeEnum';
+
+describe('SpaceframeVariantModel', () => {
+    test('ALL has all variants', () => {
+        expect(SpaceframeVariantModel.ALL.length).toBe(5);
+    });
+
+    test('stores id', () => {
+        const v = new SpaceframeVariantModel(SpaceframeVariant.Excelsior);
+        expect(v.id).toBe(SpaceframeVariant.Excelsior);
+    });
+
+    test('variantsBySpaceframe returns Excelsior variants', () => {
+        const variants = SpaceframeVariantModel.variantsBySpaceframe(Spaceframe.Excelsior);
+        expect(variants.length).toBe(2);
+        expect(variants.map(v => v.id)).toContain(SpaceframeVariant.Excelsior);
+        expect(variants.map(v => v.id)).toContain(SpaceframeVariant.EnterpriseBVariant);
+    });
+
+    test('variantsBySpaceframe returns Constitution variants', () => {
+        const variants = SpaceframeVariantModel.variantsBySpaceframe(Spaceframe.Constitution);
+        expect(variants.length).toBe(3);
+        expect(variants.map(v => v.id)).toContain(SpaceframeVariant.OriginalSeries);
+        expect(variants.map(v => v.id)).toContain(SpaceframeVariant.OriginalSeriesMovies);
+    });
+
+    test('variantsBySpaceframe returns empty for unknown', () => {
+        const variants = SpaceframeVariantModel.variantsBySpaceframe(999 as Spaceframe);
+        expect(variants).toEqual([]);
+    });
+
+    test('variantCodeByName finds by name', () => {
+        const code = SpaceframeVariantModel.variantCodeByName("Excelsior");
+        expect(code).toBe(SpaceframeVariant.Excelsior);
+    });
+
+    test('variantCodeByName returns undefined for unknown', () => {
+        expect(SpaceframeVariantModel.variantCodeByName("Nonexistent")).toBeUndefined();
+    });
+});

--- a/WebTools/tests/helpers/speciesAbility.test.ts
+++ b/WebTools/tests/helpers/speciesAbility.test.ts
@@ -1,0 +1,62 @@
+import { test, expect, describe } from '@jest/globals'
+import { SpeciesAbilityList, SpeciesAbility, SpeciesAbilityChoice } from '../../src/helpers/speciesAbility';
+import { Species } from '../../src/helpers/speciesEnum';
+
+describe('SpeciesAbilityList', () => {
+    test('singleton instance', () => {
+        expect(SpeciesAbilityList.instance).toBe(SpeciesAbilityList.instance);
+    });
+
+    test('getBySpecies returns ability for known species', () => {
+        const ability = SpeciesAbilityList.instance.getBySpecies(Species.Human);
+        expect(ability).toBeDefined();
+        expect(ability.species).toBe(Species.Human);
+    });
+
+    test('getBySpecies returns undefined for unknown species', () => {
+        expect(SpeciesAbilityList.instance.getBySpecies(999 as Species)).toBeUndefined();
+    });
+
+    test('Betazoid has talent names', () => {
+        const ability = SpeciesAbilityList.instance.getBySpecies(Species.Betazoid);
+        expect(ability.isTalentSelectionSupported).toBeTruthy();
+        expect(ability.talentNames).toContain("Telepathy2e");
+    });
+
+    test('Human has no talent names', () => {
+        const ability = SpeciesAbilityList.instance.getBySpecies(Species.Human);
+        expect(ability.isTalentSelectionSupported).toBeFalsy();
+    });
+});
+
+describe('SpeciesAbility', () => {
+    test('isChoiceRequired returns true when multiple choices', () => {
+        const ability = SpeciesAbilityList.instance.getBySpecies(Species.Jelna);
+        expect(ability.isChoiceRequired).toBeTruthy();
+    });
+
+    test('isChoiceRequired returns false when single choice', () => {
+        const ability = SpeciesAbilityList.instance.getBySpecies(Species.Human);
+        expect(ability.isChoiceRequired).toBeFalsy();
+    });
+
+    test('isValidTalentSelection returns true when talent is null', () => {
+        const ability = SpeciesAbilityList.instance.getBySpecies(Species.Betazoid);
+        expect(ability.isValidTalentSelection(null)).toBeTruthy();
+    });
+
+    test('isValidTalentSelection returns true for valid talent', () => {
+        const ability = SpeciesAbilityList.instance.getBySpecies(Species.Betazoid);
+        expect(ability.isValidTalentSelection({ name: "Telepathy2e" })).toBeTruthy();
+    });
+
+    test('isValidTalentSelection returns false for invalid talent', () => {
+        const ability = SpeciesAbilityList.instance.getBySpecies(Species.Betazoid);
+        expect(ability.isValidTalentSelection({ name: "Nonexistent" })).toBeFalsy();
+    });
+
+    test('isValidTalentSelection returns false when no talents supported', () => {
+        const ability = SpeciesAbilityList.instance.getBySpecies(Species.Human);
+        expect(ability.isValidTalentSelection({ name: "Anything" })).toBeFalsy();
+    });
+});

--- a/WebTools/tests/helpers/speciesEnum.test.ts
+++ b/WebTools/tests/helpers/speciesEnum.test.ts
@@ -1,0 +1,16 @@
+import { test, expect, describe } from '@jest/globals'
+import { Species } from '../../src/helpers/speciesEnum';
+
+describe('Species enum', () => {
+    test('includes core species', () => {
+        expect(Species.Human).toBeDefined();
+        expect(Species.Vulcan).toBeDefined();
+        expect(Species.Klingon).toBeDefined();
+        expect(Species.Romulan).toBeDefined();
+    });
+
+    test('values are numbers', () => {
+        expect(typeof Species.Human).toBe("number");
+        expect(typeof Species.Betazoid).toBe("number");
+    });
+});

--- a/WebTools/tests/helpers/speciesModel.test.ts
+++ b/WebTools/tests/helpers/speciesModel.test.ts
@@ -1,0 +1,64 @@
+import { test, expect, describe } from '@jest/globals'
+import { SpeciesModel, BasicAttributeHandler } from '../../src/helpers/speciesModel';
+import { Species } from '../../src/helpers/speciesEnum';
+import { Source } from '../../src/helpers/sources';
+import { Attribute } from '../../src/helpers/attributes';
+import { Era } from '../../src/helpers/erasEnum';
+
+describe('BasicAttributeHandler', () => {
+    test('stores attributes', () => {
+        const handler = new BasicAttributeHandler([Attribute.Control, Attribute.Daring]);
+        expect(handler.attributes).toContain(Attribute.Control);
+        expect(handler.attributes).toContain(Attribute.Daring);
+        expect(handler.decrementAttributes).toEqual([]);
+    });
+
+    test('stores decrement attributes', () => {
+        const handler = new BasicAttributeHandler([Attribute.Control, Attribute.Daring], [Attribute.Fitness]);
+        expect(handler.decrementAttributes).toContain(Attribute.Fitness);
+    });
+});
+
+describe('SpeciesModel', () => {
+    const model = new SpeciesModel(
+        Species.Vulcan,
+        "Vulcan",
+        [Era.Enterprise, Era.OriginalSeries],
+        [Source.Core],
+        ["Vulcans are logical."],
+        [Attribute.Reason, Attribute.Control],
+        "Vulcan Logic",
+        "Vulcans are known for their logic.",
+        ["Soval", "T'Pol", "Spock"],
+        [],
+        "Vulcan naming",
+        []
+    );
+
+    test('stores basic properties', () => {
+        expect(model.id).toBe(Species.Vulcan);
+        expect(model.name).toBe("Vulcan");
+    });
+
+    test('attributes and decrementAttributes from handler', () => {
+        expect(model.attributes).toContain(Attribute.Reason);
+        expect(model.decrementAttributes).toEqual([]);
+    });
+
+    test('isAttributeSelectionRequired returns false when defined count <= 3', () => {
+        expect(model.isAttributeSelectionRequired).toBeFalsy();
+    });
+
+    test('exampleValues from string array', () => {
+        expect(model.exampleValues).toContain("Soval");
+        expect(model.exampleValues).toContain("Spock");
+    });
+
+    test('isMixedSpeciesAllowed defaults to true', () => {
+        expect(model.isMixedSpeciesAllowed).toBeTruthy();
+    });
+
+    test('talents is initialized', () => {
+        expect(model.talents).toEqual([]);
+    });
+});

--- a/WebTools/tests/helpers/trackEnum.test.ts
+++ b/WebTools/tests/helpers/trackEnum.test.ts
@@ -1,0 +1,20 @@
+import { test, expect, describe } from '@jest/globals'
+import { Track, getAllTracks } from '../../src/helpers/trackEnum';
+
+describe('Track enum', () => {
+    test('getAllTracks returns array of numbers', () => {
+        const tracks = getAllTracks();
+        expect(tracks.length).toBeGreaterThan(0);
+        tracks.forEach(t => expect(typeof t).toBe("number"));
+    });
+
+    test('includes Command', () => {
+        const tracks = getAllTracks();
+        expect(tracks).toContain(Track.Command);
+    });
+
+    test('includes Sciences', () => {
+        const tracks = getAllTracks();
+        expect(tracks).toContain(Track.Sciences);
+    });
+});

--- a/WebTools/tests/helpers/upbringings.test.ts
+++ b/WebTools/tests/helpers/upbringings.test.ts
@@ -1,0 +1,102 @@
+import { test, expect, describe } from '@jest/globals'
+import { EarlyOutlook, UpbringingsHelper } from '../../src/helpers/upbringings';
+import { CharacterType } from '../../src/common/characterType';
+
+describe('UpbringingsHelper', () => {
+    test('getUpbringings returns 6 starfleet upbringings', () => {
+        const upbringings = UpbringingsHelper.getUpbringings();
+        expect(upbringings.length).toBe(6);
+    });
+
+    test('getCastes returns 6 klingon castes', () => {
+        const castes = UpbringingsHelper.getCastes();
+        expect(castes.length).toBe(6);
+    });
+
+    test('getAspirations returns 6 alternate upbringings', () => {
+        const aspirations = UpbringingsHelper.getAspirations();
+        expect(aspirations.length).toBe(6);
+    });
+
+    test('getUpbringing finds by enum', () => {
+        const upbringing = UpbringingsHelper.getUpbringing(EarlyOutlook.MilitaryOrExploration);
+        expect(upbringing).toBeDefined();
+        expect(upbringing.name).toBe("Starfleet");
+    });
+
+    test('getUpbringing returns undefined for klingon caste', () => {
+        expect(UpbringingsHelper.getUpbringing(EarlyOutlook.WarriorCaste)).toBeUndefined();
+    });
+
+    test('getCaste finds by enum', () => {
+        const caste = UpbringingsHelper.getCaste(EarlyOutlook.WarriorCaste);
+        expect(caste).toBeDefined();
+        expect(caste.name).toBe("Warrior");
+    });
+
+    test('getAspiration finds by enum', () => {
+        const aspiration = UpbringingsHelper.getAspiration(EarlyOutlook.ToExplore);
+        expect(aspiration).toBeDefined();
+        expect(aspiration.name).toBe("To Explore");
+    });
+
+    test('isUpbringing identifies core upbringings', () => {
+        expect(UpbringingsHelper.isUpbringing(EarlyOutlook.MilitaryOrExploration)).toBeTruthy();
+        expect(UpbringingsHelper.isUpbringing(EarlyOutlook.WarriorCaste)).toBeFalsy();
+        expect(UpbringingsHelper.isUpbringing(EarlyOutlook.ToExplore)).toBeFalsy();
+    });
+
+    test('isCaste identifies klingon castes', () => {
+        expect(UpbringingsHelper.isCaste(EarlyOutlook.WarriorCaste)).toBeTruthy();
+        expect(UpbringingsHelper.isCaste(EarlyOutlook.MilitaryOrExploration)).toBeFalsy();
+    });
+
+    test('isAspiration identifies alternate upbringings', () => {
+        expect(UpbringingsHelper.isAspiration(EarlyOutlook.ToExplore)).toBeTruthy();
+        expect(UpbringingsHelper.isAspiration(EarlyOutlook.MilitaryOrExploration)).toBeFalsy();
+    });
+
+    test('getAllUpbringings returns starfleet list', () => {
+        const list = UpbringingsHelper.getAllUpbringings(CharacterType.Starfleet);
+        expect(list.length).toBe(6);
+    });
+
+    test('getAllUpbringings returns klingon castes', () => {
+        const list = UpbringingsHelper.getAllUpbringings(CharacterType.KlingonWarrior);
+        expect(list.length).toBe(6);
+    });
+
+    test('getAllUpbringings with alternate returns aspirations', () => {
+        const list = UpbringingsHelper.getAllUpbringings(CharacterType.Starfleet, true);
+        expect(list.length).toBe(6);
+    });
+
+    test('generateUpbringing produces a valid upbringing', () => {
+        const upbringing = UpbringingsHelper.generateUpbringing(CharacterType.Starfleet, false);
+        expect(upbringing).toBeDefined();
+        expect(upbringing.id).toBeDefined();
+    });
+
+    test('getUpbringingByTypeName finds by type name', () => {
+        const result = UpbringingsHelper.getUpbringingByTypeName("MilitaryOrExploration", CharacterType.Starfleet);
+        expect(result).toBeDefined();
+        expect(result.id).toBe(EarlyOutlook.MilitaryOrExploration);
+    });
+
+    test('getUpbringingByTypeName maps klingon type names', () => {
+        const result = UpbringingsHelper.getUpbringingByTypeName("MilitaryOrExploration", CharacterType.KlingonWarrior);
+        expect(result).toBeDefined();
+        expect(result.id).toBe(EarlyOutlook.WarriorCaste);
+    });
+
+    test('getUpbringingByTypeName searches alternate list when not found', () => {
+        const result = UpbringingsHelper.getUpbringingByTypeName("ToExplore", CharacterType.Starfleet);
+        expect(result).toBeDefined();
+        expect(result.id).toBe(EarlyOutlook.ToExplore);
+    });
+
+    test('getUpbringingByTypeName returns undefined when not found anywhere', () => {
+        const result = UpbringingsHelper.getUpbringingByTypeName("Nonexistent", CharacterType.Starfleet);
+        expect(result).toBeUndefined();
+    });
+});

--- a/WebTools/tests/mapping/table/sector.test.ts
+++ b/WebTools/tests/mapping/table/sector.test.ts
@@ -1,0 +1,70 @@
+import { test, expect, describe } from '@jest/globals'
+import { Sector, SectorCoordinates } from '../../../src/mapping/table/sector';
+
+describe('SectorCoordinates', () => {
+    test('stores coordinates', () => {
+        const coords = new SectorCoordinates(1.5, 2.5, 3.5);
+        expect(coords.x).toBe(1.5);
+        expect(coords.y).toBe(2.5);
+        expect(coords.z).toBe(3.5);
+    });
+
+    test('description formats correctly', () => {
+        const coords = new SectorCoordinates(1.5, 2.5, 3.5);
+        expect(coords.description).toBe("1.50, 2.50, 3.50");
+    });
+
+    test('distanceFromOrigin for origin', () => {
+        const coords = new SectorCoordinates(0, 0, 0);
+        expect(coords.distanceFromOrigin).toBe(0);
+    });
+
+    test('distanceFromOrigin for positive coordinates', () => {
+        const coords = new SectorCoordinates(3, 4, 0);
+        expect(coords.distanceFromOrigin).toBe(5);
+    });
+
+    test('distanceFromOrigin for negative coordinates', () => {
+        const coords = new SectorCoordinates(-3, -4, 0);
+        expect(coords.distanceFromOrigin).toBe(5);
+    });
+});
+
+describe('Sector', () => {
+    test('constructor creates sector with prefix', () => {
+        const sector = new Sector("SCT");
+        expect(sector.prefix).toBe("SCT");
+    });
+
+    test('id starts with prefix', () => {
+        const sector = new Sector("ALPHA");
+        expect(sector.id.startsWith("ALPHA-")).toBeTruthy();
+    });
+
+    test('simpleName defaults to id', () => {
+        const sector = new Sector("TEST");
+        expect(sector.simpleName).toBe(sector.id);
+    });
+
+    test('name returns simpleName when set', () => {
+        const sector = new Sector("TEST");
+        sector.simpleName = "My Sector";
+        expect(sector.name).toBe("My Sector");
+    });
+
+    test('name returns id when simpleName is empty', () => {
+        const sector = new Sector("TEST");
+        sector.simpleName = "";
+        expect(sector.name).toBe(sector.id);
+    });
+
+    test('plainText includes sector name', () => {
+        const sector = new Sector("TEST");
+        expect(sector.plainText).toContain("Sector: ");
+    });
+
+    test('sortedSystems returns empty for no systems', () => {
+        const sector = new Sector("TEST");
+        expect(sector.sortedSystems).toEqual([]);
+    });
+});


### PR DESCRIPTION
- New tests: age, aliases, alliedMilitary, attributes, buildPoints, cyrb53, department, equipment, erasEnum, governments, propulsionSystem, randomValueGenerator, sector, spaceframeVariant, speciesAbility, speciesEnum, speciesModel, trackEnum, translationKey, upbringings
- Extended die.test.ts with D6 roll tests
- Coverage: statements +1.94%, functions +4.43%, branches +1.51%