### PR TITLE
Mission pod selection after mission profile, overlap replacement rule, and pod swap

### DIFF
--- a/WebTools/src/common/starship.ts
+++ b/WebTools/src/common/starship.ts
@@ -4,7 +4,7 @@ import { MissionPodModel } from "../helpers/missionPods";
 import { MissionProfileModel } from "../helpers/missionProfiles";
 import { SpaceframeModel } from "../helpers/spaceframeModel";
 import { allSystems, System } from "../helpers/systems";
-import { TALENT_NAME_ABLATIVE_ARMOUR, TALENT_NAME_ABUNDANT_PERSONNEL, TALENT_NAME_IMPROVED_HULL_INTEGRITY, TALENT_NAME_MINELAYER, TALENT_NAME_MISSION_POD } from "../helpers/talents";
+import { TALENT_NAME_ABLATIVE_ARMOUR, TALENT_NAME_ABUNDANT_PERSONNEL, TALENT_NAME_IMPROVED_HULL_INTEGRITY, TALENT_NAME_MINELAYER, TALENT_NAME_MISSION_POD, TalentsHelper } from "../helpers/talents";
 import StarshipWeaponRegistry, { Weapon, WeaponType } from "../helpers/weapons";
 import { CharacterType } from "./characterType";
 import { Construct, Stereotype } from "./construct";
@@ -197,6 +197,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
     serviceYear?: number;
     spaceframeStep?: SpaceframeStep;
     missionPodModel?: MissionPodModel;
+    missionPodReplacements: (SelectedTalent|undefined)[] = [];
     missionProfileStep?: MissionProfileStep;
     additionalTalents: SelectedTalent[] = [];
     refits: System[] = [];
@@ -235,6 +236,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
         this.spaceframeStep = new SpaceframeStep(spaceframe);
         if (!spaceframe?.isMissionPodAvailable) {
             this.missionPodModel = undefined;
+            this.missionPodReplacements = [];
         }
         if (original?.model?.isCustom && spaceframe.isCustom && original?.appearance != null) {
             this.spaceframeStep.appearance = original.appearance;
@@ -490,6 +492,51 @@ export class Starship extends Construct implements IWeaponDiceProvider {
         }
     }
 
+    getMissionPodOverlapTalents() {
+        const grantedTalentNames = new Set<string>();
+        if (this.spaceframeModel && this.stereotype !== Stereotype.SoloStarship) {
+            this.spaceframeModel.talentsEffectiveForDate(this.serviceYear).forEach(t => grantedTalentNames.add(t.name));
+        }
+        if (this.missionProfileStep?.talent && this.stereotype !== Stereotype.SoloStarship) {
+            grantedTalentNames.add(this.missionProfileStep.talent.name);
+        }
+
+        let result: SelectedTalent[] = [];
+        this.missionPodModel?.talents.forEach(t => {
+            if (grantedTalentNames.has(t.name)) {
+                result.push(t instanceof SelectedTalent ? t as SelectedTalent : new SelectedTalent(t.name));
+            }
+        });
+        return result;
+    }
+
+    getValidMissionPodReplacementTalents() {
+        if (!this.getMissionPodOverlapTalents().length) {
+            return [];
+        }
+
+        const grantedTalentNames = new Set<string>();
+        this.talentsWithoutAdditional.forEach(t => grantedTalentNames.add(t.name));
+        this.additionalTalents.forEach(t => grantedTalentNames.add(t.name));
+
+        this.missionPodReplacements.forEach(r => {
+            if (r != null) {
+                grantedTalentNames.delete(r.name);
+            }
+        });
+
+        return TalentsHelper.getStarshipOrStationTalents(this, true)
+            .filter(t => !t.isSpecialRule(this.version))
+            .filter(t => !grantedTalentNames.has(t.name));
+    }
+
+    hasUnreplacedMissionPodOverlaps() {
+        return this.getMissionPodOverlapTalents().some(t => {
+            const index = this.missionPodModel?.talents.findIndex(p => p.name === t.name) ?? -1;
+            return index >= 0 && this.missionPodReplacements?.[index] == null;
+        });
+    }
+
     get talentsWithoutAdditional() {
         let result: SelectedTalent[] = [];
         if (this.spaceframeModel && this.stereotype !== Stereotype.SoloStarship) {
@@ -514,8 +561,14 @@ export class Starship extends Construct implements IWeaponDiceProvider {
         }
 
         if (this.missionPodModel && this.stereotype !== Stereotype.SoloStarship) {
-            this.missionPodModel.talents.forEach(t => {
-                if (t instanceof SelectedTalent) {
+            const overlappingTalentNames = this.getMissionPodOverlapTalents().map(t => t.name);
+            this.missionPodModel.talents.forEach((t, i) => {
+                if (overlappingTalentNames.includes(t.name)) {
+                    let replacement = this.missionPodReplacements[i];
+                    if (replacement != null) {
+                        result.push(replacement);
+                    }
+                } else if (t instanceof SelectedTalent) {
                     result.push(t as SelectedTalent);
                 } else {
                     result.push(new SelectedTalent(t.name));
@@ -882,6 +935,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
         result.serviceYear = this.serviceYear;
         result.spaceframeStep = this.spaceframeStep?.copy();
         result.missionPodModel = this.missionPodModel;
+        result.missionPodReplacements = this.missionPodReplacements.map(r => r?.copy());
         result.missionProfileStep = this.missionProfileStep?.copy();
         result.additionalTalents = [...this.additionalTalents];
         result.refits = [...this.refits];

--- a/WebTools/src/helpers/marshaller.ts
+++ b/WebTools/src/helpers/marshaller.ts
@@ -1049,6 +1049,9 @@ class Marshaller {
             sheet['missionPod'] = {
                 "name": MissionPod[starship.missionPodModel.id]
             }
+            if (starship.missionPodReplacements?.length) {
+                sheet['missionPod']['replacements'] = starship.missionPodReplacements.map(r => r == null ? null : this.talentToJson(r));
+            }
         }
         if (starship.serviceRecordStep) {
             sheet["serviceRecord"] = {
@@ -1344,6 +1347,9 @@ class Marshaller {
         }
         if (json.missionPod) {
             result.missionPodModel = MissionPodHelper.instance().getMissionPodByName(json.missionPod.name, result.version);
+            if (json.missionPod.replacements?.length) {
+                result.missionPodReplacements = json.missionPod.replacements.map(t => t == null ? undefined : this.hydrateTalent(t, result.version));
+            }
         }
         if (json.serviceRecord) {
             let types = allServiceRecords().filter(t => ServiceRecord[t] === json.serviceRecord.type);

--- a/WebTools/src/i18n/locales/en/translations.json
+++ b/WebTools/src/i18n/locales/en/translations.json
@@ -279,6 +279,14 @@
     "MissionPodSelectionPage.text": "Certain spaceframes have the ability to be fitted with a single mission pod, chosen from the list below. The talents provided by the pod may not be swapped out normally, but the entire mission pod (and all its benefits) may be swapped out as if it were a single talent.",
     "MissionPodSelectionPage.errorNoSelection": "Please select a mission pod before proceeding.",
 
+    "MissionPodReplacement.title": "Replace Overlapping Mission Pod Talent",
+    "MissionPodReplacement.instruction": "The mission pod provides a talent that the spaceframe or mission profile already grants. That talent is lost, so choose a replacement talent that the ship meets the requirements for.",
+    "MissionPodReplacement.forTalent": "Replacement for {{talent}}:",
+    "MissionPodReplacement.errorMissing": "Please choose a replacement talent for every talent the mission pod duplicates.",
+
+    "SwapMissionPodPage.instruction": "Swap the ship's current mission pod for a new one. The new pod's benefits replace the old pod's, and any talent it duplicates (from the spaceframe or mission profile) must be replaced with another talent.",
+    "SwapMissionPodPage.errorNoSelection": "Please select a mission pod before proceeding.",
+
     "MissionProfileSelectionPage.text": "A mission profile is what makes one starship different from another in her same class. It determines the specialized equipment that is installed before venturing into the unknown, the priority in personnel that Starfleet gives the vessel, and its overall mission goal. All spaceframes have a mission profile.",
     "MissionProfileSelectionPage.errorNoSelection": "Please select a mission profile before proceeding.",
 
@@ -624,6 +632,7 @@
     "Common.button.create": "Create",
     "Common.button.delete": "Delete",
     "Common.button.modify": "Modify",
+    "Common.button.swapMissionPod": "Swap Mission Pod",
     "Common.button.next": "Next",
     "Common.button.previous": "Previous",
     "Common.button.save": "Save",
@@ -834,6 +843,7 @@
     "Page.title.home": "Home",
     "Page.title.modifySupportingCharacter": "Modify Supporting Character",
     "Page.title.modifyStarship": "Modify Starship",
+    "Page.title.swapMissionPod": "Swap Mission Pod",
     "Page.title.missionPodSelection": "Mission Pod Selection",
     "Page.title.missionProfileSelection": "Mission Profile Selection",
     "Page.title.missionProfileTalentSelection": "Mission Profile Talent",

--- a/WebTools/src/index.tsx
+++ b/WebTools/src/index.tsx
@@ -25,6 +25,7 @@ const TacticalAssetsPage = React.lazy(() => import(/* webpackChunkName: 'statc' 
 const ModifySupportCharacterPage = React.lazy(() => import(/* webpackChunkName: 'modify' */ './supportingcharacters/modify/modifySupportCharacterPage'));
 const ModifyCharacterPage = React.lazy(() => import(/* webpackChunkName: 'modify' */ './modify/page/modifyMainCharacterPage'));
 const ModifyStarshipPage = React.lazy(() => import(/* webpackChunkName: 'modify' */ './modify/page/modifyStarshipPage'));
+const SwapMissionPodPage = React.lazy(() => import(/* webpackChunkName: 'modify' */ './modify/page/swapMissionPodPage'));
 const NpcBuilderPage = React.lazy(() => import(/* webpackChunkName: 'npc' */ './npc/page/npcBuilderPage'));
 const NpcSpeciesSelectionPage = React.lazy(() => import(/* webpackChunkName: 'npc' */ './npc/page/npcSpeciesSelectionPage'));
 const NpcSpeciesDetailsPage = React.lazy(() => import(/* webpackChunkName: 'npc' */ './npc/page/npcSpeciesDetailsPage'));
@@ -51,6 +52,7 @@ root.render(
                     <Routes>
                         <Route path="/modify/main" element={<ModifyCharacterPage />} />
                         <Route path="/modify/starship" element={<ModifyStarshipPage />} />
+                        <Route path="/modify/starship/pod" element={<SwapMissionPodPage />} />
                         <Route path="/modify/supporting" element={<ModifySupportCharacterPage />} />
                         <Route path="/talents" element={<TalentsOverviewMainPage />} />
                         <Route path="/view" element={<ViewSheetPage />} />

--- a/WebTools/src/modify/page/swapMissionPodPage.tsx
+++ b/WebTools/src/modify/page/swapMissionPodPage.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect } from "react";
+import { connect } from "react-redux";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
+import { Link } from "react-router-dom";
+import { Button } from "react-bootstrap";
+import LcarsFrame from "../../components/lcarsFrame";
+import { Header } from "../../components/header";
+import { Dialog } from "../../components/dialog";
+import { PageIdentity } from "../../pages/pageIdentity";
+import { starshipMapStateToProperties } from "../../solo/page/soloCharacterProperties";
+import { IStarshipProperties } from "../../starship/iStarshipProperties";
+import MissionPodSelection from "../../starship/view/missionPodSelection";
+import MissionPodReplacementSelection from "../../starship/view/missionPodReplacementSelection";
+import { setStarshipMissionPod } from "../../state/starshipActions";
+import store from "../../state/store";
+import { saveStarshipToLocalStorage } from "../../state/savedConstructActions";
+import { marshaller } from "../../helpers/marshaller";
+
+const SwapMissionPodPage: React.FC<IStarshipProperties> = ({starship}) => {
+    const { t } = useTranslation();
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        if (starship == null || !starship.spaceframeModel?.isMissionPodAvailable) {
+            navigate("/");
+        }
+    }, [starship, navigate]);
+
+    const viewStarship = () => {
+        setTimeout(() => {
+            let c = store.getState().starship.starship;
+            let hash = store.getState().starship.hash;
+            store.dispatch(saveStarshipToLocalStorage(c, hash));
+            const value = marshaller.encodeStarship(c);
+            navigate('/view?s=' + value);
+        }, 200);
+    }
+
+    const finish = () => {
+        if (starship.missionPodModel == null) {
+            Dialog.show(t('SwapMissionPodPage.errorNoSelection'));
+        } else if (starship.hasUnreplacedMissionPodOverlaps()) {
+            Dialog.show(t('MissionPodReplacement.errorMissing'));
+        } else {
+            viewStarship();
+        }
+    }
+
+    return (<LcarsFrame activePage={PageIdentity.ModifyStarship}>
+        <div id="app">
+            <div className="page container ms-0">
+
+                <nav aria-label="breadcrumb">
+                    <ol className="breadcrumb">
+                        <li className="breadcrumb-item"><Link to="/index.html">{t("Page.title.home")}</Link></li>
+                        <li className="breadcrumb-item active" aria-current="page">{t('Page.title.swapMissionPod')}</li>
+                    </ol>
+                </nav>
+
+                <Header>{t('Page.title.swapMissionPod')}</Header>
+                <p>{t('SwapMissionPodPage.instruction')}</p>
+
+                {starship == null ? undefined : (<>
+                    <MissionPodSelection
+                        initialSelection={starship.missionPodModel}
+                        starship={starship}
+                        onSelection={(missionPod) => store.dispatch(setStarshipMissionPod(missionPod))} />
+                    <MissionPodReplacementSelection starship={starship} />
+                </>)}
+
+                <div className="mt-5 text-end">
+                    <Button size="sm" onClick={() => finish()}>{t('Common.button.view')}</Button>
+                </div>
+            </div>
+        </div>
+    </LcarsFrame>);
+}
+
+export default connect(starshipMapStateToProperties)(SwapMissionPodPage);

--- a/WebTools/src/starship/page/extraStarshipTalentChoicesPage.tsx
+++ b/WebTools/src/starship/page/extraStarshipTalentChoicesPage.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import Button from 'react-bootstrap/Button';
-import { PageIdentity } from '../../pages/pageIdentity';
 import { Navigation } from '../../common/navigator';
 import { Header } from '../../components/header';
 import { useTranslation } from 'react-i18next';
@@ -39,8 +38,6 @@ const ExtraStarshipTalentChoicesPage : React.FC<IExtraStarshipTalentChoicesPrope
             Dialog.show(t('Common.error.system'));
         } else if (selection.name === TALENT_NAME_DEDICATED_PERSONNEL && selection.department == null) {
             Dialog.show(t('Common.error.department'));
-        } else if (starship.spaceframeModel.isMissionPodAvailable) {
-            Navigation.navigateToPage(PageIdentity.MissionPodSelection);
         } else {
             let step = workflow.peekNextStep();
             store.dispatch(nextStarshipWorkflowStep());

--- a/WebTools/src/starship/page/missionPodSelectionPage.tsx
+++ b/WebTools/src/starship/page/missionPodSelectionPage.tsx
@@ -9,6 +9,7 @@ import { nextStarshipWorkflowStep, setStarshipMissionPod } from "../../state/sta
 import store from "../../state/store";
 import { ShipBuildWorkflow } from "../model/shipBuildWorkflow";
 import MissionPodSelection from "../view/missionPodSelection";
+import MissionPodReplacementSelection from "../view/missionPodReplacementSelection";
 import ShipBuildingBreadcrumbs from "../view/shipBuildingBreadcrumbs";
 import { withTranslation, WithTranslation } from 'react-i18next';
 
@@ -29,6 +30,7 @@ class MissionPodSelectionPage extends React.Component<IMissionPodSelectionPagePr
                 initialSelection={this.props.starship.missionPodModel}
                 starship={this.props.starship}
                 onSelection={(missionPod) => store.dispatch(setStarshipMissionPod(missionPod))} />
+            <MissionPodReplacementSelection starship={this.props.starship} />
             <div className="text-end mt-4">
                 <Button onClick={() => this.nextPage()}>{t('Common.button.next')}</Button>
             </div>
@@ -39,6 +41,8 @@ class MissionPodSelectionPage extends React.Component<IMissionPodSelectionPagePr
         const { t } = this.props;
         if (this.props.starship.missionPodModel == null) {
             Dialog.show(t('MissionPodSelectionPage.errorNoSelection'));
+        } else if (this.props.starship.hasUnreplacedMissionPodOverlaps()) {
+            Dialog.show(t('MissionPodReplacement.errorMissing'));
         } else {
             let step = this.props.workflow.peekNextStep();
             store.dispatch(nextStarshipWorkflowStep());

--- a/WebTools/src/starship/page/missionProfileTalentSelectionPage.tsx
+++ b/WebTools/src/starship/page/missionProfileTalentSelectionPage.tsx
@@ -21,6 +21,7 @@ import { CheckBox } from "../../components/checkBox";
 import { SelectedTalent } from "../../common/selectedTalent";
 import SingleTalentSelectionList from "../../components/singleTalentSelectionList";
 import { RankedTalent } from "../../helpers/rankedTalent";
+import { PageIdentity } from "../../pages/pageIdentity";
 
 interface IMissionProfileTalentSelectionPageProperties {
     starship: Starship;
@@ -58,6 +59,8 @@ const MissionProfileTalentSelectionPage: React.FC<IMissionProfileTalentSelection
             Dialog.show(t('MissionProfileTalentSelection.error.talent'));
         } else if (starship.version > 1 && starship.missionProfileStep?.system == null) {
             Dialog.show(t("MissionProfileTalentSelection.error.system"));
+        } else if (starship.spaceframeModel?.isMissionPodAvailable) {
+            Navigation.navigateToPage(PageIdentity.MissionPodSelection);
         } else {
             let step = workflow.peekNextStep();
             store.dispatch(nextStarshipWorkflowStep());

--- a/WebTools/src/starship/page/spaceframeSelectionPage.tsx
+++ b/WebTools/src/starship/page/spaceframeSelectionPage.tsx
@@ -73,8 +73,6 @@ const SpaceframeSelectionPage: React.FC<ISpaceframeSelectionPageProperties> = ({
                 Dialog.show("Please select a spaceframe before proceeding.");
             } else if (requiresDedicatedPersonnelSelection() || requiresRedundantSystemsSelection()) {
                 Navigation.navigateToPage(PageIdentity.ExtraStarshipTalentChoice);
-            } else if (starship.spaceframeModel.isMissionPodAvailable) {
-                Navigation.navigateToPage(PageIdentity.MissionPodSelection);
             } else {
                 let step = workflow.peekNextStep();
                 store.dispatch(nextStarshipWorkflowStep());

--- a/WebTools/src/starship/view/missionPodReplacementSelection.tsx
+++ b/WebTools/src/starship/view/missionPodReplacementSelection.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Starship } from "../../common/starship";
+import { SelectedTalent } from "../../common/selectedTalent";
+import { RankedTalent } from "../../helpers/rankedTalent";
+import SingleTalentSelectionList from "../../components/singleTalentSelectionList";
+import { Header } from "../../components/header";
+import { setStarshipMissionPod } from "../../state/starshipActions";
+import store from "../../state/store";
+
+interface IMissionPodReplacementSelectionProperties {
+    starship: Starship;
+}
+
+const MissionPodReplacementSelection: React.FC<IMissionPodReplacementSelectionProperties> = ({starship}) => {
+    const { t } = useTranslation();
+    const overlaps = starship.getMissionPodOverlapTalents();
+    const replacementPool = starship.getValidMissionPodReplacementTalents();
+
+    if (starship.missionPodModel == null || overlaps.length === 0) {
+        return null;
+    }
+
+    const setReplacement = (podIndex: number, talent?: SelectedTalent) => {
+        let replacements = [...(starship.missionPodReplacements ?? [])];
+        while (replacements.length <= podIndex) {
+            replacements.push(undefined);
+        }
+        replacements[podIndex] = talent;
+        store.dispatch(setStarshipMissionPod(starship.missionPodModel, replacements));
+    }
+
+    return (
+        <div className="mt-4">
+            <Header level={2}>{t('MissionPodReplacement.title')}</Header>
+            <p>{t('MissionPodReplacement.instruction')}</p>
+            {overlaps.map((talent, i) => {
+                const podIndex = starship.missionPodModel.talents.findIndex(p => p.name === talent.name);
+                return (
+                    <div key={starship.missionPodModel.id + '-replacement-' + i} className="mt-3">
+                        <Header level={3}>{t('MissionPodReplacement.forTalent', { talent: talent.name })}</Header>
+                        <SingleTalentSelectionList
+                            talents={replacementPool.map(r => new RankedTalent(r, r.maxRank > 1 ? 1 : undefined))}
+                            initialSelection={starship.missionPodReplacements?.[podIndex]}
+                            construct={starship}
+                            onSelection={(selected) => setReplacement(podIndex, selected)} />
+                    </div>
+                );
+            })}
+        </div>
+    );
+}
+
+export default MissionPodReplacementSelection;

--- a/WebTools/src/state/starshipActions.ts
+++ b/WebTools/src/state/starshipActions.ts
@@ -163,8 +163,8 @@ export function setStarshipMissionProfileTalent(talent: SelectedTalent) {
     }
 }
 
-export function setStarshipMissionPod(missionPod: MissionPodModel) {
-    let payload = { missionPod: missionPod };
+export function setStarshipMissionPod(missionPod: MissionPodModel, replacements?: (SelectedTalent|undefined)[]) {
+    let payload = { missionPod: missionPod, replacements: replacements ?? [] };
     return {
        type: SET_STARSHIP_MISSION_POD,
        payload: payload

--- a/WebTools/src/state/starshipReducer.ts
+++ b/WebTools/src/state/starshipReducer.ts
@@ -240,6 +240,20 @@ const starshipReducer = (state: StarshipState = { starship: undefined, workflow:
         case SET_STARSHIP_MISSION_POD: {
             let s = state.starship.copy();
             s.missionPodModel = action.payload.missionPod;
+            if (s.missionPodModel == null) {
+                s.missionPodReplacements = [];
+            } else {
+                let replacements = (action.payload.replacements ?? []).map(r => r?.copy());
+                while (replacements.length < s.missionPodModel.talents.length) {
+                    replacements.push(undefined);
+                }
+                s.missionPodReplacements = replacements;
+            }
+            if (s.missionPodModel) {
+                const podTalentNames = s.missionPodModel.talents.map(t => t.name);
+                s.additionalTalents = s.additionalTalents.filter(t => !podTalentNames.includes(t.name));
+                s.pruneExcessTalents();
+            }
             return {
                 ...state,
                 starship: s

--- a/WebTools/src/view/starshipView.tsx
+++ b/WebTools/src/view/starshipView.tsx
@@ -107,6 +107,12 @@ const StarshipView: React.FC<IStarshipViewProperties> = ({starship}) => {
         navigate("/modify/starship");
     }
 
+    function navigateToMissionPodSwap() {
+        const hash = cyrb53(originalEncodedSheet());
+        store.dispatch(createStarship(starship, hash));
+        navigate("/modify/starship/pod");
+    }
+
     const { t } = useTranslation();
 
     let name = "";
@@ -199,10 +205,12 @@ const StarshipView: React.FC<IStarshipViewProperties> = ({starship}) => {
                 <Button size="sm" className="me-3" onClick={() => showVttExportDialog() }>{t('Common.button.exportVtt')}</Button>
             </div>
 
-            {starship.version === 1 ? undefined :
+            {starship.spaceframeModel?.isMissionPodAvailable || starship.version > 1 ?
             (<div className="mt-5 mb-3">
-                <Button size="sm" onClick={() => navigateToModification() }>{t('Common.button.modify')}</Button>
-            </div>)}
+                {starship.spaceframeModel?.isMissionPodAvailable ? (<Button size="sm" className="me-3" onClick={() => navigateToMissionPodSwap() }>{t('Common.button.swapMissionPod')}</Button>) : undefined}
+                {starship.version === 1 ? undefined :
+                (<Button size="sm" onClick={() => navigateToModification() }>{t('Common.button.modify')}</Button>)}
+            </div>) : undefined}
         </div>)
 
     </main>);

--- a/WebTools/tests/starship/missionPodSwap.test.ts
+++ b/WebTools/tests/starship/missionPodSwap.test.ts
@@ -1,0 +1,76 @@
+import { test, expect, describe } from '@jest/globals'
+import '../../src/helpers/species';
+import starshipReducer from '../../src/state/starshipReducer';
+import { setStarshipMissionPod } from '../../src/state/starshipActions';
+import { Starship, MissionProfileStep } from '../../src/common/starship';
+import { CharacterType } from '../../src/common/characterType';
+import { Era } from '../../src/helpers/erasEnum';
+import MissionProfiles from '../../src/helpers/missionProfiles';
+import { MissionPodHelper } from '../../src/helpers/missionPods';
+import { SelectedTalent } from '../../src/common/selectedTalent';
+
+jest.mock('i18next', () => {
+    const mockI18n: any = (key: string) => key;
+    mockI18n.t = (key: string) => key;
+    mockI18n.use = function () { return this; };
+    mockI18n.init = function () { return this; };
+    mockI18n.on = function () { return this; };
+    mockI18n.changeLanguage = function () { return Promise.resolve(); };
+    return mockI18n;
+});
+
+jest.mock('../../src/state/store', () => {
+    const core2ndEdition = 1;
+    return {
+        getState: () => ({ context: { sources: [core2ndEdition] } }),
+        dispatch: () => undefined,
+    };
+});
+
+function shipWithRuggedDesignFromProfileAndPod() {
+    const starship = Starship.createStandardStarship(Era.NextGeneration, CharacterType.Starfleet, 2);
+    starship.missionProfileStep = new MissionProfileStep(
+        MissionProfiles.instance.getMissionProfileByName('LogisticalQuartermaster', CharacterType.Starfleet, 2));
+    starship.missionProfileStep.talent = new SelectedTalent('Rugged Design');
+    return starship;
+}
+
+describe('Mission pod swap reconciliation (#345)', () => {
+    test('swapping in a pod drops duplicate additional talents', () => {
+        const starship = shipWithRuggedDesignFromProfileAndPod();
+        starship.additionalTalents = [new SelectedTalent('Rugged Design')];
+
+        const state = starshipReducer(
+            { starship: starship, workflow: undefined, hash: undefined },
+            setStarshipMissionPod(MissionPodHelper.instance().getMissionPodByName('MobileDrydock', 2)));
+
+        const rugged = state.starship.additionalTalents.filter(t => t.name === 'Rugged Design');
+        expect(rugged.length).toBe(0);
+    });
+
+    test('swapping in a pod normalizes the replacements to the pod talent count', () => {
+        const starship = shipWithRuggedDesignFromProfileAndPod();
+
+        const state = starshipReducer(
+            { starship: starship, workflow: undefined, hash: undefined },
+            setStarshipMissionPod(MissionPodHelper.instance().getMissionPodByName('MobileDrydock', 2),
+                [new SelectedTalent('Advanced Holographic Emitters')]));
+
+        expect(state.starship.missionPodReplacements.length).toBe(2);
+        expect(state.starship.missionPodReplacements[0]?.name).toBe('Advanced Holographic Emitters');
+        expect(state.starship.missionPodReplacements[1]).toBeUndefined();
+    });
+
+    test('clearing the mission pod clears the replacements', () => {
+        const starship = shipWithRuggedDesignFromProfileAndPod();
+        starship.missionPodModel = MissionPodHelper.instance().getMissionPodByName('MobileDrydock', 2);
+        starship.missionPodReplacements = [undefined, new SelectedTalent('Advanced Holographic Emitters')];
+
+        const state = starshipReducer(
+            { starship: starship, workflow: undefined, hash: undefined },
+            setStarshipMissionPod(undefined));
+
+        expect(state.starship.missionPodModel).toBeUndefined();
+        expect(state.starship.missionPodReplacements.length).toBe(0);
+    });
+});

--- a/WebTools/tests/starship/missionPodTalentOverlap.test.ts
+++ b/WebTools/tests/starship/missionPodTalentOverlap.test.ts
@@ -6,6 +6,7 @@ import { Era } from '../../src/helpers/erasEnum';
 import MissionProfiles from '../../src/helpers/missionProfiles';
 import { MissionPodHelper } from '../../src/helpers/missionPods';
 import { SelectedTalent } from '../../src/common/selectedTalent';
+import { marshaller } from '../../src/helpers/marshaller';
 
 jest.mock('i18next', () => {
     const mockI18n: any = (key: string) => key;
@@ -34,12 +35,12 @@ function shipWithRuggedDesignFromProfileAndPod() {
     return starship;
 }
 
-describe('Mission pod and mission profile talent overlap (#112)', () => {
-    test('a Mobile Drydock pod and a Logistical/Quartermaster profile both grant Rugged Design', () => {
+describe('Mission pod and mission profile talent overlap (#345)', () => {
+    test('an overlapping mission pod talent is not granted twice', () => {
         const starship = shipWithRuggedDesignFromProfileAndPod();
 
         const ruggedDesign = starship.talentsWithoutAdditional.filter(s => s.talent === 'Rugged Design');
-        expect(ruggedDesign.length).toBe(2);
+        expect(ruggedDesign.length).toBe(1);
     });
 
     test('Rugged Design is not offered again as an additional talent when already granted', () => {
@@ -49,5 +50,61 @@ describe('Mission pod and mission profile talent overlap (#112)', () => {
         const isOffered = count === 0;
 
         expect(isOffered).toBe(false);
+    });
+});
+
+describe('Mission pod talent replacement rule (#345)', () => {
+    test('an overlapping mission pod talent is dropped when no replacement is chosen', () => {
+        const starship = shipWithRuggedDesignFromProfileAndPod();
+
+        const ruggedDesign = starship.talentsWithoutAdditional.filter(s => s.talent === 'Rugged Design');
+        expect(ruggedDesign.length).toBe(1);
+    });
+
+    test('an overlapping mission pod talent is replaced when a replacement is chosen', () => {
+        const starship = shipWithRuggedDesignFromProfileAndPod();
+        const replacement = new SelectedTalent(starship.getValidMissionPodReplacementTalents()[0].name);
+
+        starship.missionPodReplacements[1] = replacement;
+
+        const ruggedDesign = starship.talentsWithoutAdditional.filter(s => s.talent === 'Rugged Design');
+        expect(ruggedDesign.length).toBe(1);
+        expect(starship.talentsWithoutAdditional.filter(s => s.name === replacement.name).length).toBe(1);
+    });
+
+    test('overlapping mission pod talents are identified', () => {
+        const starship = shipWithRuggedDesignFromProfileAndPod();
+
+        const overlaps = starship.getMissionPodOverlapTalents();
+        expect(overlaps.map(t => t.name)).toEqual(['Rugged Design']);
+    });
+
+    test('the replacement pool excludes already-granted talents and special rules', () => {
+        const starship = shipWithRuggedDesignFromProfileAndPod();
+
+        const pool = starship.getValidMissionPodReplacementTalents();
+        expect(pool.length).toBeGreaterThan(0);
+        expect(pool.some(t => t.name === 'Rugged Design')).toBe(false);
+        expect(pool.some(t => t.isSpecialRule(2))).toBe(false);
+    });
+
+    test('a ship with an unreplaced overlap cannot proceed until a replacement is chosen', () => {
+        const starship = shipWithRuggedDesignFromProfileAndPod();
+        expect(starship.hasUnreplacedMissionPodOverlaps()).toBe(true);
+
+        starship.missionPodReplacements[1] = new SelectedTalent(starship.getValidMissionPodReplacementTalents()[0].name);
+        expect(starship.hasUnreplacedMissionPodOverlaps()).toBe(false);
+    });
+
+    test('mission pod replacements survive an encode/decode round-trip', () => {
+        const starship = shipWithRuggedDesignFromProfileAndPod();
+        const replacement = new SelectedTalent(starship.getValidMissionPodReplacementTalents()[0].name);
+        starship.missionPodReplacements[1] = replacement;
+
+        const encoded = marshaller.encodeStarship(starship);
+        const decoded = marshaller.decodeStarship(encoded);
+
+        expect(decoded.missionPodModel?.name).toBe('Mobile Drydock');
+        expect(decoded.missionPodReplacements?.[1]?.name).toBe(replacement.name);
     });
 });


### PR DESCRIPTION
Fixes #345

Mission pod selection now happens after the mission profile (and its talent) and before general talent selection, matching the Toolkit's build order.

- Reordered the build flow: spaceframe and extra-talent pages no longer route to mission pod selection; the mission profile talent page does, for pod-capable spaceframes.
- Implemented the replacement rule for overlapping talents: when a mission pod grants a talent the spaceframe or mission profile already grants, the pod talent is dropped and must be replaced with another talent the ship qualifies for. The replacement pool excludes already-granted talents and special rules.
- Added the ability to swap mission pods on finished ships (1e and 2e) via a new "Swap Mission Pod" button, without needing a milestone.
- Mission pod replacements survive save/load (marshaller round-trip) and are reconciled when swapping pods (duplicate additional talents are dropped).
- Updated and added tests in tests/starship/missionPodTalentOverlap.test.ts and tests/starship/missionPodSwap.test.ts. All 300 tests pass; tsc and eslint are clean.