### PR TITLE
Add regression test for #257 FoundryVTT character export

### DIFF
--- a/WebTools/tests/vtt/foundryVttExporter.test.ts
+++ b/WebTools/tests/vtt/foundryVttExporter.test.ts
@@ -1,0 +1,66 @@
+import { test, expect, describe } from '@jest/globals'
+import '../../src/helpers/species';
+import { Character } from '../../src/common/character';
+import { CharacterType } from '../../src/common/characterType';
+import { Era } from '../../src/helpers/erasEnum';
+import { Role, RolesHelper } from '../../src/helpers/roles';
+import { FoundryVttExporter } from '../../src/vtt/foundryVttExporter';
+import { FoundryPluginType } from '../../src/vtt/foundryPluginType';
+
+jest.mock('i18next', () => {
+    const mockI18n: any = (key: string) => key;
+    mockI18n.t = (key: string) => key;
+    mockI18n.use = function () { return this; };
+    mockI18n.init = function () { return this; };
+    mockI18n.on = function () { return this; };
+    mockI18n.changeLanguage = function () { return Promise.resolve(); };
+    return mockI18n;
+});
+
+jest.mock('../../src/state/store', () => {
+    const core2ndEdition = 1; // Source.Core2ndEdition
+    return {
+        getState: () => ({ context: { sources: [core2ndEdition] } }),
+        dispatch: () => undefined,
+    };
+});
+
+const characterWeapons = (result: any) => result.items.filter((item: any) =>
+    item.type === "characterweapon" || item.type === "characterweapon2e");
+
+function exportedCharacter(version: 1 | 2) {
+    const character = Character.createMainCharacter(CharacterType.Starfleet, Era.NextGeneration, version);
+    return FoundryVttExporter.instance.exportCharacter(character, FoundryPluginType.Standard);
+}
+
+describe('FoundryVTT character export (#257)', () => {
+    test('exports 2e character weapons as characterweapon2e', () => {
+        const result = exportedCharacter(2);
+        const weapons = characterWeapons(result);
+
+        expect(weapons.length).toBeGreaterThan(0);
+        expect(weapons.every(w => w.type === "characterweapon2e")).toBe(true);
+    });
+
+    test('exports 1e character weapons as characterweapon', () => {
+        const result = exportedCharacter(1);
+        const weapons = characterWeapons(result);
+
+        expect(weapons.length).toBeGreaterThan(0);
+        expect(weapons.every(w => w.type === "characterweapon")).toBe(true);
+    });
+
+    test('exports the role only in characterrole and the ship only in assignment', () => {
+        const character = Character.createMainCharacter(CharacterType.Starfleet, Era.NextGeneration, 2);
+        character.role = Role.ChiefEngineer;
+        character.assignedShip = "USS Enterprise";
+
+        const result = FoundryVttExporter.instance.exportCharacter(character, FoundryPluginType.Standard);
+
+        const expectedRole = RolesHelper.instance.getRole(Role.ChiefEngineer, CharacterType.Starfleet)?.name;
+        expect(result.system.assignment).toBe("USS Enterprise");
+        expect(result.system.characterrole).toBe(expectedRole);
+        expect(result.system.assignment).not.toContain("Chief");
+        expect(result.system.characterrole).not.toContain("Enterprise");
+    });
+});


### PR DESCRIPTION
Adds regression tests for the FoundryVTT character export revisions made per issue #257:
- 2e character weapons export as characterweapon2e, 1e as characterweapon
- The role is exported only in the characterrole field, and the ship only in the assignment field

Fixes #257