### PR TITLE
Fix SelectedTalent.copy() crashing on string weapons

### DIFF
--- a/WebTools/src/common/selectedTalent.ts
+++ b/WebTools/src/common/selectedTalent.ts
@@ -60,7 +60,7 @@ export class SelectedTalent implements ITalent {
         result.system = this.system;
         result.customTalentName = this.customTalentName;
         result.customTalentDescription = this.customTalentDescription;
-        if (this.weapon != null || this.weapon instanceof Weapon) {
+        if (this.weapon instanceof Weapon) {
             result.weapon = (this.weapon as Weapon).copy();
         } else {
             result.weapon = this.weapon;

--- a/WebTools/tests/common/selectedTalent.test.ts
+++ b/WebTools/tests/common/selectedTalent.test.ts
@@ -23,6 +23,12 @@ jest.mock('../../src/state/store', () => {
 
 describe('SelectedTalent', () => {
     describe('copy', () => {
+        test('copies a string weapon without throwing', () => {
+            const talent = SelectedTalent.createWithWeapon("Expanded Munitions", "Phaser Cannons");
+            const result = talent.copy();
+            expect(result.weapon).toBe("Phaser Cannons");
+        });
+
         test('deep-copies a Weapon instance', () => {
             const talent = new SelectedTalent("Expanded Munitions");
             talent.weapon = Weapon.createStarshipWeapon('', WeaponType.TORPEDO,

--- a/WebTools/tests/common/selectedTalent.test.ts
+++ b/WebTools/tests/common/selectedTalent.test.ts
@@ -1,0 +1,41 @@
+import { test, expect, describe } from '@jest/globals'
+import '../../src/helpers/species';
+import { SelectedTalent } from '../../src/common/selectedTalent';
+import { Weapon, WeaponType, TorpedoLoadTypeModel } from '../../src/helpers/weapons';
+
+jest.mock('i18next', () => {
+    const mockI18n: any = (key: string) => key;
+    mockI18n.t = (key: string) => key;
+    mockI18n.use = function () { return this; };
+    mockI18n.init = function () { return this; };
+    mockI18n.on = function () { return this; };
+    mockI18n.changeLanguage = function () { return Promise.resolve(); };
+    return mockI18n;
+});
+
+jest.mock('../../src/state/store', () => {
+    const core2ndEdition = 1; // Source.Core2ndEdition
+    return {
+        getState: () => ({ context: { sources: [core2ndEdition] } }),
+        dispatch: () => undefined,
+    };
+});
+
+describe('SelectedTalent', () => {
+    describe('copy', () => {
+        test('deep-copies a Weapon instance', () => {
+            const talent = new SelectedTalent("Expanded Munitions");
+            talent.weapon = Weapon.createStarshipWeapon('', WeaponType.TORPEDO,
+                TorpedoLoadTypeModel.allTypes(1)[0]);
+            const result = talent.copy();
+            expect(result.weapon).toBeInstanceOf(Weapon);
+            expect(result.weapon).not.toBe(talent.weapon);
+        });
+
+        test('copies a talent with no weapon', () => {
+            const talent = new SelectedTalent("Fast Targeting Systems");
+            const result = talent.copy();
+            expect(result.weapon).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes the latent `SelectedTalent.copy()` bug in the Expanded Munitions weapon-selection path.

## Changes

- `WebTools/src/common/selectedTalent.ts` — `copy()` previously evaluated
  `this.weapon != null || this.weapon instanceof Weapon`. With a *string* weapon
  (e.g. `SelectedTalent.createWithWeapon("Expanded Munitions", "Phaser Cannons")`,
  as provided by the Ganashia spaceframe), `copy()` called `.copy()` on the
  string and threw `this.weapon.copy is not a function`. Now it only deep-copies
  when the weapon is a `Weapon` instance and passes strings through unchanged.
- `WebTools/tests/common/selectedTalent.test.ts` — new regression tests covering
  string weapons, `Weapon` instance deep-copy, and no-weapon copy.

## Verification

- 41 test suites / 228 tests pass.
- The string-weapon test fails against the unmodified code and passes with the fix.

References #339