### PR TITLE
Allow modifying a character's pastimes

### DIFF
--- a/WebTools/src/modify/page/finalDetailsView.tsx
+++ b/WebTools/src/modify/page/finalDetailsView.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { TFunction } from "i18next";
+import { InputFieldAndLabel } from "../../common/inputFieldAndLabel";
+import { Header } from "../../components/header";
+import D20IconButton from "../../solo/component/d20IconButton";
+import { Character } from "../../common/character";
+
+interface IFinalDetailsViewProperties {
+    character: Character;
+    t: TFunction;
+    showRandomName: boolean;
+    onNameChanged: (value: string) => void;
+    onPronounsChanged: (value: string) => void;
+    onRandomName: () => void;
+}
+
+export class FinalDetailsView extends React.Component<IFinalDetailsViewProperties, {}> {
+
+    render() {
+        const { character, t, showRandomName } = this.props;
+        return (<div className="row mt-4">
+            <div className="col-12 col-md-6">
+                <Header level={2} className="mb-3">{t('Construct.other.name')}</Header>
+                <div className="d-flex justify-content-between align-items-center flex-wrap">
+                    <InputFieldAndLabel labelName={t('Construct.other.name')} id="name" onChange={(value) => this.props.onNameChanged(value)} value={character.name ?? ""} />
+                    {showRandomName
+                        ? (<div style={{ flexShrink: 0 }} className="mt-1">
+                            <D20IconButton onClick={() => this.props.onRandomName()}/>
+                        </div>)
+                        : undefined}
+                </div>
+
+                <div className="mt-3">
+                    <InputFieldAndLabel labelName={t('Construct.other.pronouns')} id="pronouns" onChange={(value) => this.props.onPronounsChanged(value)} value={character.pronouns ?? ""} />
+                    <div className="text-white mt-1"><small><b>{t('Common.text.suggestions')}: </b> <i>she/her, they/them, etc.</i></small></div>
+                </div>
+            </div>
+        </div>)
+    }
+}

--- a/WebTools/src/modify/page/finalDetailsView.tsx
+++ b/WebTools/src/modify/page/finalDetailsView.tsx
@@ -9,15 +9,17 @@ interface IFinalDetailsViewProperties {
     character: Character;
     t: TFunction;
     showRandomName: boolean;
+    showPastime: boolean;
     onNameChanged: (value: string) => void;
     onPronounsChanged: (value: string) => void;
+    onPasttimeChanged: (value: string) => void;
     onRandomName: () => void;
 }
 
 export class FinalDetailsView extends React.Component<IFinalDetailsViewProperties, {}> {
 
     render() {
-        const { character, t, showRandomName } = this.props;
+        const { character, t, showRandomName, showPastime } = this.props;
         return (<div className="row mt-4">
             <div className="col-12 col-md-6">
                 <Header level={2} className="mb-3">{t('Construct.other.name')}</Header>
@@ -34,6 +36,13 @@ export class FinalDetailsView extends React.Component<IFinalDetailsViewPropertie
                     <InputFieldAndLabel labelName={t('Construct.other.pronouns')} id="pronouns" onChange={(value) => this.props.onPronounsChanged(value)} value={character.pronouns ?? ""} />
                     <div className="text-white mt-1"><small><b>{t('Common.text.suggestions')}: </b> <i>she/her, they/them, etc.</i></small></div>
                 </div>
+
+                {showPastime
+                    ? (<div className="mt-3">
+                        <InputFieldAndLabel labelName={t('Construct.other.pastimes')} id="pastimes" onChange={(value) => this.props.onPasttimeChanged(value)} value={character.pastime?.join(', ') ?? ""} />
+                        <div className="text-white mt-1"><small>{t('FinishPage.pastime.instruction')}</small></div>
+                    </div>)
+                    : undefined}
             </div>
         </div>)
     }

--- a/WebTools/src/modify/page/generalEditView.tsx
+++ b/WebTools/src/modify/page/generalEditView.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import { Header } from "../../components/header";
 import store from "../../state/store";
 import { FinalDetailsView } from "./finalDetailsView";
-import { addCharacterTalent, setCharacterName, setCharacterPronouns, StepContext, updateCharacterGeneralEditFocusChange, updateCharacterGeneralEditSpeciesAbility, updateCharacterGeneralEditTalentChange, updateCharacterGeneralEditValueChange } from "../../state/characterActions";
+import { addCharacterTalent, setCharacterName, setCharacterPastime, setCharacterPronouns, StepContext, updateCharacterGeneralEditFocusChange, updateCharacterGeneralEditSpeciesAbility, updateCharacterGeneralEditTalentChange, updateCharacterGeneralEditValueChange } from "../../state/characterActions";
 import { AssemblyContext, FocusAssembly, TalentAssembly, ValueAssembly } from "../../common/characterAssembly";
 import { SpeciesAbilityList } from "../../helpers/speciesAbility";
 import { AttributesHelper } from "../../helpers/attributes";
@@ -113,6 +113,10 @@ export const GeneralEditView: React.FC<IGeneralEditViewProperties> = ({character
         store.dispatch(setCharacterPronouns(value));
     }
 
+    const onPasttimeChanged = (value: string) => {
+        store.dispatch(setCharacterPastime(value));
+    }
+
     const randomName = (species: SpeciesModel) => {
         let { name, pronouns } = NameGenerator.instance.createName(species);
         store.dispatch(setCharacterName(name));
@@ -124,8 +128,10 @@ export const GeneralEditView: React.FC<IGeneralEditViewProperties> = ({character
         return (<FinalDetailsView character={character}
             t={t}
             showRandomName={NameGenerator.instance.isSupported(species)}
+            showPastime={character.version > 1}
             onNameChanged={(value) => onNameChanged(value)}
             onPronounsChanged={(value) => onPronounsChanged(value)}
+            onPasttimeChanged={(value) => onPasttimeChanged(value)}
             onRandomName={() => randomName(species)} />);
     }
 

--- a/WebTools/src/modify/page/generalEditView.tsx
+++ b/WebTools/src/modify/page/generalEditView.tsx
@@ -4,8 +4,8 @@ import Markdown from "react-markdown";
 import { Button } from "react-bootstrap";
 import { useState } from "react";
 import { Header } from "../../components/header";
-import { InputFieldAndLabel } from "../../common/inputFieldAndLabel";
 import store from "../../state/store";
+import { FinalDetailsView } from "./finalDetailsView";
 import { addCharacterTalent, setCharacterName, setCharacterPronouns, StepContext, updateCharacterGeneralEditFocusChange, updateCharacterGeneralEditSpeciesAbility, updateCharacterGeneralEditTalentChange, updateCharacterGeneralEditValueChange } from "../../state/characterActions";
 import { AssemblyContext, FocusAssembly, TalentAssembly, ValueAssembly } from "../../common/characterAssembly";
 import { SpeciesAbilityList } from "../../helpers/speciesAbility";
@@ -16,7 +16,6 @@ import { AdditionalTalentInfo } from "../../supportingcharacters/modify/addition
 import { SelectedTalentDescriptionView } from "../../components/selectedTalentDescriptionView";
 import { NameGenerator } from "../../npc/nameGenerator";
 import { SpeciesHelper } from "../../helpers/species";
-import D20IconButton from "../../solo/component/d20IconButton";
 import { SpeciesModel } from "../../helpers/speciesModel";
 import { TalentsHelper } from "../../helpers/talents";
 import { ModalControl } from "../../components/modal";
@@ -122,24 +121,12 @@ export const GeneralEditView: React.FC<IGeneralEditViewProperties> = ({character
 
     const renderFinalTab = () => {
         const species = SpeciesHelper.getSpeciesByType(character?.speciesStep?.species);
-        return (<div className="row mt-4">
-            <div className="col-12 col-md-6">
-                <Header level={2} className="mb-3">{t('Construct.other.name')}</Header>
-                <div className="d-flex justify-content-between align-items-center flex-wrap">
-                    <InputFieldAndLabel labelName={t('Construct.other.name')} id="name" onChange={(value) => onNameChanged(value)} value={character.name ?? ""} />
-                    {NameGenerator.instance.isSupported(species)
-                        ? (<div style={{ flexShrink: 0 }} className="mt-1">
-                            <D20IconButton onClick={() => randomName(species)}/>
-                        </div>)
-                        : undefined}
-                </div>
-
-                <div className="mt-3">
-                    <InputFieldAndLabel labelName={t('Construct.other.pronouns')} id="pronouns" onChange={(value) => onPronounsChanged(value)} value={character.pronouns ?? ""} />
-                    <div className="text-white mt-1"><small><b>{t('Common.text.suggestions')}: </b> <i>she/her, they/them, etc.</i></small></div>
-                </div>
-            </div>
-        </div>)
+        return (<FinalDetailsView character={character}
+            t={t}
+            showRandomName={NameGenerator.instance.isSupported(species)}
+            onNameChanged={(value) => onNameChanged(value)}
+            onPronounsChanged={(value) => onPronounsChanged(value)}
+            onRandomName={() => randomName(species)} />);
     }
 
     const renderSpeciesTab = () => {

--- a/WebTools/tests/modify/page/finalDetailsView.test.ts
+++ b/WebTools/tests/modify/page/finalDetailsView.test.ts
@@ -1,0 +1,147 @@
+import { test, expect, describe, jest } from '@jest/globals'
+import { FinalDetailsView } from '../../../src/modify/page/finalDetailsView';
+import { Character } from '../../../src/common/character';
+import D20IconButton from '../../../src/solo/component/d20IconButton';
+
+function createMockCharacter(name?: string, pronouns?: string) {
+    const character = new Character();
+    character.name = name ?? "Jim";
+    character.pronouns = pronouns ?? "he/him";
+    return character;
+}
+
+function createFinalDetailsView(character: Character, overrides?: any) {
+    const props = {
+        character,
+        t: ((key: string) => key) as any,
+        showRandomName: false,
+        onNameChanged: jest.fn(),
+        onPronounsChanged: jest.fn(),
+        onRandomName: jest.fn(),
+        ...overrides,
+    };
+    const instance = new FinalDetailsView(props as any);
+    (instance as any).forceUpdate = jest.fn();
+    return instance;
+}
+
+function findInputs(element: any): any[] {
+    const results: any[] = [];
+    const walk = (node: any) => {
+        if (node == null || typeof node === 'string' || typeof node === 'number') {
+            return;
+        }
+        if (node.props?.id != null && node.props?.onChange != null) {
+            results.push(node);
+        }
+        const children = node.props?.children;
+        if (Array.isArray(children)) {
+            children.forEach(walk);
+        } else if (children != null && typeof children === 'object') {
+            walk(children);
+        }
+    };
+    walk(element);
+    return results;
+}
+
+describe('FinalDetailsView', () => {
+    describe('name field', () => {
+        test('renders the character name', () => {
+            const character = createMockCharacter("Jim");
+            const instance = createFinalDetailsView(character);
+            const nameInput = findInputs(instance.render()).find(e => e.props.id === 'name');
+            expect(nameInput.props.value).toBe("Jim");
+        });
+
+        test('renders an empty name when the character has no name', () => {
+            const character = createMockCharacter();
+            character.name = undefined;
+            const instance = createFinalDetailsView(character);
+            const nameInput = findInputs(instance.render()).find(e => e.props.id === 'name');
+            expect(nameInput.props.value).toBe("");
+        });
+
+        test('fires onNameChanged when edited', () => {
+            const character = createMockCharacter();
+            const onNameChanged = jest.fn();
+            const instance = createFinalDetailsView(character, { onNameChanged });
+            const nameInput = findInputs(instance.render()).find(e => e.props.id === 'name');
+            nameInput.props.onChange("James");
+            expect(onNameChanged).toHaveBeenCalledWith("James");
+        });
+    });
+
+    describe('pronouns field', () => {
+        test('renders the character pronouns', () => {
+            const character = createMockCharacter(undefined, "she/her");
+            const instance = createFinalDetailsView(character);
+            const pronounsInput = findInputs(instance.render()).find(e => e.props.id === 'pronouns');
+            expect(pronounsInput.props.value).toBe("she/her");
+        });
+
+        test('renders an empty value when the character has no pronouns', () => {
+            const character = createMockCharacter();
+            character.pronouns = undefined;
+            const instance = createFinalDetailsView(character);
+            const pronounsInput = findInputs(instance.render()).find(e => e.props.id === 'pronouns');
+            expect(pronounsInput.props.value).toBe("");
+        });
+
+        test('fires onPronounsChanged when edited', () => {
+            const character = createMockCharacter();
+            const onPronounsChanged = jest.fn();
+            const instance = createFinalDetailsView(character, { onPronounsChanged });
+            const pronounsInput = findInputs(instance.render()).find(e => e.props.id === 'pronouns');
+            pronounsInput.props.onChange("they/them");
+            expect(onPronounsChanged).toHaveBeenCalledWith("they/them");
+        });
+    });
+
+    describe('random name button', () => {
+        test('renders a random name button when showRandomName is true', () => {
+            const character = createMockCharacter();
+            const onRandomName = jest.fn();
+            const instance = createFinalDetailsView(character, { showRandomName: true, onRandomName });
+            const buttons = findRandomNameButtons(instance.render());
+            expect(buttons.length).toBe(1);
+            buttons[0].props.onClick();
+            expect(onRandomName).toHaveBeenCalled();
+        });
+
+        test('does not render a random name button when showRandomName is false', () => {
+            const character = createMockCharacter();
+            const instance = createFinalDetailsView(character, { showRandomName: false });
+            expect(findRandomNameButtons(instance.render()).length).toBe(0);
+        });
+    });
+
+    describe('pastime field', () => {
+        test('does not render a pastime field', () => {
+            const character = createMockCharacter();
+            const instance = createFinalDetailsView(character);
+            const pastimeInput = findInputs(instance.render()).find(e => e.props.id === 'pastimes');
+            expect(pastimeInput).toBeUndefined();
+        });
+    });
+});
+
+function findRandomNameButtons(element: any): any[] {
+    const results: any[] = [];
+    const walk = (node: any) => {
+        if (node == null || typeof node === 'string' || typeof node === 'number') {
+            return;
+        }
+        if (node.type === D20IconButton) {
+            results.push(node);
+        }
+        const children = node.props?.children;
+        if (Array.isArray(children)) {
+            children.forEach(walk);
+        } else if (children != null && typeof children === 'object') {
+            walk(children);
+        }
+    };
+    walk(element);
+    return results;
+}

--- a/WebTools/tests/modify/page/finalDetailsView.test.ts
+++ b/WebTools/tests/modify/page/finalDetailsView.test.ts
@@ -15,8 +15,10 @@ function createFinalDetailsView(character: Character, overrides?: any) {
         character,
         t: ((key: string) => key) as any,
         showRandomName: false,
+        showPastime: false,
         onNameChanged: jest.fn(),
         onPronounsChanged: jest.fn(),
+        onPasttimeChanged: jest.fn(),
         onRandomName: jest.fn(),
         ...overrides,
     };
@@ -117,11 +119,38 @@ describe('FinalDetailsView', () => {
     });
 
     describe('pastime field', () => {
-        test('does not render a pastime field', () => {
+        test('renders pastimes as a comma-separated string when shown', () => {
             const character = createMockCharacter();
-            const instance = createFinalDetailsView(character);
+            character.pastime = ["Chess", "Golf"];
+            const instance = createFinalDetailsView(character, { showPastime: true });
+            const pastimeInput = findInputs(instance.render()).find(e => e.props.id === 'pastimes');
+            expect(pastimeInput.props.value).toBe("Chess, Golf");
+        });
+
+        test('renders an empty value when the character has no pastimes', () => {
+            const character = createMockCharacter();
+            character.pastime = [];
+            const instance = createFinalDetailsView(character, { showPastime: true });
+            const pastimeInput = findInputs(instance.render()).find(e => e.props.id === 'pastimes');
+            expect(pastimeInput.props.value).toBe("");
+        });
+
+        test('does not render a pastime field when hidden', () => {
+            const character = createMockCharacter();
+            character.pastime = ["Chess"];
+            const instance = createFinalDetailsView(character, { showPastime: false });
             const pastimeInput = findInputs(instance.render()).find(e => e.props.id === 'pastimes');
             expect(pastimeInput).toBeUndefined();
+        });
+
+        test('fires onPasttimeChanged when edited', () => {
+            const character = createMockCharacter();
+            character.pastime = ["Chess"];
+            const onPasttimeChanged = jest.fn();
+            const instance = createFinalDetailsView(character, { showPastime: true, onPasttimeChanged });
+            const pastimeInput = findInputs(instance.render()).find(e => e.props.id === 'pastimes');
+            pastimeInput.props.onChange("Reading, Chess");
+            expect(onPasttimeChanged).toHaveBeenCalledWith("Reading, Chess");
         });
     });
 });


### PR DESCRIPTION
Fixes #401

Adds a pastime field to the Final Details tab of the General Edit character modification page, matching the character creation flow. The field is shown for 2e characters only (version greater than 1), uses the existing setCharacterPastime action and reducer, and persists pastimes as a comma-separated string.

Split into two commits per the PR #398 pattern:
1. Add test coverage for general edit final details (extracts the Final Details fields into a testable FinalDetailsView component and covers existing name and pronouns behavior)
2. Allow modifying a character's pastimes (adds the pastime field plus test coverage for it)