### PR TITLE
Add Prettier tooling for TypeScript convention work

### DIFF
--- a/WebTools/.prettierignore
+++ b/WebTools/.prettierignore
@@ -1,0 +1,2 @@
+build
+public

--- a/WebTools/.prettierrc.json
+++ b/WebTools/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 2,
+  "singleQuote": true,
+  "semi": true
+}

--- a/WebTools/package-lock.json
+++ b/WebTools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "startrek",
-  "version": "1.260612",
+  "version": "1.260813",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "startrek",
-      "version": "1.260612",
+      "version": "1.260813",
       "license": "ISC",
       "dependencies": {
         "@cantoo/pdf-lib": "2.2.3",
@@ -56,6 +56,7 @@
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
         "postcss-cli": "^9.0.1",
+        "prettier": "3.9.6",
         "purgecss": "^4.0.2",
         "sass": "^1.57.1",
         "serve": "^14.2.0",
@@ -19563,6 +19564,22 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-bytes": {
@@ -39736,6 +39753,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+    },
+    "prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/WebTools/package.json
+++ b/WebTools/package.json
@@ -91,6 +91,7 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",
     "postcss-cli": "^9.0.1",
+    "prettier": "3.9.6",
     "purgecss": "^4.0.2",
     "sass": "^1.57.1",
     "serve": "^14.2.0",
@@ -103,7 +104,9 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "jest --forceExit",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "prettier": "prettier \"src/**/*.{ts,tsx}\" \"tests/**/*.{ts,tsx}\" --write",
+    "prettier:check": "prettier \"src/**/*.{ts,tsx}\" \"tests/**/*.{ts,tsx}\" --check"
   },
   "eslintConfig": {
     "extends": "react-app",


### PR DESCRIPTION
## Summary

Part of #438. Adds the Prettier tooling foundation only, with no code reformatting in this PR. The reformat itself is a separate, later PR (very large diff, per the plan in `.opencode/typescript_conventions_plan.md`).

## Changes

- `WebTools/.prettierrc.json` with `tabWidth: 2`, `singleQuote: true`, `semi: true` (plan items 1, 2, 6). `printWidth` and `trailingComma` left at Prettier defaults (80 / "all").
- `prettier@3.9.6` devDependency, exact-pinned per repo convention.
- `prettier` and `prettier:check` npm scripts scoped to `src/**/*.{ts,tsx}` and `tests/**/*.{ts,tsx}`.
- `WebTools/.prettierignore` excluding `build` and `public`.
- `package-lock.json` updated (stayed at lockfileVersion 2; also syncs a stale `version` field to match `package.json`).

No ESLint rule changes yet. The targeted rules (`semi`, `no-var`, `prefer-const`) will be added as errors in the PRs that make the code compliant, keeping `full_check.sh` green at every commit.

## Verification

- `full_check.sh` passes: 58 test suites / 322 tests, `tsc --noEmit`, eslint on `src` and `tests`.
- `npm run prettier:check` reports 630 files would reformat, documenting the scope of the follow-up reformat PR (not a gate here).

## Follow-ups

1. Run the Prettier reformat over `src/` and `tests/`; wire `prettier:check` into `full_check.sh`; add `semi: error`.
2. Autofix `var` to `let`/`const` with manual review of loop-closure sites; add `no-var` and `prefer-const` as errors.
3. Manual renames and the remaining plan items, each as its own PR.

No user-facing text changes, so the translation workflow does not apply.