### PR TITLE
Fix #326: include all custom talents in starship PDF exports

### DIFF
--- a/WebTools/src/exportpdf/generatedsheet.ts
+++ b/WebTools/src/exportpdf/generatedsheet.ts
@@ -225,7 +225,9 @@ export const assembleStarshipTalents = (starship: Starship|Station, includeSpeci
     starship.talents.forEach(t => {
         const talent = t.talentModel;
         if (talent && !handledTalents.includes(t.talent)) {
-            handledTalents.push(talent.name);
+            if (!t.isCustom) {
+                handledTalents.push(t.talent);
+            }
             const readableTalent = new ReadableTalentModel(starship.type, talent);
 
             if (talent.maxRank > 1) {

--- a/WebTools/tests/exportpdf/assembleStarshipTalents.test.ts
+++ b/WebTools/tests/exportpdf/assembleStarshipTalents.test.ts
@@ -1,0 +1,75 @@
+import { test, expect, describe } from '@jest/globals'
+import '../../src/helpers/species';
+import { Starship } from '../../src/common/starship';
+import { CharacterType } from '../../src/common/characterType';
+import { Era } from '../../src/helpers/erasEnum';
+import { SelectedTalent } from '../../src/common/selectedTalent';
+import { TALENT_NAME_CUSTOM_TALENT } from '../../src/helpers/talents';
+import { assembleStarshipTalents } from '../../src/exportpdf/generatedsheet';
+import { ReadableTalentModel } from '../../src/exportpdf/talentWriter';
+
+jest.mock('i18next', () => {
+    const mockI18n: any = (key: string) => key;
+    mockI18n.t = (key: string) => key;
+    mockI18n.use = function () { return this; };
+    mockI18n.init = function () { return this; };
+    mockI18n.on = function () { return this; };
+    mockI18n.changeLanguage = function () { return Promise.resolve(); };
+    return mockI18n;
+});
+
+jest.mock('../../src/state/store', () => {
+    const core2ndEdition = 1;
+    return {
+        getState: () => ({ context: { sources: [core2ndEdition] } }),
+        dispatch: () => undefined,
+    };
+});
+
+function customTalent(name: string, description: string) {
+    const talent = new SelectedTalent(TALENT_NAME_CUSTOM_TALENT);
+    talent.customTalentName = name;
+    talent.customTalentDescription = description;
+    return talent;
+}
+
+function shipWithMixedCustomAndStandardTalents() {
+    const starship = Starship.createStandardStarship(Era.NextGeneration, CharacterType.Starfleet, 2);
+    starship.additionalTalents = [
+        customTalent('Advanced Transporters', 'Custom description one'),
+        customTalent('Anti-Cloak Sensors', 'Custom description two'),
+        customTalent('Backup EPS Conduits', 'Custom description three'),
+        new SelectedTalent('High-Intensity Energy Weapons'),
+        new SelectedTalent('Improved Power Systems'),
+        customTalent('Rapid Fire Torpedo Launcher', 'Custom description four'),
+    ];
+    return starship;
+}
+
+describe('assembleStarshipTalents (#326)', () => {
+    test('includes every custom talent, not just the first one', () => {
+        const starship = shipWithMixedCustomAndStandardTalents();
+        const talents = assembleStarshipTalents(starship, false) as ReadableTalentModel[];
+
+        const names = talents.map(t => t.talent.localizedName);
+        expect(names).toContain('High-Intensity Energy Weapons');
+        expect(names).toContain('Improved Power Systems');
+
+        const customNames = talents
+            .filter(t => t.talent.name === TALENT_NAME_CUSTOM_TALENT)
+            .map(t => t.customTalentName);
+        expect(customNames).toEqual([
+            'Advanced Transporters',
+            'Anti-Cloak Sensors',
+            'Backup EPS Conduits',
+            'Rapid Fire Torpedo Launcher',
+        ]);
+    });
+
+    test('returns all six talents of a simplified-build ship', () => {
+        const starship = shipWithMixedCustomAndStandardTalents();
+        const talents = assembleStarshipTalents(starship, false);
+
+        expect(talents.length).toBe(6);
+    });
+});


### PR DESCRIPTION
Fixes #326

The simplified-build starship export only printed 3 of 6 talents when the ship included custom talents.

Root cause: assembleStarshipTalents in generatedsheet.ts deduplicated talents by their model name. Every custom talent shares the model name 'Custom Talent', so all custom talents after the first were dropped from the PDF.

The character-sheet assembly already handles this correctly by skipping the dedupe for custom talents; the starship assembly was missing that guard. This change applies the same logic, and adds regression tests covering a ship with four custom talents and two standard talents.