### PR TITLE
Fix starship refit crash when adding Expanded Munitions

### DIFF
--- a/WebTools/src/common/selectedTalentExtraCheck.ts
+++ b/WebTools/src/common/selectedTalentExtraCheck.ts
@@ -47,7 +47,7 @@ export const determineSelectedTalentExtraErrors = (talent: SelectedTalent, const
     } else if (talent?.talent === TALENT_NAME_EXPANDED_MUNITIONS && talent.weapon == null) {
         return i18next.t("Talent.expandedMunitions.error");
     } else if (talent?.talent === TALENT_NAME_EXPANDED_MUNITIONS) {
-        const minelayer = (construct as Starship).isMineLayer;
+        const minelayer = (construct as Starship)?.isMineLayer;
         if (!minelayer && talent.weapon instanceof Weapon && (talent.weapon as Weapon).type === WeaponType.MINE) {
             return i18next.t("Talent.expandedMunitions.errorMines");
         } else {

--- a/WebTools/src/modify/page/modifyStarshipPage.tsx
+++ b/WebTools/src/modify/page/modifyStarshipPage.tsx
@@ -105,11 +105,14 @@ const ModifyStarshipPage: React.FC<IStarshipProperties> = ({starship}) => {
             if (advancementType === CharacterAdvancementType.Milestone) {
                 if (selectedTalent == null || removedTalentIndex == null) {
                     Dialog.show(t('ModifyStarshipPage.error.twoTalents'));
-                } else if (determineSelectedTalentExtraErrors(selectedTalent) != null) {
-                    Dialog.show(determineSelectedTalentExtraErrors(selectedTalent, starship));
                 } else {
-                    store.dispatch(modifyStarshipAddAdvancement(choice, selectedTalent, starship.talentsWithoutSpecialRules[removedTalentIndex]));
-                    nextStep();
+                    const talentError = determineSelectedTalentExtraErrors(selectedTalent, starship);
+                    if (talentError != null) {
+                        Dialog.show(talentError);
+                    } else {
+                        store.dispatch(modifyStarshipAddAdvancement(choice, selectedTalent, starship.talentsWithoutSpecialRules[removedTalentIndex]));
+                        nextStep();
+                    }
                 }
             } else {
                 if (selectedTalent == null) {

--- a/WebTools/tests/common/selectedTalentExtraCheck.test.ts
+++ b/WebTools/tests/common/selectedTalentExtraCheck.test.ts
@@ -1,0 +1,63 @@
+import { test, expect, describe } from '@jest/globals'
+import '../../src/helpers/species';
+import { SelectedTalent } from '../../src/common/selectedTalent';
+import { Weapon, WeaponType, MineTypeModel, TorpedoLoadTypeModel } from '../../src/helpers/weapons';
+import { determineSelectedTalentExtraErrors } from '../../src/common/selectedTalentExtraCheck';
+
+jest.mock('i18next', () => {
+    const mockI18n: any = (key: string) => key;
+    mockI18n.t = (key: string) => key;
+    mockI18n.use = function () { return this; };
+    mockI18n.init = function () { return this; };
+    mockI18n.on = function () { return this; };
+    mockI18n.changeLanguage = function () { return Promise.resolve(); };
+    return mockI18n;
+});
+
+jest.mock('../../src/state/store', () => {
+    const core2ndEdition = 1; // Source.Core2ndEdition
+    return {
+        getState: () => ({ context: { sources: [core2ndEdition] } }),
+        dispatch: () => undefined,
+    };
+});
+
+const createMineWeapon = () =>
+    Weapon.createStarshipWeapon('Mine', WeaponType.MINE, MineTypeModel.allTypes(1)[0]);
+
+const createTorpedoWeapon = () =>
+    Weapon.createStarshipWeapon('Torpedo', WeaponType.TORPEDO, TorpedoLoadTypeModel.allTypes(1)[0]);
+
+const createExpandedMunitionsWithWeapon = (weapon: Weapon) => {
+    const talent = new SelectedTalent('Expanded Munitions');
+    talent.weapon = weapon;
+    return talent;
+};
+
+describe('determineSelectedTalentExtraErrors', () => {
+    describe('Expanded Munitions', () => {
+        test('returns an error when no weapon has been selected', () => {
+            const talent = new SelectedTalent('Expanded Munitions');
+            expect(determineSelectedTalentExtraErrors(talent)).toBe('Talent.expandedMunitions.error');
+        });
+
+        test('returns no error for a weapon selection without a construct', () => {
+            const talent = createExpandedMunitionsWithWeapon(createTorpedoWeapon());
+            expect(() => determineSelectedTalentExtraErrors(talent)).not.toThrow();
+            expect(determineSelectedTalentExtraErrors(talent)).toBeUndefined();
+        });
+
+        test('rejects a mine weapon for a construct that is not a mine layer', () => {
+            const talent = createExpandedMunitionsWithWeapon(createMineWeapon());
+            const construct = { isMineLayer: false } as any;
+            expect(determineSelectedTalentExtraErrors(talent, construct))
+                .toBe('Talent.expandedMunitions.errorMines');
+        });
+
+        test('allows a mine weapon for a mine-layer construct', () => {
+            const talent = createExpandedMunitionsWithWeapon(createMineWeapon());
+            const construct = { isMineLayer: true } as any;
+            expect(determineSelectedTalentExtraErrors(talent, construct)).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #313

A Major Refit (modify starship, Milestone to Talent) silently failed when the newly selected talent was Expanded Munitions with a weapon already chosen. Clicking Finish did nothing because the validation crashed.

## Root cause

`modifyStarshipPage.tsx` validated the selected talent with `determineSelectedTalentExtraErrors(selectedTalent)` without passing the starship. When the talent is Expanded Munitions with a weapon, `selectedTalentExtraCheck.ts` dereferenced `(construct as Starship).isMineLayer` on an undefined `construct`, throwing a TypeError that aborted the click handler before the advancement was applied.

## Changes

- `WebTools/src/common/selectedTalentExtraCheck.ts` to optional chain the construct lookup, so the check never crashes when no construct is supplied.
- `WebTools/src/modify/page/modifyStarshipPage.tsx` to pass the starship into the milestone validation and evaluate the error once, so mine-weapon eligibility is judged correctly for version-1 ships and minelayers.
- `WebTools/tests/common/selectedTalentExtraCheck.test.ts` new regression tests covering the crash case and mine-weapon eligibility.

## Verification

- New regression test fails against the pre-fix code with `TypeError: Cannot read properties of undefined (reading 'isMineLayer')` and passes with the fix.
- Full suite: 56 suites, 304 tests pass. `tsc --noEmit` clean.