### PR TITLE
Use Klingon Core mission profiles for 2e Klingon Warrior ships

### DIFF
--- a/WebTools/src/helpers/missionProfiles.ts
+++ b/WebTools/src/helpers/missionProfiles.ts
@@ -659,6 +659,115 @@ class MissionProfiles {
         //    []),
     };
 
+    private _klingonProfiles2e: { [id: number]: MissionProfileModel } = {
+        [MissionProfile.CrisisAndEmergencyResponse]: new MissionProfileModel(
+            MissionProfile.CrisisAndEmergencyResponse,
+            "Crisis Response and Interception",
+            [2, 2, 2, 3, 1, 2],
+            [
+                TalentsHelper.getTalent("Advanced Medical Ward"),
+                TalentsHelper.getTalent("Extensive Shuttlebays"),
+                TalentsHelper.getTalent("Improved Impulse Drive"),
+                TalentsHelper.getTalent("Improved Warp Drive")
+            ],
+            CharacterType.KlingonWarrior,
+            [System.Sensors],
+            undefined,
+            undefined,
+            new SourcePrerequisite(Source.Core2ndEdition)),
+        [MissionProfile.MultiroleExplorer]: new MissionProfileModel(
+            MissionProfile.MultiroleExplorer,
+            "Multirole Battle Cruiser",
+            [2, 2, 2, 2, 2, 2],
+            [
+                TalentsHelper.getTalent("Improved Damage Control"),
+                TalentsHelper.getTalent("Improved Hull Integrity"),
+                TalentsHelper.getTalent("Redundant Systems"),
+                TalentsHelper.getTalent("Secondary Reactors")
+            ],
+            CharacterType.KlingonWarrior,
+            [...allSystems()],
+            undefined,
+            undefined,
+            new SourcePrerequisite(Source.Core2ndEdition)),
+        [MissionProfile.PathfinderAndReconaissance]: new MissionProfileModel(
+            MissionProfile.PathfinderAndReconaissance,
+            "Intelligence and Reconnaissance Operations",
+            [2, 2, 2, 2, 3, 1],
+            [
+                TalentsHelper.getTalent("Electronic Warfare Systems"),
+                TalentsHelper.getTalent("Improved Reaction Control System"),
+                TalentsHelper.getTalent("Improved Warp Drive"),
+                TalentsHelper.getTalent("High-Resolution Sensors")
+            ],
+            CharacterType.KlingonWarrior,
+            [System.Sensors],
+            undefined,
+            undefined,
+            new SourcePrerequisite(Source.Core2ndEdition)),
+        [MissionProfile.ScientificAndSurvey]: new MissionProfileModel(
+            MissionProfile.ScientificAndSurvey,
+            "Scientific and Survey Operations",
+            [2, 1, 2, 2, 3, 2],
+            [
+                TalentsHelper.getTalent("Advanced Medical Ward"),
+                TalentsHelper.getTalent("Advanced Research Facilities"),
+                TalentsHelper.getTalent("Advanced Sensor Suites"),
+                TalentsHelper.getTalent("Modular Laboratories")
+            ],
+            CharacterType.KlingonWarrior,
+            [System.Computer],
+            undefined,
+            undefined,
+            new SourcePrerequisite(Source.Core2ndEdition)),
+        [MissionProfile.StrategicAndDiplomatic]: new MissionProfileModel(
+            MissionProfile.StrategicAndDiplomatic,
+            "Strategic and Diplomatic Operations",
+            [3, 1, 2, 2, 2, 2],
+            [
+                TalentsHelper.getTalent("Command Ship"),
+                TalentsHelper.getTalent("Extensive Shuttlebays"),
+                TalentsHelper.getTalent("Rugged Design")
+            ],
+            CharacterType.KlingonWarrior,
+            [System.Comms],
+            undefined,
+            undefined,
+            new SourcePrerequisite(Source.Core2ndEdition)),
+        [MissionProfile.Warship]: new MissionProfileModel(
+            MissionProfile.Warship,
+            "Warship",
+            [2, 2, 3, 3, 1, 1],
+            [
+                TalentsHelper.getTalent("Ablative Armor"),
+                TalentsHelper.getTalent("Fast Targeting Systems"),
+                TalentsHelper.getTalent("Improved Damage Control"),
+                TalentsHelper.getTalent("Quantum Torpedoes"),
+                TalentsHelper.getTalent("Rapid-Fire Torpedo Launcher"),
+                TalentsHelper.getTalent("Expanded Munitions")
+            ],
+            CharacterType.KlingonWarrior,
+            [System.Weapons],
+            undefined,
+            undefined,
+            new SourcePrerequisite(Source.Core2ndEdition)),
+        [MissionProfile.HouseGuard]: new MissionProfileModel(
+            MissionProfile.HouseGuard,
+            "House Guard",
+            [2, 2, 2, 3, 2, 1],
+            [
+                TalentsHelper.getTalent("Backup EPS Conduits"),
+                TalentsHelper.getTalent("Improved Power Systems"),
+                TalentsHelper.getTalent("Redundant Systems"),
+                TalentsHelper.getTalent("Rugged Design")
+            ],
+            CharacterType.KlingonWarrior,
+            [System.Structure],
+            undefined,
+            undefined,
+            new SourcePrerequisite(Source.Core2ndEdition)),
+    };
+
 
     private _stationProfiles: { [id: number]: MissionProfileModel } = {
         [MissionProfile.AdministrationAndBureaucracyStation]: new MissionProfileModel(
@@ -771,6 +880,8 @@ class MissionProfiles {
             list = (starship.type === CharacterType.KlingonWarrior && starship.version === 1)
                 ? this._klingonProfiles
                 : this._profiles;
+        } else if (starship.type === CharacterType.KlingonWarrior) {
+            list = this._klingonProfiles2e;
         } else if (starship.type === CharacterType.Civilian) {
             list = {
                 [MissionProfile.CrisisAndEmergencyResponse]: this._profiles2e[MissionProfile.CrisisAndEmergencyResponse],
@@ -823,6 +934,8 @@ class MissionProfiles {
             list = (type === CharacterType.KlingonWarrior && version === 1)
                 ? this._klingonProfiles
                 : this._profiles;
+        } else if (type === CharacterType.KlingonWarrior) {
+            list = this._klingonProfiles2e;
         }
         let result = null;
         for (let id in list) {

--- a/WebTools/tests/starship/missionProfiles.test.ts
+++ b/WebTools/tests/starship/missionProfiles.test.ts
@@ -1,0 +1,63 @@
+import { test, expect, describe } from '@jest/globals'
+import '../../src/helpers/species';
+import { Starship } from '../../src/common/starship';
+import { CharacterType } from '../../src/common/characterType';
+import { Era } from '../../src/helpers/erasEnum';
+import MissionProfiles from '../../src/helpers/missionProfiles';
+
+jest.mock('i18next', () => {
+    const mockI18n: any = (key: string) => key;
+    mockI18n.t = (key: string) => key;
+    mockI18n.use = function () { return this; };
+    mockI18n.init = function () { return this; };
+    mockI18n.on = function () { return this; };
+    mockI18n.changeLanguage = function () { return Promise.resolve(); };
+    return mockI18n;
+});
+
+jest.mock('../../src/state/store', () => {
+    const core2ndEdition = 1; // Source.Core2ndEdition
+    return {
+        getState: () => ({ context: { sources: [core2ndEdition] } }),
+        dispatch: () => undefined,
+    };
+});
+
+function createStarship(type: CharacterType, version: number) {
+    return Starship.createStandardStarship(Era.NextGeneration, type, version);
+}
+
+describe('MissionProfiles', () => {
+    describe('getMissionProfiles', () => {
+        test('returns 2e Core profiles with systems for a 2e Starfleet ship', () => {
+            const profiles = MissionProfiles.instance.getMissionProfiles(createStarship(CharacterType.Starfleet, 2));
+
+            expect(profiles.length).toBeGreaterThan(0);
+            expect(profiles.every(p => p.systems.length > 0)).toBe(true);
+            expect(profiles.some(p => p.type === CharacterType.KlingonWarrior)).toBe(false);
+        });
+
+        test('returns the Starfleet 2e profiles for a 2e Klingon Warrior ship', () => {
+            const starfleetProfiles = MissionProfiles.instance.getMissionProfiles(createStarship(CharacterType.Starfleet, 2));
+            const klingonProfiles = MissionProfiles.instance.getMissionProfiles(createStarship(CharacterType.KlingonWarrior, 2));
+
+            expect(klingonProfiles.map(p => p.id)).toEqual(starfleetProfiles.map(p => p.id));
+            expect(klingonProfiles.some(p => p.type === CharacterType.KlingonWarrior)).toBe(false);
+        });
+
+        test('returns Klingon Core profiles without systems for a 1e Klingon Warrior ship', () => {
+            const profiles = MissionProfiles.instance.getMissionProfiles(createStarship(CharacterType.KlingonWarrior, 1));
+
+            expect(profiles.length).toBeGreaterThan(0);
+            expect(profiles.every(p => p.type === CharacterType.KlingonWarrior)).toBe(true);
+            expect(profiles.every(p => p.systems.length === 0)).toBe(true);
+        });
+
+        test('returns 1e Core profiles for a 1e Starfleet ship', () => {
+            const profiles = MissionProfiles.instance.getMissionProfiles(createStarship(CharacterType.Starfleet, 1));
+
+            expect(profiles.length).toBeGreaterThan(0);
+            expect(profiles.some(p => p.type === CharacterType.KlingonWarrior)).toBe(false);
+        });
+    });
+});

--- a/WebTools/tests/starship/missionProfiles.test.ts
+++ b/WebTools/tests/starship/missionProfiles.test.ts
@@ -38,11 +38,11 @@ describe('MissionProfiles', () => {
         });
 
         test('returns the Starfleet 2e profiles for a 2e Klingon Warrior ship', () => {
-            const starfleetProfiles = MissionProfiles.instance.getMissionProfiles(createStarship(CharacterType.Starfleet, 2));
             const klingonProfiles = MissionProfiles.instance.getMissionProfiles(createStarship(CharacterType.KlingonWarrior, 2));
 
-            expect(klingonProfiles.map(p => p.id)).toEqual(starfleetProfiles.map(p => p.id));
-            expect(klingonProfiles.some(p => p.type === CharacterType.KlingonWarrior)).toBe(false);
+            expect(klingonProfiles.length).toBeGreaterThan(0);
+            expect(klingonProfiles.every(p => p.type === CharacterType.KlingonWarrior)).toBe(true);
+            expect(klingonProfiles.every(p => p.systems.length > 0)).toBe(true);
         });
 
         test('returns Klingon Core profiles without systems for a 1e Klingon Warrior ship', () => {
@@ -58,6 +58,37 @@ describe('MissionProfiles', () => {
 
             expect(profiles.length).toBeGreaterThan(0);
             expect(profiles.some(p => p.type === CharacterType.KlingonWarrior)).toBe(false);
+        });
+    });
+
+    describe('getMissionProfileByName', () => {
+        test('returns a Klingon Core profile for a 2e Klingon Warrior ship', () => {
+            const profile = MissionProfiles.instance.getMissionProfileByName("Warship", CharacterType.KlingonWarrior, 2);
+
+            expect(profile).toBeDefined();
+            expect(profile.type).toBe(CharacterType.KlingonWarrior);
+            expect(profile.systems.length).toBeGreaterThan(0);
+        });
+
+        test('does not return a Starfleet 2e profile for a 2e Klingon Warrior ship', () => {
+            const profile = MissionProfiles.instance.getMissionProfileByName("Tactical", CharacterType.KlingonWarrior, 2);
+
+            expect(profile).toBeNull();
+        });
+
+        test('returns a Starfleet 2e profile for a 2e Starfleet ship', () => {
+            const profile = MissionProfiles.instance.getMissionProfileByName("Tactical", CharacterType.Starfleet, 2);
+
+            expect(profile).toBeDefined();
+            expect(profile.type).not.toBe(CharacterType.KlingonWarrior);
+        });
+
+        test('returns a Klingon Core profile without systems for a 1e Klingon Warrior ship', () => {
+            const profile = MissionProfiles.instance.getMissionProfileByName("Warship", CharacterType.KlingonWarrior, 1);
+
+            expect(profile).toBeDefined();
+            expect(profile.type).toBe(CharacterType.KlingonWarrior);
+            expect(profile.systems.length).toBe(0);
         });
     });
 });


### PR DESCRIPTION
## Summary

Fixes #387

2e Klingon Warrior ships currently use Starfleet Core mission profiles. This change routes them to the Klingon Core mission profiles (matching the 1e KDF profile list), each with a system assigned per the Core rulebook.

Per the two-commit approach (no existing test file for this code): the first commit adds coverage of the existing behavior, the second commit contains the change and its coverage.

## Verification

- npm test: 39 suites, 213 tests passed
- npx tsc --noEmit: no new errors introduced (only a pre-existing error in characterSheetDialog.tsx, present on sta-complete)