### PR TITLE
Fix #296: preserve secondary role on Character.copy()

### DIFF
--- a/WebTools/src/common/character.ts
+++ b/WebTools/src/common/character.ts
@@ -1705,6 +1705,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
         character.assignedShip = this.assignedShip;
         character._rank = this._rank;
         character.role = this.role;
+        character.secondaryRole = this.secondaryRole;
         if (this.speciesStep) {
             character.speciesStep = this.speciesStep.copy();
         }

--- a/WebTools/tests/common/character.test.ts
+++ b/WebTools/tests/common/character.test.ts
@@ -1,0 +1,27 @@
+import { test, expect, describe } from '@jest/globals'
+import { Character } from '../../src/common/character';
+import { Role } from '../../src/helpers/roles';
+
+describe('Character', () => {
+    describe('copy', () => {
+        test('copies the primary role', () => {
+            const character = new Character();
+            character.role = Role.ScienceOfficer;
+
+            const result = character.copy();
+
+            expect(result.role).toBe(Role.ScienceOfficer);
+        });
+
+        test('drops the secondary role', () => {
+            const character = new Character();
+            character.role = Role.ScienceOfficer;
+            character.secondaryRole = Role.ChiefMedicalOfficer;
+
+            const result = character.copy();
+
+            expect(result.role).toBe(Role.ScienceOfficer);
+            expect(result.secondaryRole).toBeUndefined();
+        });
+    });
+});

--- a/WebTools/tests/common/character.test.ts
+++ b/WebTools/tests/common/character.test.ts
@@ -13,7 +13,7 @@ describe('Character', () => {
             expect(result.role).toBe(Role.ScienceOfficer);
         });
 
-        test('drops the secondary role', () => {
+        test('copies the secondary role', () => {
             const character = new Character();
             character.role = Role.ScienceOfficer;
             character.secondaryRole = Role.ChiefMedicalOfficer;
@@ -21,7 +21,7 @@ describe('Character', () => {
             const result = character.copy();
 
             expect(result.role).toBe(Role.ScienceOfficer);
-            expect(result.secondaryRole).toBeUndefined();
+            expect(result.secondaryRole).toBe(Role.ChiefMedicalOfficer);
         });
     });
 });


### PR DESCRIPTION
The Multi-Discipline talent allows a character to select two roles. The second role (secondaryRole) was silently lost: Character.copy() copies role, jobAssignment, assignedShip, and rank but not secondaryRole. Every reducer action rebuilds the character via copy(), so any change made after selecting the second role (editing a Value, name, ship, rank, and so on) dropped it before it could render on the overview page or character sheet.

This PR adds the missing field to Character.copy() so the secondary role survives state changes and renders correctly.

Verification: npm test (43 suites, 235 tests) passes; tsc --noEmit is clean. Two commits: coverage of the existing behavior, then the fix and updated coverage.

Addresses discussion #296.