### PR TITLE
Fix Ushaan-tor base damage for 1e: 2 per core book

### DIFF
--- a/WebTools/src/helpers/weapons.ts
+++ b/WebTools/src/helpers/weapons.ts
@@ -1072,6 +1072,6 @@ class PersonalWeaponsVersion1 extends PersonalWeapons {
     }
 
     get ushaanTor() {
-        return Weapon.createCharacterWeapon(i18next.t('Weapon.personal.ushaantor.name'), InjuryType.Deadly, 1, [new WeaponQuality(Quality.Vicious, 1)], [], WeaponType.MELEE);
+        return Weapon.createCharacterWeapon(i18next.t('Weapon.personal.ushaantor.name'), InjuryType.Deadly, 2, [], [], WeaponType.MELEE);
     }
 }

--- a/WebTools/tests/helpers/weapons.test.ts
+++ b/WebTools/tests/helpers/weapons.test.ts
@@ -18,4 +18,12 @@ describe('testing weapons', () => {
         expect(phaser1.dice).toBe(3);
     });
 
+    test('ushaan-tor has correct base damage per edition', () => {
+        let v1 = PersonalWeapons.instance(1).ushaanTor;
+        expect(v1.dice).toBe(2);
+
+        let v2 = PersonalWeapons.instance(2).ushaanTor;
+        expect(v2.dice).toBe(3);
+    });
+
 });


### PR DESCRIPTION
Fixes #337

The 1e version (PersonalWeaponsVersion1) had dice:1 with Vicious 1, but per the 1e core book page 103 the Ushaan-tor should have 2 base damage. Changed to dice:2 with no Vicious quality.

The 2e version (PersonalWeapons) was already correct with dice:3 and no qualities.

- `WebTools/src/helpers/weapons.ts:1075`: Changed dice from 1 to 2, removed Vicious 1 quality
- `WebTools/tests/helpers/weapons.test.ts`: Added test verifying both editions' base damage