### PR TITLE
Allow modifying a character's lineage, house, and additional traits

### DIFF
--- a/WebTools/src/modify/page/finalDetailsView.tsx
+++ b/WebTools/src/modify/page/finalDetailsView.tsx
@@ -10,16 +10,21 @@ interface IFinalDetailsViewProperties {
     t: TFunction;
     showRandomName: boolean;
     showPastime: boolean;
+    showLineageAndHouse: boolean;
+    showAdditionalTraits: boolean;
     onNameChanged: (value: string) => void;
     onPronounsChanged: (value: string) => void;
     onPasttimeChanged: (value: string) => void;
+    onLineageChanged: (value: string) => void;
+    onHouseChanged: (value: string) => void;
+    onAdditionalTraitsChanged: (value: string) => void;
     onRandomName: () => void;
 }
 
 export class FinalDetailsView extends React.Component<IFinalDetailsViewProperties, {}> {
 
     render() {
-        const { character, t, showRandomName, showPastime } = this.props;
+        const { character, t, showRandomName, showPastime, showLineageAndHouse, showAdditionalTraits } = this.props;
         return (<div className="row">
             <div className="col-12 col-md-6 mt-4">
                 <Header level={2} className="mb-3">{t('Construct.other.name')}</Header>
@@ -36,17 +41,42 @@ export class FinalDetailsView extends React.Component<IFinalDetailsViewPropertie
                     <InputFieldAndLabel labelName={t('Construct.other.pronouns')} id="pronouns" onChange={(value) => this.props.onPronounsChanged(value)} value={character.pronouns ?? ""} />
                     <div className="text-white mt-1"><small><b>{t('Common.text.suggestions')}: </b> <i>she/her, they/them, etc.</i></small></div>
                 </div>
+
+                {showLineageAndHouse
+                    ? (<div className="mt-3">
+                        <div className="mb-4">
+                            <InputFieldAndLabel labelName={t('Construct.other.lineage')} id="lineage" onChange={(value) => this.props.onLineageChanged(value)} value={character.lineage ?? ""} />
+                            <div className="text-white mt-1"><small><b>Example: </b> <i>Daughter of Martok</i> or <i>Child of Koloth</i></small></div>
+                        </div>
+                        <div className="mb-4">
+                            <InputFieldAndLabel labelName={t('Construct.other.house')} id="house" onChange={(value) => this.props.onHouseChanged(value)} value={character.house ?? ""} />
+                            <div className="text-white mt-1"><small><b>Example: </b> <i>House Duras</i> or <i>House Kor</i></small></div>
+                        </div>
+                    </div>)
+                    : undefined}
             </div>
 
-            {showPastime
-                ? (<div className="col-12 col-md-6 mt-4">
-                    <Header level={2} className="mb-3">{t('Construct.other.pastimes')}</Header>
-                    <div className="mt-3">
-                        <InputFieldAndLabel labelName={t('Construct.other.pastimes')} id="pastimes" onChange={(value) => this.props.onPasttimeChanged(value)} value={character.pastime?.join(', ') ?? ""} />
-                        <div className="text-white mt-1"><small>{t('FinishPage.pastime.instruction')}</small></div>
-                    </div>
-                </div>)
-                : undefined}
+            <div className="col-12 col-md-6 mt-4">
+                {showPastime
+                    ? (<div>
+                        <Header level={2} className="mb-3">{t('Construct.other.pastimes')}</Header>
+                        <div className="mt-3">
+                            <InputFieldAndLabel labelName={t('Construct.other.pastimes')} id="pastimes" onChange={(value) => this.props.onPasttimeChanged(value)} value={character.pastime?.join(', ') ?? ""} />
+                            <div className="text-white mt-1"><small>{t('FinishPage.pastime.instruction')}</small></div>
+                        </div>
+                    </div>)
+                    : undefined}
+
+                {showAdditionalTraits
+                    ? (<div className="mt-3">
+                        <Header level={2} className="mb-3">{t('Construct.other.additionalTraits')}</Header>
+                        <div className="mt-3">
+                            <InputFieldAndLabel labelName={t('Construct.other.traits')} id="traits" onChange={(value) => this.props.onAdditionalTraitsChanged(value)} value={character?.additionalTraits ?? ""} />
+                            <div className="text-white mt-1"><small>{t('FinishPage.trait.instruction')}</small></div>
+                        </div>
+                    </div>)
+                    : undefined}
+            </div>
         </div>)
     }
 }

--- a/WebTools/src/modify/page/generalEditView.tsx
+++ b/WebTools/src/modify/page/generalEditView.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import { Header } from "../../components/header";
 import store from "../../state/store";
 import { FinalDetailsView } from "./finalDetailsView";
-import { addCharacterTalent, setCharacterName, setCharacterPastime, setCharacterPronouns, StepContext, updateCharacterGeneralEditFocusChange, updateCharacterGeneralEditSpeciesAbility, updateCharacterGeneralEditTalentChange, updateCharacterGeneralEditValueChange } from "../../state/characterActions";
+import { addCharacterTalent, setCharacterAdditionalTraits, setCharacterHouse, setCharacterLineage, setCharacterName, setCharacterPastime, setCharacterPronouns, StepContext, updateCharacterGeneralEditFocusChange, updateCharacterGeneralEditSpeciesAbility, updateCharacterGeneralEditTalentChange, updateCharacterGeneralEditValueChange } from "../../state/characterActions";
 import { AssemblyContext, FocusAssembly, TalentAssembly, ValueAssembly } from "../../common/characterAssembly";
 import { SpeciesAbilityList } from "../../helpers/speciesAbility";
 import { AttributesHelper } from "../../helpers/attributes";
@@ -117,6 +117,18 @@ export const GeneralEditView: React.FC<IGeneralEditViewProperties> = ({character
         store.dispatch(setCharacterPastime(value));
     }
 
+    const onLineageChanged = (value: string) => {
+        store.dispatch(setCharacterLineage(value));
+    }
+
+    const onHouseChanged = (value: string) => {
+        store.dispatch(setCharacterHouse(value));
+    }
+
+    const onAdditionalTraitsChanged = (value: string) => {
+        store.dispatch(setCharacterAdditionalTraits(value));
+    }
+
     const randomName = (species: SpeciesModel) => {
         let { name, pronouns } = NameGenerator.instance.createName(species);
         store.dispatch(setCharacterName(name));
@@ -129,9 +141,14 @@ export const GeneralEditView: React.FC<IGeneralEditViewProperties> = ({character
             t={t}
             showRandomName={NameGenerator.instance.isSupported(species)}
             showPastime={character.version > 1}
+            showLineageAndHouse={character.isKlingonImperialCitizen}
+            showAdditionalTraits={true}
             onNameChanged={(value) => onNameChanged(value)}
             onPronounsChanged={(value) => onPronounsChanged(value)}
             onPasttimeChanged={(value) => onPasttimeChanged(value)}
+            onLineageChanged={(value) => onLineageChanged(value)}
+            onHouseChanged={(value) => onHouseChanged(value)}
+            onAdditionalTraitsChanged={(value) => onAdditionalTraitsChanged(value)}
             onRandomName={() => randomName(species)} />);
     }
 

--- a/WebTools/tests/modify/page/finalDetailsView.test.ts
+++ b/WebTools/tests/modify/page/finalDetailsView.test.ts
@@ -16,9 +16,14 @@ function createFinalDetailsView(character: Character, overrides?: any) {
         t: ((key: string) => key) as any,
         showRandomName: false,
         showPastime: false,
+        showLineageAndHouse: false,
+        showAdditionalTraits: false,
         onNameChanged: jest.fn(),
         onPronounsChanged: jest.fn(),
         onPasttimeChanged: jest.fn(),
+        onLineageChanged: jest.fn(),
+        onHouseChanged: jest.fn(),
+        onAdditionalTraitsChanged: jest.fn(),
         onRandomName: jest.fn(),
         ...overrides,
     };
@@ -151,6 +156,108 @@ describe('FinalDetailsView', () => {
             const pastimeInput = findInputs(instance.render()).find(e => e.props.id === 'pastimes');
             pastimeInput.props.onChange("Reading, Chess");
             expect(onPasttimeChanged).toHaveBeenCalledWith("Reading, Chess");
+        });
+    });
+
+    describe('lineage field', () => {
+        test('renders the character lineage when shown', () => {
+            const character = createMockCharacter();
+            character.lineage = "Daughter of Martok";
+            const instance = createFinalDetailsView(character, { showLineageAndHouse: true });
+            const lineageInput = findInputs(instance.render()).find(e => e.props.id === 'lineage');
+            expect(lineageInput.props.value).toBe("Daughter of Martok");
+        });
+
+        test('renders an empty value when the character has no lineage', () => {
+            const character = createMockCharacter();
+            const instance = createFinalDetailsView(character, { showLineageAndHouse: true });
+            const lineageInput = findInputs(instance.render()).find(e => e.props.id === 'lineage');
+            expect(lineageInput.props.value).toBe("");
+        });
+
+        test('does not render a lineage field when hidden', () => {
+            const character = createMockCharacter();
+            character.lineage = "Daughter of Martok";
+            const instance = createFinalDetailsView(character, { showLineageAndHouse: false });
+            const lineageInput = findInputs(instance.render()).find(e => e.props.id === 'lineage');
+            expect(lineageInput).toBeUndefined();
+        });
+
+        test('fires onLineageChanged when edited', () => {
+            const character = createMockCharacter();
+            const onLineageChanged = jest.fn();
+            const instance = createFinalDetailsView(character, { showLineageAndHouse: true, onLineageChanged });
+            const lineageInput = findInputs(instance.render()).find(e => e.props.id === 'lineage');
+            lineageInput.props.onChange("Child of Koloth");
+            expect(onLineageChanged).toHaveBeenCalledWith("Child of Koloth");
+        });
+    });
+
+    describe('house field', () => {
+        test('renders the character house when shown', () => {
+            const character = createMockCharacter();
+            character.house = "House Duras";
+            const instance = createFinalDetailsView(character, { showLineageAndHouse: true });
+            const houseInput = findInputs(instance.render()).find(e => e.props.id === 'house');
+            expect(houseInput.props.value).toBe("House Duras");
+        });
+
+        test('renders an empty value when the character has no house', () => {
+            const character = createMockCharacter();
+            const instance = createFinalDetailsView(character, { showLineageAndHouse: true });
+            const houseInput = findInputs(instance.render()).find(e => e.props.id === 'house');
+            expect(houseInput.props.value).toBe("");
+        });
+
+        test('does not render a house field when hidden', () => {
+            const character = createMockCharacter();
+            character.house = "House Kor";
+            const instance = createFinalDetailsView(character, { showLineageAndHouse: false });
+            const houseInput = findInputs(instance.render()).find(e => e.props.id === 'house');
+            expect(houseInput).toBeUndefined();
+        });
+
+        test('fires onHouseChanged when edited', () => {
+            const character = createMockCharacter();
+            const onHouseChanged = jest.fn();
+            const instance = createFinalDetailsView(character, { showLineageAndHouse: true, onHouseChanged });
+            const houseInput = findInputs(instance.render()).find(e => e.props.id === 'house');
+            houseInput.props.onChange("House Martok");
+            expect(onHouseChanged).toHaveBeenCalledWith("House Martok");
+        });
+    });
+
+    describe('additional traits field', () => {
+        test('renders the character additional traits when shown', () => {
+            const character = createMockCharacter();
+            character.additionalTraits = "Veteran";
+            const instance = createFinalDetailsView(character, { showAdditionalTraits: true });
+            const traitsInput = findInputs(instance.render()).find(e => e.props.id === 'traits');
+            expect(traitsInput.props.value).toBe("Veteran");
+        });
+
+        test('renders an empty value when the character has no additional traits', () => {
+            const character = createMockCharacter();
+            const instance = createFinalDetailsView(character, { showAdditionalTraits: true });
+            const traitsInput = findInputs(instance.render()).find(e => e.props.id === 'traits');
+            expect(traitsInput.props.value).toBe("");
+        });
+
+        test('does not render an additional traits field when hidden', () => {
+            const character = createMockCharacter();
+            character.additionalTraits = "Veteran";
+            const instance = createFinalDetailsView(character, { showAdditionalTraits: false });
+            const traitsInput = findInputs(instance.render()).find(e => e.props.id === 'traits');
+            expect(traitsInput).toBeUndefined();
+        });
+
+        test('fires onAdditionalTraitsChanged when edited', () => {
+            const character = createMockCharacter();
+            const onAdditionalTraitsChanged = jest.fn();
+            const instance = createFinalDetailsView(character, { showAdditionalTraits: true, onAdditionalTraitsChanged });
+            const traitsInput = findInputs(instance.render()).find(e => e.props.id === 'traits');
+            traitsInput.props.onChange("Veteran, Bold");
+            expect(onAdditionalTraitsChanged).toHaveBeenCalledWith("Veteran, Bold");
         });
     });
 });


### PR DESCRIPTION
Adds lineage, house, and additional traits fields to the Final Details tab of the General Edit character modification page, matching the character creation flow.

- Lineage and house are shown for Klingon Imperial citizens, using the existing setCharacterLineage and setCharacterHouse actions and reducers
- Additional traits are always shown, using the existing setCharacterAdditionalTraits action and reducer
- Extends the FinalDetailsView component (extracted in PR #402) and its test coverage in finalDetailsView.test.ts