### PR TITLE
Fix react-bootstrap Button import casing

### DIFF
--- a/WebTools/src/components/characterSheetDialog.tsx
+++ b/WebTools/src/components/characterSheetDialog.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import i18n from 'i18next';
 import { PDFDocument } from '@cantoo/pdf-lib'
-import Button from 'react-bootstrap/button';
+import Button from 'react-bootstrap/Button';
 import { ModalControl } from './modal';
 import { Construct } from '../common/construct';
 import { getNavigatorLanguage } from '../i18n/config';


### PR DESCRIPTION
## Summary

Fixes the typecheck error on a clean checkout.

## Changes

- `WebTools/src/components/characterSheetDialog.tsx` — import changed from
  `react-bootstrap/button` (wrong case) to `react-bootstrap/Button`. All other
  react-bootstrap deep imports in the codebase use the correct casing.

## Verification

- `npx tsc --noEmit` failed on a clean `npm install` with
  `TS2307: Cannot find module 'react-bootstrap/button'` and now passes (exit 0).
- Full jest suite: 40 suites / 225 tests pass.