### PR TITLE
Fix #42: do not force Brak'lul twice for 1e Klingon Warriors

### DIFF
--- a/WebTools/src/helpers/earlyOutlookTalents.ts
+++ b/WebTools/src/helpers/earlyOutlookTalents.ts
@@ -1,0 +1,30 @@
+import { Character } from '../common/character';
+import { CharacterType } from '../common/characterType';
+import { Species } from './speciesEnum';
+import { isMultiSelectionTalent } from './isMultiSelectionTalent';
+import { RankedTalent } from './rankedTalent';
+import { TALENT_NAME_BRAK_LUL, TalentsHelper } from './talents';
+
+export function getEarlyOutlookTalents(character: Character): RankedTalent[] {
+    if (character.type === CharacterType.KlingonWarrior && character.speciesStep?.species === Species.Klingon && character.version === 1) {
+        return [ new RankedTalent( TalentsHelper.getTalent(TALENT_NAME_BRAK_LUL)) ];
+    } else {
+        return TalentsHelper.getAllAvailableTalentsForCharacter(character)
+            .filter(
+                t => !character.hasTalent(t.name)
+                    || (character.upbringingStep?.talent?.talent === t.name)
+                    || t.maxRank > 1
+                    || isMultiSelectionTalent(t))
+            .map(t => {
+                if (t.maxRank > 1) {
+                    if (character.upbringingStep?.talent?.talent === t.name) {
+                        return new RankedTalent(t, character.getRankForTalent(t.name));
+                    } else {
+                        return new RankedTalent(t, character.getRankForTalent(t.name) + 1);
+                    }
+                } else {
+                    return new RankedTalent(t);
+                }
+            });
+    }
+}

--- a/WebTools/src/helpers/earlyOutlookTalents.ts
+++ b/WebTools/src/helpers/earlyOutlookTalents.ts
@@ -6,7 +6,8 @@ import { RankedTalent } from './rankedTalent';
 import { TALENT_NAME_BRAK_LUL, TalentsHelper } from './talents';
 
 export function getEarlyOutlookTalents(character: Character): RankedTalent[] {
-    if (character.type === CharacterType.KlingonWarrior && character.speciesStep?.species === Species.Klingon && character.version === 1) {
+    if (character.type === CharacterType.KlingonWarrior && character.speciesStep?.species === Species.Klingon
+            && character.version === 1 && !character.hasTalent(TALENT_NAME_BRAK_LUL)) {
         return [ new RankedTalent( TalentsHelper.getTalent(TALENT_NAME_BRAK_LUL)) ];
     } else {
         return TalentsHelper.getAllAvailableTalentsForCharacter(character)

--- a/WebTools/src/pages/earlyOutlookDetailsPage.tsx
+++ b/WebTools/src/pages/earlyOutlookDetailsPage.tsx
@@ -5,7 +5,6 @@ import {AttributeView} from '../components/attribute';
 import Button from 'react-bootstrap/Button';
 import {Dialog} from '../components/dialog';
 import {CheckBox} from '../components/checkBox';
-import { TALENT_NAME_BRAK_LUL, TalentsHelper } from '../helpers/talents';
 import CharacterCreationBreadcrumbs from '../components/characterCreationBreadcrumbs';
 import SingleTalentSelectionList from '../components/singleTalentSelectionList';
 import InstructionText from '../components/instructionText';
@@ -19,15 +18,13 @@ import { connect } from 'react-redux';
 import { EarlyOutlookDiscplineController } from '../components/earlyOutlookControllers';
 import DisciplineListComponent from '../components/disciplineListComponent';
 import { CharacterType } from '../common/characterType';
-import { Species } from '../helpers/speciesEnum';
 import { makeKey } from '../common/translationKey';
 import { DisciplinesOrDepartments } from '../view/disciplinesOrDepartments';
 import TalentSettingsView from '../components/talentSettingsView';
 import { SelectedTalent } from '../common/selectedTalent';
 import { FocusSelectionView } from '../components/focusSelectionView';
 import { determineSelectedTalentExtraErrors } from '../common/selectedTalentExtraCheck';
-import { isMultiSelectionTalent } from '../helpers/isMultiSelectionTalent';
-import { RankedTalent } from '../helpers/rankedTalent';
+import { getEarlyOutlookTalents } from '../helpers/earlyOutlookTalents';
 
 const EarlyOutlookDetailsPage: React.FC<ICharacterProperties> = ({character}) => {
 
@@ -62,30 +59,6 @@ const EarlyOutlookDetailsPage: React.FC<ICharacterProperties> = ({character}) =>
         store.dispatch(addCharacterTalent(talent, StepContext.EarlyOutlook));
     }
 
-    const filterTalentList = (): RankedTalent[] => {
-        if (character.type === CharacterType.KlingonWarrior && character.speciesStep?.species === Species.Klingon && character.version === 1) {
-            return [ new RankedTalent( TalentsHelper.getTalent(TALENT_NAME_BRAK_LUL)) ];
-        } else {
-            return TalentsHelper.getAllAvailableTalentsForCharacter(character)
-                .filter(
-                    t => !character.hasTalent(t.name)
-                        || (character.upbringingStep?.talent?.talent === t.name)
-                        || t.maxRank > 1
-                        || isMultiSelectionTalent(t))
-                .map(t => {
-                    if (t.maxRank > 1) {
-                        if (character.upbringingStep?.talent?.talent === t.name) {
-                            return new RankedTalent(t, character.getRankForTalent(t.name));
-                        } else {
-                            return new RankedTalent(t, character.getRankForTalent(t.name) + 1);
-                        }
-                    } else {
-                        return new RankedTalent(t);
-                    }
-                });
-        }
-    }
-
     const attributes = character.upbringingStep?.acceptedUpbringing
         ? (<div>
             <AttributeView name={t(makeKey('Construct.attribute.', AttributesHelper.getAttributeName(earlyOutlook.attributeAcceptPlus2))) } points={2} value={character.attributes[earlyOutlook.attributeAcceptPlus2]}/>
@@ -97,7 +70,7 @@ const EarlyOutlookDetailsPage: React.FC<ICharacterProperties> = ({character}) =>
         </div>);
 
 
-    let talents = filterTalentList()
+    let talents = getEarlyOutlookTalents(character)
 
     return (
         <div className="page container ms-0">

--- a/WebTools/tests/helpers/earlyOutlookTalents.test.ts
+++ b/WebTools/tests/helpers/earlyOutlookTalents.test.ts
@@ -36,10 +36,10 @@ describe('Early outlook talents for a 1st-edition Klingon Warrior', () => {
         expect(talents[0].name).toBe(TALENT_NAME_BRAK_LUL);
     });
 
-    test('still forces Brak’lul when it has already been selected', () => {
+    test('does not force Brak’lul when it has already been selected', () => {
         const character = klingonWarriorHelper(true);
         const talents = getEarlyOutlookTalents(character);
-        expect(talents).toHaveLength(1);
-        expect(talents[0].name).toBe(TALENT_NAME_BRAK_LUL);
+        expect(talents.some(t => t.name === TALENT_NAME_BRAK_LUL)).toBe(false);
+        expect(talents.length).toBeGreaterThan(1);
     });
 });

--- a/WebTools/tests/helpers/earlyOutlookTalents.test.ts
+++ b/WebTools/tests/helpers/earlyOutlookTalents.test.ts
@@ -1,0 +1,45 @@
+import { test, expect, describe } from '@jest/globals'
+import { Character, SpeciesStep } from '../../src/common/character';
+import { CharacterType } from '../../src/common/characterType';
+import { SelectedTalent } from '../../src/common/selectedTalent';
+import { Species } from '../../src/helpers/speciesEnum';
+import { Source } from '../../src/helpers/sources';
+import { setSources } from '../../src/state/contextActions';
+import store from '../../src/state/store';
+import { getEarlyOutlookTalents } from '../../src/helpers/earlyOutlookTalents';
+import { TALENT_NAME_BRAK_LUL } from '../../src/helpers/talents';
+
+const localStorageMock = {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+};
+Object.defineProperty(global, 'window', { value: { localStorage: localStorageMock }, writable: true });
+
+const klingonWarriorHelper = (braklulAlreadySelected: boolean) => {
+    const character = new Character();
+    character.type = CharacterType.KlingonWarrior;
+    character.version = 1;
+    character.speciesStep = new SpeciesStep(Species.Klingon);
+    if (braklulAlreadySelected) {
+        character.speciesStep.talent = new SelectedTalent(TALENT_NAME_BRAK_LUL);
+    }
+    store.dispatch(setSources([Source.KlingonCore]));
+    return character;
+};
+
+describe('Early outlook talents for a 1st-edition Klingon Warrior', () => {
+    test('forces Brak’lul when it has not yet been selected', () => {
+        const character = klingonWarriorHelper(false);
+        const talents = getEarlyOutlookTalents(character);
+        expect(talents).toHaveLength(1);
+        expect(talents[0].name).toBe(TALENT_NAME_BRAK_LUL);
+    });
+
+    test('still forces Brak’lul when it has already been selected', () => {
+        const character = klingonWarriorHelper(true);
+        const talents = getEarlyOutlookTalents(character);
+        expect(talents).toHaveLength(1);
+        expect(talents[0].name).toBe(TALENT_NAME_BRAK_LUL);
+    });
+});


### PR DESCRIPTION
Fixes #42

This addresses the open regression from #42 where a 1st-edition Klingon Warrior was forced to take Brak'lul twice: once at the species step and again at the early outlook (upbringing) talent step, leaving no room to pick the actual upbringing talent.

What changed:
- Extracted the early outlook talent filtering from earlyOutlookDetailsPage.tsx into a new helper, getEarlyOutlookTalents, with the same behavior.
- The helper now only forces Brak'lul when a 1e Klingon Warrior has not already selected it. Once Brak'lul is taken (at the species step), the normal available talent list is offered instead.
- Added regression tests covering both cases (Brak'lul not yet selected, and Brak'lul already selected).

This does not address the remaining #42 design requests (roll-species button era gating, talent placement).