### PR TITLE
Speed up test suite via ts-jest isolatedModules

### DIFF
--- a/WebTools/jest.config.js
+++ b/WebTools/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    transform: {'^.+\\.tsx?$': 'ts-jest'},
+    transform: {'^.+\\.tsx?$': ['ts-jest', {isolatedModules: true}]},
     testEnvironment: 'node',
     testRegex: '/tests/.*\\.(test|spec)?\\.(ts|tsx)$',
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node']

--- a/WebTools/tsconfig.json
+++ b/WebTools/tsconfig.json
@@ -29,6 +29,7 @@
     "node_modules"
   ],
   "include": [
-    "src"
+    "src",
+    "tests"
   ]
 }


### PR DESCRIPTION
Switches the Jest transform to ts-jest transpile-only mode and extends the tsc type-check gate to cover the tests directory.

The suite is CPU-bound on per-worker work, not on parallelism. ts-jest was type-checking every transformed file across 15 workers; isolatedModules skips that per-file check, and the tsc gate now type-checks the tests directory to preserve type safety.

Measured with a warm cache on this machine (16 cores, 54 suites / 291 tests):
- full suite before: 17.7s wall, 208s user CPU
- full suite after: 8.3s wall, 98s user CPU

All tests pass. tsc --noEmit and eslint on src and tests are clean.