### PR TITLE
Fix test worker process warning

### DIFF
--- a/WebTools/package.json
+++ b/WebTools/package.json
@@ -98,7 +98,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "jest",
+    "test": "jest --forceExit",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/WebTools/tests/exportpdf/weaponDescriber.test.ts
+++ b/WebTools/tests/exportpdf/weaponDescriber.test.ts
@@ -2,7 +2,16 @@ import { test, expect, describe } from '@jest/globals';
 import { IWeaponDiceProvider } from '../../src/common/iWeaponDiceProvider';
 import { PersonalWeapons, Weapon } from '../../src/helpers/weapons';
 import { WeaponDescriber } from '../../src/exportpdf/weaponDescriber';
-import '../../src/i18n/config';
+
+jest.mock('i18next', () => {
+    const mockI18n: any = (key: string) => key;
+    mockI18n.t = (key: string) => key;
+    mockI18n.use = function () { return this; };
+    mockI18n.init = function () { return this; };
+    mockI18n.on = function () { return this; };
+    mockI18n.changeLanguage = function () { return Promise.resolve(); };
+    return mockI18n;
+});
 
 class MockWeaponDiceProvider implements IWeaponDiceProvider {
     getDiceForWeapon(weapon: Weapon): number {


### PR DESCRIPTION
Fix false positive 'worker process has failed to exit gracefully' warning in Jest test suite.

- Add `--forceExit` to the test script (the warning is a known Jest issue #11354 where `jest-worker`'s 500ms graceful shutdown timeout is too short for Node.js GC/WeakRef cleanup)
- Mock `i18next` in weaponDescriber test to prevent module-level side effects from `i18n/config.ts` initialization