### PR TITLE
2e ships receive one refit per 10 years of service, even after 2400 (#422)

### DIFF
--- a/WebTools/src/common/starship.ts
+++ b/WebTools/src/common/starship.ts
@@ -49,7 +49,7 @@ export class SimpleStats {
 
 export const refitCalculator = (starship: Starship) => {
     if (starship.buildType === ShipBuildType.Starship && starship?.serviceYear && starship?.spaceframeModel?.serviceYearForRefitCalculation) {
-        if (starship.serviceYear >= 2400 && starship.spaceframeModel.serviceYearForRefitCalculation >= 2400) {
+        if (starship.version === 1 && starship.serviceYear >= 2400 && starship.spaceframeModel.serviceYearForRefitCalculation >= 2400) {
             return Math.max(0, Math.floor((starship.serviceYear - starship.spaceframeModel.serviceYearForRefitCalculation) / 50));
         } else if (starship.version !== 1 || (starship.serviceYear < 2400 && starship.spaceframeModel.serviceYearForRefitCalculation < 2400)) {
             return Math.max(0, Math.floor((starship.serviceYear - starship.spaceframeModel.serviceYearForRefitCalculation) / 10));

--- a/WebTools/tests/common/starship.test.ts
+++ b/WebTools/tests/common/starship.test.ts
@@ -59,3 +59,21 @@ describe('Miranda class refit schedule', () => {
             .toBe(mirandaSpaceframe(Spaceframe.Oberth).serviceYear);
     });
 });
+
+describe('Refit pacing for post-2400 service years', () => {
+    test('2e spaceframe launched before 2400 gets one refit per 10 years after 2400', () => {
+        expect(createMiranda(Spaceframe.Galaxy, 2410, 2).numberOfRefits).toBe(5);
+    });
+
+    test('2e spaceframe launched at or after 2400 gets one refit per 10 years', () => {
+        expect(createMiranda(Spaceframe.Odyssey, 2451, 2).numberOfRefits).toBe(5);
+    });
+
+    test('1e spaceframe launched at or after 2400 keeps the 50-year pacing', () => {
+        expect(createMiranda(Spaceframe.Odyssey, 2451, 1).numberOfRefits).toBe(1);
+    });
+
+    test('1e spaceframe launched before 2400 uses the 50-year inflection pacing after 2400', () => {
+        expect(createMiranda(Spaceframe.Galaxy, 2410, 1).numberOfRefits).toBe(4);
+    });
+});


### PR DESCRIPTION
Fixes #422

Per the 2nd edition rulebook (p. 217): "A ship receives one refit for every 10 full years of spaceframe service. Each refit increases one of the ship's systems by 1. No system may be refit more than twice in a ship's lifetime. No system may be raised above 12 through refits."

The refit calculator only applied the "every 10 full years" pacing to 2nd edition ships whose spaceframe was launched before 2400. For spaceframes launched at or after 2400 (Odyssey, Sagan, Pathfinder, and the 32nd century frames), a 2nd edition ship still used the 1st edition 50-year post-2400 pacing from Utopia Planitia.

This change restricts the 50-year pacing to 1st edition ships, so 2nd edition ships always receive one refit per 10 full years of service, matching the 2nd edition rulebook. 1st edition behavior is unchanged.

Adds regression tests for 2nd edition post-2400 spaceframes, 2nd edition pre-2400 spaceframes in the 25th century, and 1st edition 50-year and inflection pacing.
