### PR TITLE
Fix #378: prevent duplicate random Values

### DIFF
--- a/WebTools/src/components/allCharacterValues.tsx
+++ b/WebTools/src/components/allCharacterValues.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { CharacterType } from "../common/characterType";
 import { Header } from "./header";
 import { StepContext, setCharacterValue } from "../state/characterActions";
-import { ValueRandomTable } from "../solo/table/valueRandomTable";
+import { randomUniqueValue } from "../solo/table/valueRandomTable";
 import store from "../state/store";
 import ValueInput from "./valueInput";
 import { makeKey } from "../common/translationKey";
@@ -15,7 +15,7 @@ const AllCharacterValues: React.FC<ICharacterProperties> = ({character}) => {
 
 
     const randomValue = (context: StepContext) => {
-        let value = ValueRandomTable(character.speciesStep?.species, character.educationStep?.primaryDiscipline);
+        let value = randomUniqueValue(character.values, character.speciesStep?.species, character.educationStep?.primaryDiscipline);
         onValueChanged(value, context);
     }
 

--- a/WebTools/src/components/selectedTalentDescriptionView.tsx
+++ b/WebTools/src/components/selectedTalentDescriptionView.tsx
@@ -10,7 +10,7 @@ import { DropDownElement, DropDownSelect } from './dropDownInput';
 import { FocusSelectionView } from './focusSelectionView';
 import { Character } from '../common/character';
 import ValueInput from './valueInput';
-import { ValueRandomTable } from '../solo/table/valueRandomTable';
+import { randomUniqueValue } from '../solo/table/valueRandomTable';
 import { BorgImplants, BorgImplantType } from '../helpers/borgImplant';
 import { CheckBox } from './checkBox';
 import { Attribute } from '../helpers/attributes';
@@ -119,11 +119,7 @@ export const VisitEveryStarSelectionView: React.FC<ITalentAdditionalSelectionPro
 }
 
 const randomValue = (character: Character) => {
-    let value = ValueRandomTable(character.speciesStep?.species, character.educationStep?.primaryDiscipline);
-    while (character.values.includes(value)) {
-        value = ValueRandomTable(character.speciesStep?.species, character.educationStep?.primaryDiscipline);
-    }
-    return value;
+    return randomUniqueValue(character.values, character.speciesStep?.species, character.educationStep?.primaryDiscipline);
 }
 
 export const WisdomOfYearsSelectionView: React.FC<ITalentAdditionalFocusAndValueSelectionProperties> = ({onFocusSelection, onValueSelection, character, initialFocus, initialValue}) => {

--- a/WebTools/src/components/singleTalentSelectionList.tsx
+++ b/WebTools/src/components/singleTalentSelectionList.tsx
@@ -10,7 +10,7 @@ import { FocusSelectionView } from './focusSelectionView';
 import { Character } from '../common/character';
 import { Department } from '../helpers/department';
 import ValueInput from './valueInput';
-import { ValueRandomTable } from '../solo/table/valueRandomTable';
+import { randomUniqueValue } from '../solo/table/valueRandomTable';
 import { Construct } from '../common/construct';
 import { BorgImplants } from '../helpers/borgImplant';
 import { SimpleAttributeSelector } from './simpleAttributeSelector';
@@ -581,7 +581,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({tal
                             onSelection(temp);
                         }}
                         onRandomClicked={() => {
-                            let value = ValueRandomTable((construct as Character).speciesStep?.species, (construct as Character).educationStep?.primaryDiscipline);
+                            let value = randomUniqueValue((construct as Character).values ?? [], (construct as Character).speciesStep?.species, (construct as Character).educationStep?.primaryDiscipline);
                             let temp = selection?.copy();
                             if (temp) {
                                 temp.value = value;

--- a/WebTools/src/components/valueInputWithRandomOption.tsx
+++ b/WebTools/src/components/valueInputWithRandomOption.tsx
@@ -1,6 +1,6 @@
 import { Character } from "../common/character";
 import { Department } from "../helpers/department";
-import { ValueRandomTable } from "../solo/table/valueRandomTable";
+import { randomUniqueValue } from "../solo/table/valueRandomTable";
 import ValueInput from "./valueInput";
 
 export interface IValueInputWithRandom {
@@ -17,14 +17,8 @@ export interface IValueInputWithRandom {
 const ValueInputWithRandom: React.FC<IValueInputWithRandom> = ({textDescription, id, value, onValueChanged, character, department, labelName}) => {
 
     const randomValue = () => {
-        let done = false;
-        while (!done) {
-            let value = ValueRandomTable(character.speciesStep?.species, department);
-            if (!character.values.includes(value)) {
-                onValueChanged(value);
-                done = true;
-            }
-        }
+        let value = randomUniqueValue(character.values, character.speciesStep?.species, department);
+        onValueChanged(value);
     }
 
     return (<ValueInput value={value} id={id ?? "value"}

--- a/WebTools/src/modify/page/characterAdvancementTypeView.tsx
+++ b/WebTools/src/modify/page/characterAdvancementTypeView.tsx
@@ -15,7 +15,7 @@ import { SimpleDepartmentSelector } from "../../components/simpleDepartmentSelec
 import store from "../../state/store";
 import { modifyCharacterAddAdvancement } from "../../state/characterActions";
 import { Dialog } from "../../components/dialog";
-import { ValueRandomTable } from "../../solo/table/valueRandomTable";
+import { randomUniqueValue } from "../../solo/table/valueRandomTable";
 import ValueInput from "../../components/valueInput";
 import { ModalControl } from "../../components/modal";
 import { TALENT_NAME_AUGMENTED_ABILITY, TALENT_NAME_BOLD, TALENT_NAME_BORG_IMPLANTS, TALENT_NAME_CAUTIOUS, TALENT_NAME_COLLABORATION, TALENT_NAME_CUSTOM_TALENT, TALENT_NAME_DEFENSIVE_TRAINING, TALENT_NAME_EXPANDED_PROGRAM, TALENT_NAME_IM_A_DOCTOR_NOT_A, TALENT_NAME_VISIT_EVERY_STAR, TALENT_NAME_WARRIORS_SPIRIT, TALENT_NAME_WISDOM_OF_YEARS, TalentsHelper } from "../../helpers/talents";
@@ -59,14 +59,8 @@ export const CharacterAdvancementTypeView: React.FC<ICharacterAdvancementTypeVie
     useEffect(() => setChoice(undefined), [type]);
 
     const randomValue = () => {
-        let done = false;
-        while (!done) {
-            let value = ValueRandomTable(character?.speciesStep?.species);
-            if (!character?.values?.includes(value)) {
-                done = true;
-                setValueSelection(value);
-            }
-        }
+        let value = randomUniqueValue(character?.values ?? [], character?.speciesStep?.species);
+        setValueSelection(value);
     }
 
     const dropDownChoices = () => {

--- a/WebTools/src/pages/attributesAndDisciplinesPage.tsx
+++ b/WebTools/src/pages/attributesAndDisciplinesPage.tsx
@@ -9,7 +9,7 @@ import ValueInput from '../components/valueInput';
 import CharacterCreationBreadcrumbs from '../components/characterCreationBreadcrumbs';
 import { CharacterType } from '../common/characterType';
 import SingleTalentSelectionList from '../components/singleTalentSelectionList';
-import { ValueRandomTable } from '../solo/table/valueRandomTable';
+import { randomUniqueValue } from '../solo/table/valueRandomTable';
 import { useTranslation } from 'react-i18next';
 import { Header } from '../components/header';
 import InstructionText from '../components/instructionText';
@@ -30,14 +30,8 @@ const AttributesAndDisciplinesPage: React.FC<ICharacterProperties> = ({character
     const { t } = useTranslation();
 
     const randomValue = () => {
-        let done = false;
-        while (!done) {
-            let value = ValueRandomTable(character.speciesStep?.species, character.educationStep?.primaryDiscipline);
-            if (character.values.indexOf(value) < 0) {
-                done = true;
-                store.dispatch(setCharacterValue(value, StepContext.FinishingTouches));
-            }
-        }
+        let value = randomUniqueValue(character.values, character.speciesStep?.species, character.educationStep?.primaryDiscipline);
+        store.dispatch(setCharacterValue(value, StepContext.FinishingTouches));
     }
 
     const filterTalentList = () => {

--- a/WebTools/src/pages/careerLengthDetailsPage.tsx
+++ b/WebTools/src/pages/careerLengthDetailsPage.tsx
@@ -11,7 +11,7 @@ import CharacterCreationBreadcrumbs from '../components/characterCreationBreadcr
 import SingleTalentSelectionList from '../components/singleTalentSelectionList';
 import { useTranslation } from 'react-i18next';
 import { Header } from '../components/header';
-import { ValueRandomTable } from '../solo/table/valueRandomTable';
+import { randomUniqueValue } from '../solo/table/valueRandomTable';
 import { Career } from '../helpers/careerEnum';
 import store from '../state/store';
 import { StepContext, addCharacterTalent, setCharacterValue } from '../state/characterActions';
@@ -47,7 +47,7 @@ const CareerLengthDetailsPage : React.FC<ICharacterProperties> = ({character}) =
     )
 
     const randomValue = () => {
-        let value = ValueRandomTable(character.speciesStep?.species, character.educationStep?.primaryDiscipline);
+        let value = randomUniqueValue(character.values, character.speciesStep?.species, character.educationStep?.primaryDiscipline);
         onValueChanged(value);
     }
 

--- a/WebTools/src/pages/childEducationDetailsPage.tsx
+++ b/WebTools/src/pages/childEducationDetailsPage.tsx
@@ -11,7 +11,7 @@ import ReactMarkdown from 'react-markdown';
 import { InputFieldAndLabel } from '../common/inputFieldAndLabel';
 import store from '../state/store';
 import { StepContext, modifyCharacterAttribute, modifyCharacterDiscipline, setCharacterFocus, setCharacterValue } from '../state/characterActions';
-import { ValueRandomTable } from '../solo/table/valueRandomTable';
+import { randomUniqueValue } from '../solo/table/valueRandomTable';
 import AttributeListComponent from '../components/attributeListComponent';
 import { IAttributeController } from '../components/attributeController';
 import { Character } from '../common/character';
@@ -225,7 +225,7 @@ const ChildEducationDetailsPage: React.FC<ICharacterPageProperties> = ({characte
     const secondaryDisciplineController = new ChildSecondaryDisciplineController(character);
 
     const randomValue = () => {
-        let value = ValueRandomTable(character.speciesStep?.species, character.educationStep?.primaryDiscipline);
+        let value = randomUniqueValue(character.values, character.speciesStep?.species, character.educationStep?.primaryDiscipline);
         onValueChanged(value);
     }
 

--- a/WebTools/src/pages/educationDetailsPage.tsx
+++ b/WebTools/src/pages/educationDetailsPage.tsx
@@ -12,7 +12,7 @@ import { Header } from '../components/header';
 import CharacterCreationBreadcrumbs from '../components/characterCreationBreadcrumbs';
 import SingleTalentSelectionList from '../components/singleTalentSelectionList';
 import { Track } from '../helpers/trackEnum';
-import { ValueRandomTable } from '../solo/table/valueRandomTable';
+import { randomUniqueValue } from '../solo/table/valueRandomTable';
 import { useTranslation } from 'react-i18next';
 import InstructionText from '../components/instructionText';
 import ReactMarkdown from 'react-markdown';
@@ -46,7 +46,7 @@ const EducationDetailsPage: React.FC<ICharacterProperties> = ({character}) => {
     const secondaryDisciplineController = new EducationSecondaryDisciplineController(character, track);
 
     const randomValue = () => {
-        let value = ValueRandomTable(character.speciesStep?.species, character.educationStep?.primaryDiscipline);
+        let value = randomUniqueValue(character.values, character.speciesStep?.species, character.educationStep?.primaryDiscipline);
         onValueChanged(value);
     }
 

--- a/WebTools/src/pages/environmentDetailsPage.tsx
+++ b/WebTools/src/pages/environmentDetailsPage.tsx
@@ -11,7 +11,7 @@ import { Species } from '../helpers/speciesEnum';
 import { Attribute, AttributesHelper } from '../helpers/attributes';
 import { Header } from '../components/header';
 import { useTranslation } from 'react-i18next';
-import { ValueRandomTable } from '../solo/table/valueRandomTable';
+import { randomUniqueValue } from '../solo/table/valueRandomTable';
 import store from '../state/store';
 import { StepContext, modifyCharacterAttribute, modifyCharacterDiscipline, setCharacterEnvironment, setCharacterValue } from '../state/characterActions';
 import { IAttributeController } from '../components/attributeController';
@@ -153,14 +153,8 @@ const EnvironmentDetailsPage: React.FC<ICharacterProperties> = ({character}) => 
     }
 
     const randomValue = () => {
-        let done = false;
-        while (!done) {
-            let value = ValueRandomTable(character.speciesStep?.species, character.environmentStep?.discipline);
-            if (character.values.indexOf(value) < 0) {
-                done = true;
-                store.dispatch(setCharacterValue(value, StepContext.Environment));
-            }
-        }
+        let value = randomUniqueValue(character.values, character.speciesStep?.species, character.environmentStep?.discipline);
+        store.dispatch(setCharacterValue(value, StepContext.Environment));
     }
 
     const isSpeciesSelectionNeeded = () => {

--- a/WebTools/src/pages/noviceOrCadetExperiencePage.tsx
+++ b/WebTools/src/pages/noviceOrCadetExperiencePage.tsx
@@ -14,7 +14,7 @@ import { PageIdentity } from './pageIdentity';
 import store from '../state/store';
 import { StepContext, addCharacterTalent, addCharacterUntappedPotentialAttribute, setCharacterValue } from '../state/characterActions';
 import { CharacterType } from '../common/characterType';
-import { ValueRandomTable } from '../solo/table/valueRandomTable';
+import { randomUniqueValue } from '../solo/table/valueRandomTable';
 import { Attribute, AttributesHelper } from '../helpers/attributes';
 import { CheckBox } from '../components/checkBox';
 import { makeKey } from '../common/translationKey';
@@ -36,7 +36,7 @@ const NoviceOrCadetExperiencePage: React.FC<ICharacterProperties> = ({character}
     }
 
     const randomValue = () => {
-        let value = ValueRandomTable(character.speciesStep?.species, character.educationStep?.primaryDiscipline);
+        let value = randomUniqueValue(character.values, character.speciesStep?.species, character.educationStep?.primaryDiscipline);
         onValueChanged(value);
     }
 

--- a/WebTools/src/pages/simpleCareerPage.tsx
+++ b/WebTools/src/pages/simpleCareerPage.tsx
@@ -14,7 +14,7 @@ import { PageIdentity } from './pageIdentity';
 import store from '../state/store';
 import { StepContext, addCharacterTalent, setCharacterValue } from '../state/characterActions';
 import { CharacterType } from '../common/characterType';
-import { ValueRandomTable } from '../solo/table/valueRandomTable';
+import { randomUniqueValue } from '../solo/table/valueRandomTable';
 
 interface ISimpleCareerPageProperties extends ICharacterProperties {
     talent: string;
@@ -31,7 +31,7 @@ const SimpleCareerPage: React.FC<ISimpleCareerPageProperties> = ({character, tal
     }
 
     const randomValue = () => {
-        let value = ValueRandomTable(character.speciesStep?.species, character.educationStep?.primaryDiscipline);
+        let value = randomUniqueValue(character.values, character.speciesStep?.species, character.educationStep?.primaryDiscipline);
         onValueChanged(value);
     }
 

--- a/WebTools/src/solo/page/soloCareerLengthDetailsPage.tsx
+++ b/WebTools/src/solo/page/soloCareerLengthDetailsPage.tsx
@@ -14,7 +14,7 @@ import { makeKey } from "../../common/translationKey";
 import { Career } from "../../helpers/careerEnum";
 import SoloCharacterBreadcrumbs from "../component/soloCharacterBreadcrumbs";
 import D20IconButton from "../component/d20IconButton";
-import { ValueRandomTable } from "../table/valueRandomTable";
+import { randomUniqueValue } from "../table/valueRandomTable";
 
 const SoloCareerLengthDetailsPage: React.FC<ICharacterProperties> = ({character}) => {
     const { t } = useTranslation();
@@ -30,14 +30,8 @@ const SoloCareerLengthDetailsPage: React.FC<ICharacterProperties> = ({character}
     }
 
     const randomValue = () => {
-        let done = false;
-        while (!done) {
-            let value = ValueRandomTable(character.speciesStep?.species, character.educationStep?.primaryDiscipline);
-            if (character.values.indexOf(value) < 0) {
-                done = true;
-                store.dispatch(setCharacterValue(value, StepContext.Career));
-            }
-        }
+        let value = randomUniqueValue(character.values, character.speciesStep?.species, character.educationStep?.primaryDiscipline);
+        store.dispatch(setCharacterValue(value, StepContext.Career));
     }
 
     return (

--- a/WebTools/src/solo/page/soloEducationDetailsPage.tsx
+++ b/WebTools/src/solo/page/soloEducationDetailsPage.tsx
@@ -17,7 +17,7 @@ import DisciplineListComponent from "../../components/disciplineListComponent";
 import { Dialog } from "../../components/dialog";
 import SoloCharacterBreadcrumbs from "../component/soloCharacterBreadcrumbs";
 import D20IconButton from "../component/d20IconButton";
-import { ValueRandomTable } from "../table/valueRandomTable";
+import { randomUniqueValue } from "../table/valueRandomTable";
 import { FocusRandomTable } from "../table/focusRandomTable";
 import { EducationAttributeController, EducationPrimaryDisciplineController, EducationSecondaryDisciplineController } from "../../components/educationControllers";
 import { localizedFocus } from "../../components/focusHelper";
@@ -46,14 +46,8 @@ const SoloEducationDetailsPage: React.FC<ICharacterProperties> = ({character}) =
     }
 
     const randomValue = () => {
-        let done = false;
-        while (!done) {
-            let value = ValueRandomTable(character.speciesStep?.species, character.educationStep?.primaryDiscipline);
-            if (character.values.indexOf(value) < 0) {
-                done = true;
-                store.dispatch(setCharacterValue(value, StepContext.Education));
-            }
-        }
+        let value = randomUniqueValue(character.values, character.speciesStep?.species, character.educationStep?.primaryDiscipline);
+        store.dispatch(setCharacterValue(value, StepContext.Education));
     }
 
 

--- a/WebTools/src/solo/page/soloFinishingTouchesPage.tsx
+++ b/WebTools/src/solo/page/soloFinishingTouchesPage.tsx
@@ -12,7 +12,7 @@ import { Dialog } from "../../components/dialog";
 import DisciplineListComponent from "../../components/disciplineListComponent";
 import SoloCharacterBreadcrumbs from "../component/soloCharacterBreadcrumbs";
 import AttributeListComponent from "../../components/attributeListComponent";
-import { ValueRandomTable } from "../table/valueRandomTable";
+import { randomUniqueValue } from "../table/valueRandomTable";
 import D20IconButton from "../component/d20IconButton";
 import { FinishingTouchesAttributeController, FinishingTouchesDisciplineController } from "../../components/finishingTouchesControllers";
 
@@ -47,14 +47,8 @@ const SoloFinishingTouchesPage: React.FC<ICharacterProperties> = ({character}) =
     }
 
     const randomValue = () => {
-        let done = false;
-        while (!done) {
-            let value = ValueRandomTable(character.speciesStep?.species, character.educationStep?.primaryDiscipline);
-            if (character.values.indexOf(value) < 0) {
-                done = true;
-                store.dispatch(setCharacterValue(value, StepContext.FinishingTouches));
-            }
-        }
+        let value = randomUniqueValue(character.values, character.speciesStep?.species, character.educationStep?.primaryDiscipline);
+        store.dispatch(setCharacterValue(value, StepContext.FinishingTouches));
     }
 
     return (

--- a/WebTools/src/solo/table/valueRandomTable.ts
+++ b/WebTools/src/solo/table/valueRandomTable.ts
@@ -32,6 +32,14 @@ export const ValueRandomTable = (species?: Species, skill?: Department) => {
     }
 }
 
+export const randomUniqueValue = (existingValues: string[], species?: Species, skill?: Department) => {
+    let value = ValueRandomTable(species, skill);
+    while (existingValues.includes(value)) {
+        value = ValueRandomTable(species, skill);
+    }
+    return value;
+}
+
 const StandardValuesTable = () => {
     let roll = D20.roll();
     switch (roll) {

--- a/WebTools/src/supportingcharacters/modify/modifySupportCharacterPage.tsx
+++ b/WebTools/src/supportingcharacters/modify/modifySupportCharacterPage.tsx
@@ -14,7 +14,7 @@ import { SupportingCharacterModificationType } from "./supportingCharacterModifi
 import ValueInput from "../../components/valueInput";
 import { useNavigate } from "react-router";
 import { Dialog } from "../../components/dialog";
-import { ValueRandomTable } from "../../solo/table/valueRandomTable";
+import { randomUniqueValue } from "../../solo/table/valueRandomTable";
 import store from "../../state/store";
 import { marshaller } from "../../helpers/marshaller";
 import { modifyCharacterAddAdvancement } from "../../state/characterActions";
@@ -155,14 +155,8 @@ const ModifySupportingCharacterPage : React.FC<ICharacterPageProperties> = ({cha
     }
 
     const randomValue = () => {
-        let done = false;
-        while (!done) {
-            let value = ValueRandomTable(character?.speciesStep?.species);
-            if (!character?.values?.includes(value)) {
-                done = true;
-                setValueSelection(value);
-            }
-        }
+        let value = randomUniqueValue(character?.values ?? [], character?.speciesStep?.species);
+        setValueSelection(value);
     }
 
     const randomFocus = () => {

--- a/WebTools/src/supportingcharacters/supportingCharacterPage.tsx
+++ b/WebTools/src/supportingcharacters/supportingCharacterPage.tsx
@@ -23,7 +23,7 @@ import { FocusRandomTableWithHints } from '../solo/table/focusRandomTable';
 import D20IconButton from '../solo/component/d20IconButton';
 import { CheckBox } from '../components/checkBox';
 import ReactMarkdown from 'react-markdown';
-import { ValueRandomTable } from '../solo/table/valueRandomTable';
+import { randomUniqueValue } from '../solo/table/valueRandomTable';
 import { SpeciesAbilityView } from '../components/speciesAbilityView';
 import { LoadingButton } from '../common/loadingButton';
 import { saveCharacterToLocalStorage } from '../state/savedConstructActions';
@@ -139,14 +139,8 @@ const SupportingCharacterPage : React.FC<ICharacterPageProperties> = ({character
     }
 
     const selectRandomValue = () => {
-        let done = false;
-        while (!done) {
-            let value = ValueRandomTable(character.speciesStep?.species, character.supportingStep?.disciplines[0]);
-            if (character.values.indexOf(value) < 0) {
-                done = true;
-                store.dispatch(setCharacterValue(value, StepContext.FinishingTouches));
-            }
-        }
+        let value = randomUniqueValue(character.values, character.speciesStep?.species, character.supportingStep?.disciplines[0]);
+        store.dispatch(setCharacterValue(value, StepContext.FinishingTouches));
     }
 
     useEffect(() => {

--- a/WebTools/tests/solo/table/valueRandomTable.test.ts
+++ b/WebTools/tests/solo/table/valueRandomTable.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, jest } from '@jest/globals'
-import { ValueRandomTable } from '../../../src/solo/table/valueRandomTable';
+import { ValueRandomTable, randomUniqueValue } from '../../../src/solo/table/valueRandomTable';
 
 describe('ValueRandomTable', () => {
     test('returns a string', () => {
@@ -14,6 +14,44 @@ describe('ValueRandomTable', () => {
         const first = ValueRandomTable();
         const second = ValueRandomTable();
         expect(first).toBe(second);
+        spy.mockRestore();
+    });
+});
+
+describe('randomUniqueValue', () => {
+    test('returns a string', () => {
+        const spy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
+        const result = randomUniqueValue([]);
+        expect(typeof result).toBe('string');
+        spy.mockRestore();
+    });
+
+    test('rerolls when the rolled value is already assigned', () => {
+        // With the default store, ValueRandomTable uses StandardValuesTable.
+        // Math.random 0.5 rolls an 11, and 0.6 rolls a 13.
+        const assigned = "Push me too far and you’ll see my ugly side";
+        const rerolled = "Seeking to find myself far from home";
+
+        // ValueRandomTable consumes two random values per attempt
+        // (an unused outer roll and the StandardValuesTable roll).
+        const randomValues = [0.5, 0.5, 0.5, 0.6];
+        const spy = jest.spyOn(Math, 'random').mockImplementation(() => randomValues.shift());
+        const result = randomUniqueValue([assigned]);
+        expect(result).toBe(rerolled);
+        spy.mockRestore();
+    });
+
+    test('never returns a value already assigned', () => {
+        const assigned = ["A good mystery is irresistible", "Act with confidence, even if you don’t feel confident"];
+        let calls = 0;
+        const spy = jest.spyOn(Math, 'random').mockImplementation(() => {
+            calls = (calls + 1) % 1000;
+            return calls / 1000;
+        });
+        for (let i = 0; i < 50; i++) {
+            const result = randomUniqueValue(assigned);
+            expect(assigned).not.toContain(result);
+        }
         spy.mockRestore();
     });
 });

--- a/WebTools/tests/solo/table/valueRandomTable.test.ts
+++ b/WebTools/tests/solo/table/valueRandomTable.test.ts
@@ -1,0 +1,19 @@
+import { test, expect, describe, jest } from '@jest/globals'
+import { ValueRandomTable } from '../../../src/solo/table/valueRandomTable';
+
+describe('ValueRandomTable', () => {
+    test('returns a string', () => {
+        const spy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
+        const result = ValueRandomTable();
+        expect(typeof result).toBe('string');
+        spy.mockRestore();
+    });
+
+    test('can return the same value on successive rolls', () => {
+        const spy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
+        const first = ValueRandomTable();
+        const second = ValueRandomTable();
+        expect(first).toBe(second);
+        spy.mockRestore();
+    });
+});


### PR DESCRIPTION
Fixes #378

## Problem

The d20 random-value buttons could produce a Value that was already assigned to the character. The "reroll until unique" guard existed in only some callers; the Finish page's all-value panel (the exact scenario in the report, where four Value fields sit side by side) and five other pages had no guard at all.

## Changes

- Added a shared `randomUniqueValue` helper in `WebTools/src/solo/table/valueRandomTable.ts` that rerolls until the result is not already assigned
- Applied it to the previously unguarded callers: AllCharacterValues (Finish page), Education Details, Career Length, Simple Career, Child Education, Novice or Cadet Experience, and SingleTalentSelectionList
- Refactored the nine callers that already had their own guard to use the shared helper, removing duplicate logic

## Verification

- All 230 tests pass, including five new tests covering `ValueRandomTable` and `randomUniqueValue`
- `tsc --noEmit` reports only the pre-existing `react-bootstrap/button` module error present on `sta-complete`

Note: commits were split into two per project convention, first covering existing behavior, then the change.