### PR TITLE
Fix post-2400 refit interval: 10 years not 50 for 2e

### DIFF
--- a/WebTools/src/starship/model/buildPoints.ts
+++ b/WebTools/src/starship/model/buildPoints.ts
@@ -18,7 +18,7 @@ export class BuildPoints {
             return base + improvement;
         } else {
             let base = (serviceYear > 2400) ? 60 : 40;
-            let improvement = (serviceYear > 2400) ? Math.floor((serviceYear - 2400) / 50) :  Math.floor((serviceYear - 2200) / 10);
+            let improvement = (serviceYear > 2400) ? Math.floor((serviceYear - 2400) / 10) :  Math.floor((serviceYear - 2200) / 10);
             if (scale === 2) {
                 improvement -= 2;
             } else if (scale === 3) {

--- a/WebTools/tests/helpers/buildPoints.test.ts
+++ b/WebTools/tests/helpers/buildPoints.test.ts
@@ -12,7 +12,7 @@ describe('BuildPoints', () => {
 
         test('starship after 2400 uses higher base', () => {
             const points = BuildPoints.systemPointsForType(ShipBuildType.Starship, 2410, CharacterType.Starfleet, 4);
-            expect(points).toBe(60);
+            expect(points).toBe(61);
         });
 
         test('starship scale adjustments', () => {


### PR DESCRIPTION
Fixes #389

Changes the post-2400 starship build point improvement interval from 50 years to 10 years, matching the 2nd edition rules (confirmed by Jim). The pre-2400 formula remains unchanged.

- `WebTools/src/starship/model/buildPoints.ts:21`: Changed `/ 50` to `/ 10` for post-2400 improvement calculation
- `WebTools/tests/helpers/buildPoints.test.ts`: Updated expected value from 60 to 61 for year 2410 to reflect the new 10-year interval