### PR TITLE
Add regression test for #342 Strategic and Diplomatic mission profile

### DIFF
--- a/WebTools/tests/starship/missionProfiles.test.ts
+++ b/WebTools/tests/starship/missionProfiles.test.ts
@@ -3,7 +3,8 @@ import '../../src/helpers/species';
 import { Starship } from '../../src/common/starship';
 import { CharacterType } from '../../src/common/characterType';
 import { Era } from '../../src/helpers/erasEnum';
-import MissionProfiles from '../../src/helpers/missionProfiles';
+import MissionProfiles, { MissionProfile } from '../../src/helpers/missionProfiles';
+import { Department } from '../../src/helpers/department';
 
 jest.mock('i18next', () => {
     const mockI18n: any = (key: string) => key;
@@ -90,5 +91,38 @@ describe('MissionProfiles', () => {
             expect(profile.type).toBe(CharacterType.KlingonWarrior);
             expect(profile.systems.length).toBe(0);
         });
+    });
+});
+
+describe('Strategic and Diplomatic Operations mission profile (#342)', () => {
+    function strategicDiplomaticProfile(type: CharacterType, version: number) {
+        const starship = createStarship(type, version);
+        return MissionProfiles.instance.getMissionProfiles(starship)
+            .find(p => p.id === MissionProfile.StrategicAndDiplomatic);
+    }
+
+    test('grants a Command bonus rather than a Science bonus for a 2e Starfleet ship', () => {
+        const profile = strategicDiplomaticProfile(CharacterType.Starfleet, 2);
+
+        expect(profile).toBeDefined();
+        expect(profile.departments[Department.Command]).toBe(3);
+        expect(profile.departments[Department.Science]).toBe(2);
+        expect(profile.departments[Department.Command]).toBeGreaterThan(profile.departments[Department.Science]);
+    });
+
+    test('matches the errata departments for every edition and faction', () => {
+        const expectedDepartments = [3, 1, 2, 2, 2, 2];
+        const editionsAndFactions = [
+            [CharacterType.Starfleet, 1],
+            [CharacterType.Starfleet, 2],
+            [CharacterType.KlingonWarrior, 1],
+            [CharacterType.KlingonWarrior, 2],
+        ];
+
+        for (const [type, version] of editionsAndFactions) {
+            const profile = strategicDiplomaticProfile(type, version);
+            expect(profile).toBeDefined();
+            expect(profile.departments).toEqual(expectedDepartments);
+        }
     });
 });


### PR DESCRIPTION
Fixes #342, #377

Adds a regression test confirming the Strategic and Diplomatic Operations mission profile grants a bonus to Command rather than Science, matching the errata (COMMAND 03, CONN 01, ENGINEERING 02, SECURITY 02, MEDICINE 02, SCIENCE 02). The departments data was already corrected in commit 178c5f77 (bundled with #371); this PR just locks in that behavior with coverage across every edition and faction.