### PR TITLE
Fix #228: Miranda refit schedule starts from the 2274 redesign

### DIFF
--- a/WebTools/src/helpers/spaceframeModel.ts
+++ b/WebTools/src/helpers/spaceframeModel.ts
@@ -68,7 +68,7 @@ export class SpaceframeModel implements IServiceYearProvider {
     }
 
     get serviceYearForRefitCalculation() {
-        if (this.id === Spaceframe.Miranda_2E) {
+        if (this.id === Spaceframe.Miranda_2E || this.id === Spaceframe.Miranda_UP) {
             return this.serviceYear + 10;
         } else {
             return this.serviceYear;

--- a/WebTools/tests/common/starship.test.ts
+++ b/WebTools/tests/common/starship.test.ts
@@ -1,0 +1,61 @@
+import { test, expect, describe } from '@jest/globals'
+import '../../src/helpers/species';
+import { Starship } from '../../src/common/starship';
+import { CharacterType } from '../../src/common/characterType';
+import { Era } from '../../src/helpers/erasEnum';
+import { SpaceframeHelper } from '../../src/helpers/spaceframes';
+import { Spaceframe } from '../../src/helpers/spaceframeEnum';
+
+jest.mock('i18next', () => {
+    const mockI18n: any = (key: string) => key;
+    mockI18n.t = (key: string) => key;
+    mockI18n.use = function () { return this; };
+    mockI18n.init = function () { return this; };
+    mockI18n.on = function () { return this; };
+    mockI18n.changeLanguage = function () { return Promise.resolve(); };
+    return mockI18n;
+});
+
+jest.mock('../../src/state/store', () => {
+    const core2ndEdition = 1; // Source.Core2ndEdition
+    return {
+        getState: () => ({ context: { sources: [core2ndEdition] } }),
+        dispatch: () => undefined,
+    };
+});
+
+function mirandaSpaceframe(frame: Spaceframe) {
+    return SpaceframeHelper.instance().getSpaceframe(frame);
+}
+
+function createMiranda(frame: Spaceframe, serviceYear: number, version: number) {
+    const ship = Starship.createStandardStarship(Era.NextGeneration, CharacterType.Starfleet, version);
+    ship.spaceframeModel = mirandaSpaceframe(frame);
+    ship.serviceYear = serviceYear;
+    return ship;
+}
+
+describe('Miranda class refit schedule', () => {
+    test('2e Miranda uses the 2274 redesign date as its refit baseline', () => {
+        expect(mirandaSpaceframe(Spaceframe.Miranda_2E).serviceYearForRefitCalculation).toBe(2274);
+    });
+
+    test('2e Miranda has 9 refits at the default 2371 service year', () => {
+        expect(createMiranda(Spaceframe.Miranda_2E, 2371, 2).numberOfRefits).toBe(9);
+    });
+
+    test('1e Core Miranda already uses the 2274 redesign date as its service year', () => {
+        expect(mirandaSpaceframe(Spaceframe.Miranda).serviceYear).toBe(2274);
+        expect(createMiranda(Spaceframe.Miranda, 2371, 1).numberOfRefits).toBe(9);
+    });
+
+    test('Utopia Planitia Miranda uses the 2264 launch date as its refit baseline', () => {
+        expect(mirandaSpaceframe(Spaceframe.Miranda_UP).serviceYearForRefitCalculation).toBe(2264);
+        expect(createMiranda(Spaceframe.Miranda_UP, 2371, 1).numberOfRefits).toBe(10);
+    });
+
+    test('non-Miranda spaceframes use their service year as the refit baseline', () => {
+        expect(mirandaSpaceframe(Spaceframe.Oberth).serviceYearForRefitCalculation)
+            .toBe(mirandaSpaceframe(Spaceframe.Oberth).serviceYear);
+    });
+});

--- a/WebTools/tests/common/starship.test.ts
+++ b/WebTools/tests/common/starship.test.ts
@@ -49,9 +49,9 @@ describe('Miranda class refit schedule', () => {
         expect(createMiranda(Spaceframe.Miranda, 2371, 1).numberOfRefits).toBe(9);
     });
 
-    test('Utopia Planitia Miranda uses the 2264 launch date as its refit baseline', () => {
-        expect(mirandaSpaceframe(Spaceframe.Miranda_UP).serviceYearForRefitCalculation).toBe(2264);
-        expect(createMiranda(Spaceframe.Miranda_UP, 2371, 1).numberOfRefits).toBe(10);
+    test('Utopia Planitia Miranda uses the 2274 redesign date as its refit baseline', () => {
+        expect(mirandaSpaceframe(Spaceframe.Miranda_UP).serviceYearForRefitCalculation).toBe(2274);
+        expect(createMiranda(Spaceframe.Miranda_UP, 2371, 1).numberOfRefits).toBe(9);
     });
 
     test('non-Miranda spaceframes use their service year as the refit baseline', () => {


### PR DESCRIPTION
Fixes #228

The Miranda's refit schedule should start from the 2274 date of the redesign, not the 2264 launch date. The maintainer already applied this for the 2e variant in commit a778ce6b via the serviceYearForRefitCalculation getter. This PR extends that same rule to the 1e Utopia Planitia variant (Miranda_UP), which still used the 2264 launch date and reported 10 refits at the default 2371 service year instead of 9.

Two commits:
1. Coverage of the current behavior (including the Miranda_UP bug).
2. The fix extending serviceYearForRefitCalculation to Miranda_UP, with the test updated to expect 9 refits.