### PR TITLE
Add regression test for #315

### DIFF
--- a/WebTools/tests/starship/model/spaceframeModel.test.ts
+++ b/WebTools/tests/starship/model/spaceframeModel.test.ts
@@ -1,0 +1,43 @@
+import { test, expect, describe } from '@jest/globals'
+import '../../../src/helpers/species';
+import { SpaceframeHelper } from '../../../src/helpers/spaceframes';
+import { Spaceframe } from '../../../src/helpers/spaceframeEnum';
+
+jest.mock('i18next', () => {
+    const mockI18n: any = (key: string) => key;
+    mockI18n.t = (key: string) => key;
+    mockI18n.use = function () { return this; };
+    mockI18n.init = function () { return this; };
+    mockI18n.on = function () { return this; };
+    mockI18n.changeLanguage = function () { return Promise.resolve(); };
+    return mockI18n;
+});
+
+jest.mock('../../../src/state/store', () => {
+    const core2ndEdition = 1; // Source.Core2ndEdition
+    return {
+        getState: () => ({ context: { sources: [core2ndEdition] } }),
+        dispatch: () => undefined,
+    };
+});
+
+function talentNames(serviceYear?: number) {
+    const model = SpaceframeHelper.instance().getSpaceframe(Spaceframe.Intrepid);
+    return model.talentsEffectiveForDate(serviceYear).map(t => t.name);
+}
+
+describe('SpaceframeModel.talentsEffectiveForDate', () => {
+    test('includes the Emergency Medical Hologram talent for a pre-2380 service year', () => {
+        expect(talentNames(2371)).toContain('Emergency Medical Hologram');
+    });
+
+    test('excludes the Emergency Medical Hologram talent for a post-2380 service year', () => {
+        expect(talentNames(2400)).not.toContain('Emergency Medical Hologram');
+    });
+
+    test('keeps talents without a maximum service year for a post-2380 service year', () => {
+        const names = talentNames(2400);
+        expect(names).toContain('Improved Warp Drive');
+        expect(names).toContain('Advanced Sensor Suites');
+    });
+});


### PR DESCRIPTION
Fixes #315

Adds a regression test for SpaceframeModel.talentsEffectiveForDate, the logic behind the service record's refit swap-out list. The Emergency Medical Hologram talent has a maximum service year of 2380, and the service record page already filters spaceframe talents through talentsEffectiveForDate(serviceYear) (commit 51c737c5). This PR locks in that behavior with coverage, so EMH is no longer offered as a refit swap-out after 2380.

The tests verify that a pre-2380 ship still lists Emergency Medical Hologram, a post-2380 ship does not, and that talents without a maximum service year are unaffected.