### PR TITLE
Add Hardship and Subjugation upbringing from Species Sourcebook

### DIFF
--- a/WebTools/src/helpers/upbringings.ts
+++ b/WebTools/src/helpers/upbringings.ts
@@ -309,6 +309,18 @@ class Upbringings {
             "The character’s Focus should relate to the character’s preferred way of applying their skills.",
             ["Composure", "Debate", "Diplomacy", "Espionage", "Interrogation", "Law", "Philosophy", "Starfleet Protocol"]
         ),
+        new EarlyOutlookModel(
+            EarlyOutlook.HardshipAndSubjugation,
+            "Hardship and Subjugation",
+            "The character grew up under the yoke of oppression. Though their people had proud traditions, they were under the control of others and either served a specific purpose or hungered for freedom from hardship.",
+            Attribute.Control,
+            Attribute.Presence,
+            Attribute.Daring,
+            Attribute.Fitness,
+            [Department.Command, Department.Security, Department.Medicine],
+            "The character's focus should relate to their hardened existence, and the skills they learned to stay alive.",
+            ["Emergency Medicine", "Endurance", "Guerrilla Tactics", "Stealth", "Survival Training"]
+        ),
     ];
 
     private _castes: EarlyOutlookModel[] = [


### PR DESCRIPTION
Fixes #363

Adds the missing Hardship and Subjugation upbringing option from page 95 of the Species Sourcebook. The enum already existed but no model entry was defined.

- Accept: Control +2, Presence +1
- Rebel: Daring +2, Fitness +1
- Disciplines: Command, Security, Medicine
- Focus: hardened existence (Emergency Medicine, Endurance, Guerrilla Tactics, Stealth, Survival Training)

Also fixes a typo in the description: "yolk" to "yoke"