### PR TITLE
Limit refits to 2 per system

### DIFF
--- a/WebTools/jest.config.js
+++ b/WebTools/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    transform: {'^.+\\.ts?$': 'ts-jest'},
+    transform: {'^.+\\.tsx?$': 'ts-jest'},
     testEnvironment: 'node',
     testRegex: '/tests/.*\\.(test|spec)?\\.(ts|tsx)$',
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node']

--- a/WebTools/src/components/refits.tsx
+++ b/WebTools/src/components/refits.tsx
@@ -56,7 +56,7 @@ interface IRefitsProperties extends WithTranslation {
     onDecrease?: (system: System) => void;
 }
 
-class Refits extends React.Component<IRefitsProperties, {}> {
+export class Refits extends React.Component<IRefitsProperties, {}> {
     private _absoluteMax: number = 12;
 
     render() {

--- a/WebTools/src/components/refits.tsx
+++ b/WebTools/src/components/refits.tsx
@@ -85,7 +85,8 @@ export class Refits extends React.Component<IRefitsProperties, {}> {
     }
 
     showIncrease(system: System) {
-        return this.currentValue(system) < this._absoluteMax && this.props.refits.length < this.props.points;
+        const refitCount = this.props.refits.filter(r => r === system).length;
+        return refitCount < 2 && this.props.refits.length < this.props.points;
     }
 
     currentValue(s: System) {

--- a/WebTools/tests/components/refits.test.ts
+++ b/WebTools/tests/components/refits.test.ts
@@ -1,0 +1,75 @@
+import { test, expect, describe, jest } from '@jest/globals'
+import { Refits, Refit } from '../../src/components/refits';
+import { System } from '../../src/helpers/systems';
+
+function createMockStarship(baseValues: number[], currentValues: number[]) {
+    return {
+        getBaseSystem: (system: System) => baseValues[system],
+        getSystemValue: (system: System) => currentValues[system],
+    } as any;
+}
+
+function createRefits(starship: any, refits: System[], points: number) {
+    const props = {
+        starship,
+        refits,
+        points,
+        t: ((key: string) => key) as any,
+        i18n: {} as any,
+        tReady: true,
+    };
+    const instance = new Refits(props as any);
+    (instance as any).forceUpdate = jest.fn();
+    return instance;
+}
+
+describe('Refits', () => {
+    describe('currentValue', () => {
+        test('returns starship system value', () => {
+            const starship = createMockStarship([0, 0, 0, 0, 0, 0], [3, 4, 5, 2, 1, 6]);
+            const refits = createRefits(starship, [], 0);
+            expect(refits.currentValue(System.Comms)).toBe(3);
+            expect(refits.currentValue(System.Weapons)).toBe(6);
+        });
+    });
+
+    describe('showDecrease', () => {
+        test('returns true when current exceeds base', () => {
+            const starship = createMockStarship([3, 0, 0, 0, 0, 0], [4, 0, 0, 0, 0, 0]);
+            const refits = createRefits(starship, [System.Comms], 1);
+            expect(refits.showDecrease(System.Comms)).toBe(true);
+        });
+
+        test('returns false when current equals base', () => {
+            const starship = createMockStarship([3, 0, 0, 0, 0, 0], [3, 0, 0, 0, 0, 0]);
+            const refits = createRefits(starship, [], 0);
+            expect(refits.showDecrease(System.Comms)).toBe(false);
+        });
+    });
+
+    describe('showIncrease', () => {
+        test('returns true when system below max and refit points remain', () => {
+            const starship = createMockStarship([0, 0, 0, 0, 0, 0], [5, 0, 0, 0, 0, 0]);
+            const refits = createRefits(starship, [], 3);
+            expect(refits.showIncrease(System.Comms)).toBe(true);
+        });
+
+        test('returns false when no refit points remain', () => {
+            const starship = createMockStarship([0, 0, 0, 0, 0, 0], [5, 0, 0, 0, 0, 0]);
+            const refits = createRefits(starship, [System.Comms, System.Weapons, System.Engines], 3);
+            expect(refits.showIncrease(System.Comms)).toBe(false);
+        });
+
+        test('returns false when system reaches absolute max', () => {
+            const starship = createMockStarship([0, 0, 0, 0, 0, 0], [12, 0, 0, 0, 0, 0]);
+            const refits = createRefits(starship, [], 3);
+            expect(refits.showIncrease(System.Comms)).toBe(false);
+        });
+
+        test('allows increase when points remain and below max', () => {
+            const starship = createMockStarship([0, 0, 0, 0, 0, 0], [3, 3, 3, 3, 3, 3]);
+            const refits = createRefits(starship, [System.Comms], 3);
+            expect(refits.showIncrease(System.Comms)).toBe(true);
+        });
+    });
+});

--- a/WebTools/tests/components/refits.test.ts
+++ b/WebTools/tests/components/refits.test.ts
@@ -48,9 +48,9 @@ describe('Refits', () => {
     });
 
     describe('showIncrease', () => {
-        test('returns true when system below max and refit points remain', () => {
+        test('returns true when system refit count below 2 and points remain', () => {
             const starship = createMockStarship([0, 0, 0, 0, 0, 0], [5, 0, 0, 0, 0, 0]);
-            const refits = createRefits(starship, [], 3);
+            const refits = createRefits(starship, [System.Computer], 3);
             expect(refits.showIncrease(System.Comms)).toBe(true);
         });
 
@@ -60,16 +60,24 @@ describe('Refits', () => {
             expect(refits.showIncrease(System.Comms)).toBe(false);
         });
 
-        test('returns false when system reaches absolute max', () => {
-            const starship = createMockStarship([0, 0, 0, 0, 0, 0], [12, 0, 0, 0, 0, 0]);
-            const refits = createRefits(starship, [], 3);
+        test('returns false when system already has 2 refits', () => {
+            const starship = createMockStarship([0, 0, 0, 0, 0, 0], [11, 0, 0, 0, 0, 0]);
+            const refits = createRefits(starship, [System.Comms, System.Comms], 3);
             expect(refits.showIncrease(System.Comms)).toBe(false);
         });
 
-        test('allows increase when points remain and below max', () => {
-            const starship = createMockStarship([0, 0, 0, 0, 0, 0], [3, 3, 3, 3, 3, 3]);
+        test('allows increase with 1 refit already on the system', () => {
+            const starship = createMockStarship([0, 0, 0, 0, 0, 0], [10, 3, 3, 3, 3, 3]);
             const refits = createRefits(starship, [System.Comms], 3);
             expect(refits.showIncrease(System.Comms)).toBe(true);
+        });
+
+        test('allows increase on different systems independently', () => {
+            const starship = createMockStarship([0, 0, 0, 0, 0, 0], [5, 5, 5, 5, 5, 5]);
+            const refits = createRefits(starship, [System.Comms, System.Comms], 3);
+            expect(refits.showIncrease(System.Comms)).toBe(false);
+            expect(refits.showIncrease(System.Weapons)).toBe(true);
+            expect(refits.showIncrease(System.Engines)).toBe(true);
         });
     });
 });


### PR DESCRIPTION
Limit refits to 2 per system, replacing the previous _absoluteMax (12) check.

Commit 1 adds test coverage for the refits component (8 tests).
Commit 2 applies the per-system 2-refit limit and updates tests accordingly.

Fixes #331