### PR TITLE
Convert var to let/const (part of #438)

### DIFF
--- a/WebTools/package.json
+++ b/WebTools/package.json
@@ -112,7 +112,9 @@
     "extends": "react-app",
     "rules": {
       "unicode-bom": 0,
-      "semi": "error"
+      "semi": "error",
+      "no-var": "error",
+      "prefer-const": "error"
     }
   },
   "browserslist": {

--- a/WebTools/src/app.tsx
+++ b/WebTools/src/app.tsx
@@ -53,7 +53,7 @@ export class CharacterCreationApp extends React.Component<{}, IAppState> {
           this.state.activePage,
         ))
     ) {
-      var pageComponent = document.getElementsByClassName('page')[0];
+      const pageComponent = document.getElementsByClassName('page')[0];
       pageComponent.classList.remove('page-out');
       if (page === this.state.activePage) {
         return;

--- a/WebTools/src/asset/assetType.ts
+++ b/WebTools/src/asset/assetType.ts
@@ -35,7 +35,7 @@ export class AssetTypes {
   }
 
   getTypeByTypeName(name: string) {
-    let results = this.types.filter((t) => AssetType[t.type] === name);
+    const results = this.types.filter((t) => AssetType[t.type] === name);
     return results.length === 1 ? results[0] : null;
   }
 }

--- a/WebTools/src/asset/page/tacticalAssetsPage.tsx
+++ b/WebTools/src/asset/page/tacticalAssetsPage.tsx
@@ -30,7 +30,7 @@ const TacticalAssetsPage = () => {
   const [assets, setAssets] = useState([]);
 
   const getAssetTypes = () => {
-    let result = [new DropDownElement('', 'Any')];
+    const result = [new DropDownElement('', 'Any')];
     AssetTypes.instance
       .getTypes()
       .forEach((t) => result.push(new DropDownElement(t.type, t.name)));
@@ -44,7 +44,7 @@ const TacticalAssetsPage = () => {
 
   const getSpaceframe = (asset: Asset) => {
     if (asset.type === AssetType.Ship) {
-      let spaceframe = SpaceframeHelper.instance().getSpaceframe(
+      const spaceframe = SpaceframeHelper.instance().getSpaceframe(
         asset.additionalInformation as Spaceframe,
       );
       return (
@@ -61,7 +61,7 @@ const TacticalAssetsPage = () => {
   };
 
   const generateAsset = () => {
-    let newAssets = [...assets];
+    const newAssets = [...assets];
     let options = [];
     if (type === AssetType.Character) {
       options = [...characterAssets];
@@ -75,11 +75,11 @@ const TacticalAssetsPage = () => {
       options.push(...resourceAssets);
     }
 
-    let names = newAssets.map((a) => a.name);
+    const names = newAssets.map((a) => a.name);
     options = options.filter((a) => !names.includes(a.name));
 
     if (options.length > 0) {
-      let asset = options[Math.floor(Math.random() * options.length)];
+      const asset = options[Math.floor(Math.random() * options.length)];
       newAssets.push(asset);
       setAssets(newAssets);
     } else {

--- a/WebTools/src/common/arrowhead.tsx
+++ b/WebTools/src/common/arrowhead.tsx
@@ -2,11 +2,11 @@ const replaceDiceWithArrowhead = (description: string) => {
   if (description.indexOf('[D]') < 0) {
     return <span>{description}</span>;
   } else {
-    let parts = [];
+    const parts = [];
     while (description.indexOf('[D]') >= 0) {
-      let index = description.indexOf('[D]');
+      const index = description.indexOf('[D]');
       if (index > 0) {
-        let part = description.substring(0, index);
+        const part = description.substring(0, index);
         parts.push(part);
       }
       parts.push('[D]');
@@ -15,7 +15,7 @@ const replaceDiceWithArrowhead = (description: string) => {
     if (description.length > 0) {
       parts.push(description);
     }
-    let content = parts.map((p, i) =>
+    const content = parts.map((p, i) =>
       p === '[D]' ? (
         <span className="delta" key={'part' + i}>
           {p}

--- a/WebTools/src/common/character.ts
+++ b/WebTools/src/common/character.ts
@@ -140,8 +140,8 @@ export class CharacterRank {
 
   get localizedName() {
     if (this.id != null) {
-      let key = makeKey('Rank.', Rank[this.id], '.name');
-      let result = i18next.t(key);
+      const key = makeKey('Rank.', Rank[this.id], '.name');
+      const result = i18next.t(key);
       return key === result ? this.name : result;
     } else {
       return this.name;
@@ -150,8 +150,8 @@ export class CharacterRank {
 
   get localizedAbbreviation() {
     if (this.id != null) {
-      let key = makeKey('Rank.', Rank[this.id], '.abbrev');
-      let result = i18next.t(key);
+      const key = makeKey('Rank.', Rank[this.id], '.abbrev');
+      const result = i18next.t(key);
       return key === result ? this.name : result;
     } else {
       return this.localizedName;
@@ -192,7 +192,7 @@ export class SupportingStep {
   }
 
   copy() {
-    let result = new SupportingStep();
+    const result = new SupportingStep();
     result.focuses = [...this.focuses];
     result.attributes = [...this.attributes];
     result.disciplines = [...this.disciplines];
@@ -222,7 +222,7 @@ export class CharacterAdvancementStep {
   logCallback?: number;
 
   copy() {
-    let result = new CharacterAdvancementStep();
+    const result = new CharacterAdvancementStep();
     result.choice = this.choice;
     if (this.value instanceof SelectedTalent) {
       result.value = (this.value as SelectedTalent).copy();
@@ -263,7 +263,7 @@ export class SpeciesAbilityOptions {
   implants?: BorgImplantType[] = [];
 
   copy() {
-    let result = new SpeciesAbilityOptions();
+    const result = new SpeciesAbilityOptions();
     result.focuses = [...this.focuses];
     result.implants = [...this.implants];
     result.choice = this.choice;
@@ -299,14 +299,14 @@ export class SpeciesStep {
     if (this.species === Species.Custom) {
       return this.customSpeciesName || '';
     } else {
-      let species = SpeciesHelper.getSpeciesByType(this.species);
+      const species = SpeciesHelper.getSpeciesByType(this.species);
       let result = species.name;
       if (this.mixedSpecies != null) {
-        let mixedSpecies = SpeciesHelper.getSpeciesByType(this.mixedSpecies);
+        const mixedSpecies = SpeciesHelper.getSpeciesByType(this.mixedSpecies);
         result += ' / ' + mixedSpecies.name;
       }
       if (this.originalSpecies != null) {
-        let orginalSpecies = SpeciesHelper.getSpeciesByType(
+        const orginalSpecies = SpeciesHelper.getSpeciesByType(
           this.originalSpecies,
         );
         result += ' (originally ' + orginalSpecies.name + ')';
@@ -331,7 +331,7 @@ export class SpeciesStep {
   }
 
   copy() {
-    let result = new SpeciesStep(this.species);
+    const result = new SpeciesStep(this.species);
     result.mixedSpecies = this.mixedSpecies;
     result.originalSpecies = this.originalSpecies;
     result.customSpeciesName = this.customSpeciesName;
@@ -435,7 +435,7 @@ export class FinishingStep {
   }
 
   copy() {
-    let result = new FinishingStep();
+    const result = new FinishingStep();
     result.attributes = [...this.attributes];
     result.disciplines = [...this.disciplines];
     result.value = this.value;
@@ -475,7 +475,7 @@ export class NpcGenerationStep {
   }
 
   copy() {
-    let result = new NpcGenerationStep();
+    const result = new NpcGenerationStep();
     result.type = this.type;
     result.specialization = this.specialization;
     result.values = [...this.values];
@@ -564,7 +564,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
       this._attributeInitialValue,
     ];
 
-    for (var i = 0; i <= Department.Medicine; i++) {
+    for (let i = 0; i <= Department.Medicine; i++) {
       this._skills.push(0);
     }
 
@@ -604,7 +604,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
     if (this.role != null) {
       result = RolesHelper.instance.getRole(this.role, this.type)?.name ?? '';
       if (this.secondaryRole != null) {
-        let secondary =
+        const secondary =
           RolesHelper.instance.getRole(this.secondaryRole, this.type)?.name ??
           '';
         result = result + ' / ' + secondary;
@@ -645,7 +645,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
       result =
         RolesHelper.instance.getRole(this.role, this.type)?.localizedName ?? '';
       if (this.secondaryRole != null) {
-        let secondary =
+        const secondary =
           RolesHelper.instance.getRole(this.secondaryRole, this.type)
             ?.localizedName ?? '';
         result = result + ' / ' + secondary;
@@ -664,7 +664,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   get talentAssemblies() {
-    let result: TalentAssembly[] = [];
+    const result: TalentAssembly[] = [];
     if (this.stereotype === Stereotype.Npc) {
       return this.npcGenerationStep
         ? this.npcGenerationStep.talents.map(
@@ -713,7 +713,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
         s instanceof CharacterAdvancementStep &&
         s.choice === CharacterAdvancementChoice.Talent
       ) {
-        let step = s as CharacterAdvancementStep;
+        const step = s as CharacterAdvancementStep;
         if (step.removeValue != null) {
           let index = -1;
           result.forEach((t, i) => {
@@ -749,12 +749,12 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   get rankedTalents(): SelectedTalent[] {
-    let talents = this.talents;
-    let duplicates = [];
-    let result = [];
+    const talents = this.talents;
+    const duplicates = [];
+    const result = [];
     talents.forEach((t) => {
       if (t.talentModel.maxRank > 1 && !duplicates.includes(t.name)) {
-        let temp = t.copy();
+        const temp = t.copy();
         temp.multiple = this.getRankForTalent(t.name);
         duplicates.push(t.name);
         result.push(temp);
@@ -778,7 +778,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
           result[this.environmentStep.attribute] + 1;
       }
       if (this.upbringingStep != null) {
-        let earlyOutlook = this.upbringingStep.upbringing;
+        const earlyOutlook = this.upbringingStep.upbringing;
         if (this.upbringingStep.acceptedUpbringing) {
           result[earlyOutlook.attributeAcceptPlus2] =
             result[earlyOutlook.attributeAcceptPlus2] + 2;
@@ -821,11 +821,11 @@ export class Character extends Construct implements IWeaponDiceProvider {
         values = [10, 10, 9, 9, 8, 8];
       }
       result = AttributesHelper.getAllAttributes().map((a) => {
-        let index = this.supportingStep?.attributes?.indexOf(a);
-        let speciesBonus = this.speciesStep?.attributes?.filter(
+        const index = this.supportingStep?.attributes?.indexOf(a);
+        const speciesBonus = this.speciesStep?.attributes?.filter(
           (att) => att === a,
         ).length;
-        let speciesminuses = this.speciesStep?.decrementAttributes?.filter(
+        const speciesminuses = this.speciesStep?.decrementAttributes?.filter(
           (att) => att === a,
         ).length;
         return values[index] + speciesBonus - speciesminuses;
@@ -894,7 +894,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
         values = [4, 4, 3, 2, 2, 1];
       }
       result = DepartmentsHelper.instance.getDepartments().map((s) => {
-        let index = this.supportingStep?.disciplines?.indexOf(s);
+        const index = this.supportingStep?.disciplines?.indexOf(s);
         return values[index];
       });
     } else {
@@ -1092,7 +1092,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   get equipmentModels(): EquipmentModel[] {
-    let base = this.baseEquipmentModels;
+    const base = this.baseEquipmentModels;
     this.npcGenerationStep?.equipment?.forEach((e) => {
       if (e instanceof EquipmentModel) {
         base.push(e);
@@ -1104,7 +1104,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   get baseEquipmentModels(): EquipmentModel[] {
-    let result = [];
+    const result = [];
     if (this.age.isChild) {
       result.push(EquipmentHelper.instance.findByType(EquipmentType.Clothing));
     } else if (this.isCivilian()) {
@@ -1167,7 +1167,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   get equipmentAndImplants(): (EquipmentModel | Implant)[] {
-    let result: (EquipmentModel | Implant)[] = [...this.equipmentModels];
+    const result: (EquipmentModel | Implant)[] = [...this.equipmentModels];
     if (this.implants?.length) {
       this.implants.forEach((i) =>
         result.push(BorgImplants.instance.getImplantByType(i)),
@@ -1185,7 +1185,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   get valueAssemblies() {
-    let result = [];
+    const result = [];
     if (this.stereotype === Stereotype.SupportingCharacter) {
       if (this.supportingStep?.value) {
         result.push(
@@ -1305,7 +1305,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   get implants(): BorgImplantType[] {
-    let result = [];
+    const result = [];
     this.speciesStep?.abilityOptions?.implants?.forEach((i) => result.push(i));
     this.talents.forEach((t) => result.push(...t.implants));
     return result;
@@ -1324,15 +1324,15 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   getTalentNameList() {
-    let consolidatedTalents = {};
+    const consolidatedTalents = {};
     this.talents.forEach((t) => {
-      let rank = consolidatedTalents[t.talent] ?? 0;
+      const rank = consolidatedTalents[t.talent] ?? 0;
       consolidatedTalents[t.talent] = rank + 1;
     });
 
-    let result = [];
-    for (let name in consolidatedTalents) {
-      let rank = consolidatedTalents[name];
+    const result = [];
+    for (const name in consolidatedTalents) {
+      const rank = consolidatedTalents[name];
       result.push(rank === 1 ? name : name + ' [Rank ' + rank + ']');
     }
     return result;
@@ -1340,7 +1340,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
 
   /* returns the "official" name of the talent */
   getDistinctTalentNameList(): string[] {
-    let result = [];
+    const result = [];
     this.talents.forEach((t) => {
       if (result.indexOf(t.talent) < 0) {
         result.push(t.talent);
@@ -1351,7 +1351,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   determineWeapons() {
-    let result: Weapon[] = [];
+    const result: Weapon[] = [];
 
     if (this.hasTalent('Mean Right Hook')) {
       result.push(PersonalWeapons.instance(this.version).unarmedStrikeMean);
@@ -1372,7 +1372,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
     }
 
     if (this.hasTalent(TALENT_NAME_WARRIORS_SPIRIT)) {
-      let talent = this.talents.filter(
+      const talent = this.talents.filter(
         (t) => t.talent === TALENT_NAME_WARRIORS_SPIRIT,
       )[0];
       if (talent.selection === SpecialWeapon.MekLeth) {
@@ -1445,7 +1445,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
     }
 
     this.npcGenerationStep?.weapons?.forEach((t) => {
-      let weapon = PersonalWeapons.instance(this.version).getWeaponByType(t);
+      const weapon = PersonalWeapons.instance(this.version).getWeaponByType(t);
       if (weapon) {
         result.push(weapon);
       }
@@ -1584,9 +1584,9 @@ export class Character extends Construct implements IWeaponDiceProvider {
     } else if (this.speciesStep.species === Species.Custom) {
       return this.speciesStep.customSpeciesName || '';
     } else {
-      let species = SpeciesHelper.getSpeciesByType(this.speciesStep.species);
+      const species = SpeciesHelper.getSpeciesByType(this.speciesStep.species);
       if (this.speciesStep.mixedSpecies != null) {
-        let mixedSpecies = SpeciesHelper.getSpeciesByType(
+        const mixedSpecies = SpeciesHelper.getSpeciesByType(
           this.speciesStep.mixedSpecies,
         );
         return i18next.t('Species.mixedSpecies.text', {
@@ -1595,7 +1595,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
         });
       }
       if (this.speciesStep.originalSpecies != null) {
-        let originalSpecies = SpeciesHelper.getSpeciesByType(
+        const originalSpecies = SpeciesHelper.getSpeciesByType(
           this.speciesStep.originalSpecies,
         );
         return i18next.t('Species.formerSpecies.text', {
@@ -1609,9 +1609,9 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   get baseTraits() {
-    let traits = [...this.traits];
+    const traits = [...this.traits];
     if (this.speciesStep != null) {
-      let species = SpeciesHelper.getSpeciesByType(this.speciesStep?.species);
+      const species = SpeciesHelper.getSpeciesByType(this.speciesStep?.species);
       if (species != null && traits.indexOf(species.name) >= 0) {
         traits.splice(traits.indexOf(species.name), 1);
       }
@@ -1679,7 +1679,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
     }
     if (this.role === Role.Ambassador) {
       if (this.type === CharacterType.AmbassadorDiplomat && this.typeDetails) {
-        let details = this.typeDetails as GovernmentDetails;
+        const details = this.typeDetails as GovernmentDetails;
         traits.push(details.name ? details.name + ' Ambassador' : 'Ambassador');
       } else {
         traits.push('Ambassador');
@@ -1698,7 +1698,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   getAllTraits() {
-    let traits = this.baseTraits;
+    const traits = this.baseTraits;
     if (this.additionalTraits) {
       traits.push(this.additionalTraits);
     }
@@ -1711,12 +1711,12 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   getTalentByName(talentName: string): SelectedTalent | undefined {
-    let result = this.talents.filter((t) => t.talent === talentName);
+    const result = this.talents.filter((t) => t.talent === talentName);
     return result.length > 0 ? result[0] : undefined;
   }
 
   addTalent(talentModel: ITalent | SelectedTalent) {
-    let selectedTalent =
+    const selectedTalent =
       talentModel instanceof SelectedTalent
         ? (talentModel as SelectedTalent)
         : new SelectedTalent(talentModel.name);
@@ -1760,7 +1760,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   hasTalent(name: string) {
-    let found = this.talents.filter((t) => t.talent === name);
+    const found = this.talents.filter((t) => t.talent === name);
     return found.length > 0;
   }
 
@@ -2121,7 +2121,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   public copy(): Character {
-    var character = new Character();
+    const character = new Character();
 
     character.type = this.type;
     character.stereotype = this.stereotype;
@@ -2134,7 +2134,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
     });
     character.age = this.age;
     this.careerEvents.forEach((e) => {
-      let event = new CareerEventStep(e.id);
+      const event = new CareerEventStep(e.id);
       event.attribute = e.attribute;
       event.discipline = e.discipline;
       event.focus = e.focus;
@@ -2243,7 +2243,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   public static createSoloCharacter(era: Era) {
-    let result = new Character();
+    const result = new Character();
     result.stereotype = Stereotype.SoloCharacter;
     result.era = era;
     return result;
@@ -2255,7 +2255,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
     npcType?: NpcType,
     type: CharacterType = CharacterType.Starfleet,
   ) {
-    let result = new Character();
+    const result = new Character();
     result.stereotype = Stereotype.Npc;
     result.era = era;
     result.type = type;
@@ -2271,7 +2271,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
     era: Era,
     version: 1 | 2 = 1,
   ) {
-    let result = new Character();
+    const result = new Character();
     result.type = type;
     result.version = version;
     result.era = era;
@@ -2280,7 +2280,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   public static createSupportingCharacter(era: Era, version: 1 | 2 = 1) {
-    let result = new Character();
+    const result = new Character();
     result.version = version;
     result.stereotype = Stereotype.SupportingCharacter;
     result.era = era;
@@ -2292,7 +2292,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
     }
 
     result.supportingStep = new SupportingStep();
-    let rank = RanksHelper.instance().getRank(Rank.Ensign);
+    const rank = RanksHelper.instance().getRank(Rank.Ensign);
     result._rank = new CharacterRank(rank.localizedName, rank.id);
     return result;
   }

--- a/WebTools/src/common/characterSerializer.ts
+++ b/WebTools/src/common/characterSerializer.ts
@@ -14,7 +14,7 @@ export interface ICharacterData {
 export class CharacterSerializer {
   public static serializeName(character: Character) {
     if (isKlingonWarriorType(character.type)) {
-      var result = character.name;
+      let result = character.name;
       if (character.lineage) {
         result += ', ' + character.lineage;
       }
@@ -51,7 +51,7 @@ export class CharacterSerializer {
     otherSpecies: Species,
     construct: Construct,
   ) {
-    let environmentModel =
+    const environmentModel =
       environment == null /* or, implicitly, undefined */
         ? undefined
         : EnvironmentsHelper.getEnvironment(environment, construct);
@@ -61,7 +61,7 @@ export class CharacterSerializer {
         environment === Environment.AnotherSpeciesWorld &&
         otherSpecies != null
       ) {
-        let other = SpeciesHelper.getSpeciesByType(otherSpecies);
+        const other = SpeciesHelper.getSpeciesByType(otherSpecies);
         result = i18next.t('Environment.special.name', {
           name: result,
           species: other.localizedName,

--- a/WebTools/src/common/characterType.ts
+++ b/WebTools/src/common/characterType.ts
@@ -117,7 +117,7 @@ export class CharacterTypeModel {
   }
 
   public static getCharacterTypeByTypeName(name: String) {
-    let matches = CharacterTypeModel.TYPES.filter(
+    const matches = CharacterTypeModel.TYPES.filter(
       (t) => CharacterType[t.type] === name,
     );
     return matches.length === 0 ? undefined : matches[0];

--- a/WebTools/src/common/colour.ts
+++ b/WebTools/src/common/colour.ts
@@ -69,9 +69,9 @@ export class SimpleColor {
     if (hex.length !== 6) {
       return undefined;
     } else {
-      let red = parseInt(hex.substring(0, 2), 16);
-      let green = parseInt(hex.substring(2, 4), 16);
-      let blue = parseInt(hex.substring(4), 16);
+      const red = parseInt(hex.substring(0, 2), 16);
+      const green = parseInt(hex.substring(2, 4), 16);
+      const blue = parseInt(hex.substring(4), 16);
       return new SimpleColor(red, green, blue);
     }
   }

--- a/WebTools/src/common/die.ts
+++ b/WebTools/src/common/die.ts
@@ -33,7 +33,7 @@ class D6RollResult {
 
 class D6Dice {
   rollFace() {
-    let result = Math.floor(Math.random() * 6) + 1;
+    const result = Math.floor(Math.random() * 6) + 1;
     return new D6RollResult(result);
   }
 }

--- a/WebTools/src/common/extensions.ts
+++ b/WebTools/src/common/extensions.ts
@@ -3,22 +3,22 @@ export function CopyObject(target: {}, ...sources: Array<{}>) {
     throw new TypeError('CopyObject failed due to inconsistent cast.');
   }
 
-  var to = Object(target);
-  for (var i = 0; i < sources.length; i++) {
-    var nextSource = sources[i];
+  const to = Object(target);
+  for (let i = 0; i < sources.length; i++) {
+    let nextSource = sources[i];
     if (nextSource === undefined || nextSource === null) {
       continue;
     }
     nextSource = Object(nextSource);
 
-    var keysArray = Object.keys(nextSource);
+    const keysArray = Object.keys(nextSource);
     for (
-      var nextIndex = 0, len = keysArray.length;
+      let nextIndex = 0, len = keysArray.length;
       nextIndex < len;
       nextIndex++
     ) {
-      var nextKey = keysArray[nextIndex];
-      var desc = Object.getOwnPropertyDescriptor(nextSource, nextKey);
+      const nextKey = keysArray[nextIndex];
+      const desc = Object.getOwnPropertyDescriptor(nextSource, nextKey);
       if (desc !== undefined && desc.enumerable) {
         to[nextKey] = nextSource[nextKey];
       }

--- a/WebTools/src/common/inputField.tsx
+++ b/WebTools/src/common/inputField.tsx
@@ -43,7 +43,7 @@ export class InputField extends React.Component<
   }
 
   render() {
-    let additionalProps = {};
+    const additionalProps = {};
     if (this.props.type === 'number' && this.props.max != null) {
       additionalProps['max'] = this.props.max;
     }

--- a/WebTools/src/common/logEntry.ts
+++ b/WebTools/src/common/logEntry.ts
@@ -27,7 +27,7 @@ export class ValueUseTypeModel {
   }
 
   static findTypeByTypeName(typeName: string) {
-    let result = this.types.filter((t) => ValueUseType[t.type] === typeName);
+    const result = this.types.filter((t) => ValueUseType[t.type] === typeName);
     return result?.length ? result[0].type : undefined;
   }
 }
@@ -74,7 +74,7 @@ export class LogEntry {
   }
 
   copy() {
-    let result = new LogEntry(this.id);
+    const result = new LogEntry(this.id);
     result.adventureTitle = this.adventureTitle;
     result.missionDescription = this.missionDescription;
     result.notes = this.notes;

--- a/WebTools/src/common/navigator.tsx
+++ b/WebTools/src/common/navigator.tsx
@@ -3,7 +3,7 @@ import { Events, EventIdentity } from './eventChannel';
 
 export class Navigator {
   navigateToPage(pageId: PageIdentity) {
-    var page = document.getElementsByClassName('page')[0];
+    const page = document.getElementsByClassName('page')[0];
     page.classList.add('page-out');
 
     setTimeout(() => {
@@ -12,7 +12,7 @@ export class Navigator {
   }
 
   navigateToHistoryPage(pageId: PageIdentity) {
-    var page = document.getElementsByClassName('page')[0];
+    const page = document.getElementsByClassName('page')[0];
     page.classList.add('page-out');
 
     setTimeout(() => {

--- a/WebTools/src/common/selectedTalent.ts
+++ b/WebTools/src/common/selectedTalent.ts
@@ -66,7 +66,7 @@ export class SelectedTalent implements ITalent {
   }
 
   copy() {
-    let result = new SelectedTalent(this.talent);
+    const result = new SelectedTalent(this.talent);
     result.implants = [...this.implants];
     result.focuses = [...this.focuses];
     result.value = this.value;
@@ -88,31 +88,31 @@ export class SelectedTalent implements ITalent {
   }
 
   static createWithDepartment(talentName: string, department: Department) {
-    let result = new SelectedTalent(talentName);
+    const result = new SelectedTalent(talentName);
     result.department = department;
     return result;
   }
 
   static createWithSystem(talentName: string, system: System) {
-    let result = new SelectedTalent(talentName);
+    const result = new SelectedTalent(talentName);
     result.system = system;
     return result;
   }
 
   static createWithMultiple(talentName: string, multiple: number) {
-    let result = new SelectedTalent(talentName);
+    const result = new SelectedTalent(talentName);
     result.multiple = multiple;
     return result;
   }
 
   static createWithSelection(talentName: string, selection: string) {
-    let result = new SelectedTalent(talentName);
+    const result = new SelectedTalent(talentName);
     result.selection = selection;
     return result;
   }
 
   static createWithWeapon(talentName: string, weapon: string) {
-    let result = new SelectedTalent(talentName);
+    const result = new SelectedTalent(talentName);
     result.weapon = weapon;
     return result;
   }
@@ -134,7 +134,7 @@ export class SelectedTalent implements ITalent {
 
       if (talentModel.isXQualified) {
         if (this.x != null) {
-          let xLocation = name.lastIndexOf(' X');
+          const xLocation = name.lastIndexOf(' X');
           name =
             name.substring(0, xLocation + 1) +
             this.x +

--- a/WebTools/src/common/starship.ts
+++ b/WebTools/src/common/starship.ts
@@ -46,7 +46,7 @@ export class SimpleStats {
   }
 
   copy() {
-    let result = new SimpleStats();
+    const result = new SimpleStats();
     result.className = this.className;
     result.departments = [...this.departments];
     result.systems = [...this.systems];
@@ -92,10 +92,10 @@ export const refitCalculator = (starship: Starship) => {
       starship.serviceYear >
       starship.spaceframeModel.serviceYearForRefitCalculation
     ) {
-      let remainder =
+      const remainder =
         starship.spaceframeModel.serviceYearForRefitCalculation % 10;
-      let inflectionYear = 2400 + (remainder === 0 ? 0 : remainder - 10);
-      let result =
+      const inflectionYear = 2400 + (remainder === 0 ? 0 : remainder - 10);
+      const result =
         Math.floor((starship.serviceYear - inflectionYear) / 50) +
         Math.floor(
           (inflectionYear -
@@ -121,7 +121,7 @@ export class MissionProfileStep {
   }
 
   copy() {
-    let result = new MissionProfileStep(this.type);
+    const result = new MissionProfileStep(this.type);
     result.system = this.system;
     result.talent = this.talent?.copy();
     return result;
@@ -165,7 +165,7 @@ export class ServiceRecordStep {
       ServiceRecord[this.type.type],
       '.trait',
     );
-    let result = i18next.t(key, {
+    const result = i18next.t(key, {
       X: this.selection?.length ? this.selection : 'X',
     });
     if (result === key) {
@@ -176,7 +176,7 @@ export class ServiceRecordStep {
   }
 
   copy() {
-    let result = new ServiceRecordStep(this.type);
+    const result = new ServiceRecordStep(this.type);
     result.specialRule = this.specialRule;
     result.selection = this.selection;
     result.system = this.system;
@@ -224,7 +224,7 @@ export class StarshipAdvancementStep {
   removeValue: System | Department | SelectedTalent;
 
   copy() {
-    let result = new StarshipAdvancementStep();
+    const result = new StarshipAdvancementStep();
     result.choice = this.choice;
     if (this.value instanceof SelectedTalent) {
       result.value = (this.value as SelectedTalent).copy();
@@ -287,7 +287,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
   }
 
   set spaceframeModel(spaceframe: SpaceframeModel) {
-    let original = this.spaceframeStep;
+    const original = this.spaceframeStep;
     this.spaceframeStep = new SpaceframeStep(spaceframe);
     if (!spaceframe?.isMissionPodAvailable) {
       this.missionPodModel = undefined;
@@ -333,7 +333,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
     if (this.buildType !== ShipBuildType.Starship) {
       power = Math.ceil(power / 2);
     }
-    let bonus = this.talents.filter((t) => t.name === 'Secondary Reactors');
+    const bonus = this.talents.filter((t) => t.name === 'Secondary Reactors');
     if (power != null && bonus.length > 0) {
       power += 5 * bonus.length;
     }
@@ -352,7 +352,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
       return base;
     } else {
       let base = Math.ceil(this.scale / 2);
-      let structure = this.systems[System.Structure];
+      const structure = this.systems[System.Structure];
       if (this.hasTalent(TALENT_NAME_ABLATIVE_ARMOUR)) {
         base += 2;
       }
@@ -374,7 +374,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
   }
 
   get defaultTraits() {
-    let trait = [];
+    const trait = [];
     if (
       isKlingonWarriorType(this.type) &&
       this.buildType === ShipBuildType.Starship
@@ -521,7 +521,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
   }
 
   get allTraitsAsArray() {
-    let traits = this.getAllTraits();
+    const traits = this.getAllTraits();
     return traits
       .split(',')
       .map((t) => t.trim())
@@ -555,7 +555,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
   }
 
   getDistinctTalentNameList() {
-    let result = [];
+    const result = [];
     this.talents.forEach((t) => {
       if (result.indexOf(t.name) < 0) {
         result.push(t.name);
@@ -585,7 +585,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
     ) {
       return this.missionPodModel.localizedName;
     } else {
-      let shortenedList = this.talents.filter((t) => t.name === talentName);
+      const shortenedList = this.talents.filter((t) => t.name === talentName);
       return shortenedList.length > 0
         ? shortenedList[0].additionalInformation
         : undefined;
@@ -606,7 +606,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
       grantedTalentNames.add(this.missionProfileStep.talent.name);
     }
 
-    let result: SelectedTalent[] = [];
+    const result: SelectedTalent[] = [];
     this.missionPodModel?.talents.forEach((t) => {
       if (grantedTalentNames.has(t.name)) {
         result.push(
@@ -655,7 +655,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
       this.spaceframeModel
         .talentsEffectiveForDate(this.serviceYear)
         .forEach((t) => {
-          let overrides = this.spaceframeStep.talents.filter(
+          const overrides = this.spaceframeStep.talents.filter(
             (st) => st.name === t.name,
           );
           if (overrides?.length) {
@@ -686,7 +686,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
       );
       this.missionPodModel.talents.forEach((t, i) => {
         if (overlappingTalentNames.includes(t.name)) {
-          let replacement = this.missionPodReplacements[i];
+          const replacement = this.missionPodReplacements[i];
           if (replacement != null) {
             result.push(replacement);
           }
@@ -699,7 +699,9 @@ export class Starship extends Construct implements IWeaponDiceProvider {
     }
 
     if (this.serviceRecordStep?.specialRule) {
-      let talent = new SelectedTalent(this.serviceRecordStep?.specialRule.name);
+      const talent = new SelectedTalent(
+        this.serviceRecordStep?.specialRule.name,
+      );
       if (this.serviceRecordStep?.system != null) {
         talent.system = this.serviceRecordStep?.system;
       }
@@ -713,7 +715,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
   }
 
   get talents(): SelectedTalent[] {
-    let result = this.talentsWithoutAdditional;
+    const result = this.talentsWithoutAdditional;
     this.additionalTalents.forEach((t) => {
       result.push(t);
     });
@@ -724,7 +726,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
       )
       .forEach((s) => {
         if (s.removeValue != null) {
-          let removedTalent = s.removeValue as SelectedTalent;
+          const removedTalent = s.removeValue as SelectedTalent;
           let index = -1;
           result.forEach((t, i) => {
             if (
@@ -747,12 +749,12 @@ export class Starship extends Construct implements IWeaponDiceProvider {
   }
 
   get rankedTalents(): SelectedTalent[] {
-    let talents = this.talents;
-    let duplicates = [];
-    let result = [];
+    const talents = this.talents;
+    const duplicates = [];
+    const result = [];
     talents.forEach((t) => {
       if (t.talentModel.maxRank > 1 && !duplicates.includes(t.name)) {
-        let temp = t.copy();
+        const temp = t.copy();
         temp.multiple = this.getRankForTalent(t.name);
         duplicates.push(t.name);
         result.push(temp);
@@ -771,7 +773,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
   }
 
   private getNonSpaceframeTalentSelectionList() {
-    let talents: Map<string, SelectedTalent> = new Map();
+    const talents: Map<string, SelectedTalent> = new Map();
     if (
       this.missionProfileStep?.talent &&
       this.stereotype !== Stereotype.SoloStarship
@@ -791,26 +793,26 @@ export class Starship extends Construct implements IWeaponDiceProvider {
       });
     }
 
-    let result: SelectedTalent[] = [];
+    const result: SelectedTalent[] = [];
     talents.forEach((value: SelectedTalent) => result.push(value));
     return result;
   }
 
   hasNonSpaceframeTalent(talentName: string) {
-    let talents = this.getNonSpaceframeTalentSelectionList().filter(
+    const talents = this.getNonSpaceframeTalentSelectionList().filter(
       (t) => t.name === talentName,
     );
     return talents.length > 0;
   }
 
   hasTalent(talentName: string) {
-    let talents = this.talents.filter((t) => t.name === talentName);
+    const talents = this.talents.filter((t) => t.name === talentName);
     return talents.length > 0;
   }
 
   private addTalent(t: SelectedTalent, talents: Map<string, SelectedTalent>) {
     if (talents.get(t.name) != null) {
-      let temp = talents.get(t.name);
+      const temp = talents.get(t.name);
       talents.set(t.name, new SelectedTalent(temp.talent));
     } else {
       talents.set(t.name, t);
@@ -828,7 +830,9 @@ export class Starship extends Construct implements IWeaponDiceProvider {
       if (this.buildType !== ShipBuildType.Starship) {
         base = this.power;
       }
-      let advanced = this.talents.filter((t) => t.name === 'Advanced Shields');
+      const advanced = this.talents.filter(
+        (t) => t.name === 'Advanced Shields',
+      );
       if (advanced.length > 0) {
         base += 5 * advanced.length;
       }
@@ -841,18 +845,18 @@ export class Starship extends Construct implements IWeaponDiceProvider {
   pruneExcessTalents() {
     if (this.stereotype === Stereotype.SoloStarship) {
       if (this.additionalTalents.length > this.spaceframeModel?.scale) {
-        let excess =
+        const excess =
           this.additionalTalents.length - this.spaceframeModel?.scale;
         this.additionalTalents.splice(0, excess);
       }
     } else if (this.freeTalentSlots < this.additionalTalents.length) {
-      let excess = this.additionalTalents.length - this.freeTalentSlots;
+      const excess = this.additionalTalents.length - this.freeTalentSlots;
       this.additionalTalents.splice(0, excess);
     }
   }
 
   refitsAsString() {
-    let systems: System[] = allSystems();
+    const systems: System[] = allSystems();
     let refitString = '';
     if (this.refits) {
       systems.forEach((s) => {
@@ -878,16 +882,16 @@ export class Starship extends Construct implements IWeaponDiceProvider {
   }
 
   determineWeapons(): Weapon[] {
-    let result = [];
+    const result = [];
     const spaceframe = this.spaceframeModel;
     const weaponNames = this.additionalTalents
       .filter((t) => t.weapon != null && typeof t.weapon === 'string')
       .map((t) => t.weapon);
 
-    let secondary = [];
+    const secondary = [];
     if (spaceframe) {
-      for (var attack of spaceframe.attacks) {
-        for (let weapon of this.version === 1
+      for (const attack of spaceframe.attacks) {
+        for (const weapon of this.version === 1
           ? StarshipWeaponRegistry.list
           : StarshipWeaponRegistry.list2e) {
           if (
@@ -921,8 +925,8 @@ export class Starship extends Construct implements IWeaponDiceProvider {
 
     result.push(...secondary);
 
-    let names = [];
-    let weapons = [];
+    const names = [];
+    const weapons = [];
     result.forEach((w) => {
       if (names.indexOf(w.name) >= 0) {
         // skip it
@@ -936,7 +940,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
   }
 
   get systems() {
-    let result = [0, 0, 0, 0, 0, 0];
+    const result = [0, 0, 0, 0, 0, 0];
 
     allSystems().forEach((system) => {
       let base = this.getBaseSystem(system);
@@ -961,7 +965,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
   }
 
   get departments() {
-    let result = [0, 0, 0, 0, 0, 0];
+    const result = [0, 0, 0, 0, 0, 0];
     if (this.spaceframeModel !== undefined) {
       const frame = this.spaceframeModel;
       const missionPod = this.missionPodModel;
@@ -1028,7 +1032,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
       }
       return dice;
     } else if (this.version === 1) {
-      let security = this.departments[Department.Security];
+      const security = this.departments[Department.Security];
       let dice = weapon.dice + security;
       if (weapon.scaleApplies) {
         dice += this.scale;
@@ -1095,7 +1099,7 @@ export class Starship extends Construct implements IWeaponDiceProvider {
   }
 
   public copy(): Starship {
-    let result = new Starship();
+    const result = new Starship();
     result.version = this.version;
     result.era = this.era;
     result.type = this.type;

--- a/WebTools/src/common/station.ts
+++ b/WebTools/src/common/station.ts
@@ -27,7 +27,7 @@ export class CustomStationSpaceframeStep {
   }
 
   copy() {
-    let result = new CustomStationSpaceframeStep();
+    const result = new CustomStationSpaceframeStep();
     result.scale = this.scale;
     result.appearance = this.appearance;
     result.departments = [...this.departments];
@@ -36,7 +36,7 @@ export class CustomStationSpaceframeStep {
   }
 
   static create(scale: number = CustomStationSpaceframeStep.MIN_SCALE) {
-    let frameStep = new CustomStationSpaceframeStep();
+    const frameStep = new CustomStationSpaceframeStep();
     frameStep.scale = scale;
     frameStep.systems = PointAllocator.allocatePointsEvenly(
       Station.totalAvailableSystemPointsForScale(frameStep.scale),
@@ -112,7 +112,7 @@ export class StationMissionProfileStep {
   }
 
   copy() {
-    let result = new StationMissionProfileStep(this.type);
+    const result = new StationMissionProfileStep(this.type);
     result.talent = this.talent?.copy();
     return result;
   }
@@ -138,7 +138,7 @@ export class Station extends Construct {
     version: number,
     era: Era,
   ): Station {
-    let result = new Station();
+    const result = new Station();
     result.version = version;
     result.era = era;
     result.type = type;
@@ -148,7 +148,7 @@ export class Station extends Construct {
   }
 
   public copy() {
-    let result = new Station();
+    const result = new Station();
     result.type = this.type;
     result.version = this.version;
     result.era = this.era;
@@ -181,7 +181,7 @@ export class Station extends Construct {
       return base;
     } else {
       let base = Math.ceil(this.scale / 2);
-      let structure = this.systems[System.Structure];
+      const structure = this.systems[System.Structure];
       if (this.hasTalent(TALENT_NAME_ABLATIVE_ARMOUR)) {
         base += 2;
       }
@@ -203,7 +203,7 @@ export class Station extends Construct {
   }
 
   get baseTraits(): string[] {
-    let type = CharacterTypeModel.getByType(this.type);
+    const type = CharacterTypeModel.getByType(this.type);
     if (type != null) {
       return [type.name + ' Station'];
     } else {
@@ -229,7 +229,9 @@ export class Station extends Construct {
       if (this.hasTalent('Enhanced Defense Grid')) {
         base += Math.floor(this.scale / 2);
       }
-      let advanced = this.talents.filter((t) => t.name === 'Advanced Shields');
+      const advanced = this.talents.filter(
+        (t) => t.name === 'Advanced Shields',
+      );
       if (advanced.length > 0) {
         base += 5 * advanced.length;
       }
@@ -241,7 +243,7 @@ export class Station extends Construct {
 
   get power() {
     let power = this.systems[System.Engines];
-    let bonus = this.talents.filter((t) => t.name === 'Secondary Reactors');
+    const bonus = this.talents.filter((t) => t.name === 'Secondary Reactors');
     if (power != null && bonus.length > 0) {
       power += 5 * bonus.length;
     }
@@ -289,7 +291,7 @@ export class Station extends Construct {
     if (this.stationFrameStep?.type === StationFrame.Custom) {
       slots -= 1;
     } else {
-      let model = (this.stationFrameStep as StandardStationSpaceframeStep)
+      const model = (this.stationFrameStep as StandardStationSpaceframeStep)
         .model;
       slots -= model.talents.length;
     }
@@ -297,9 +299,9 @@ export class Station extends Construct {
   }
 
   get baseTalents(): SelectedTalent[] {
-    let result = [];
+    const result = [];
     if (this.stationFrameStep instanceof StandardStationSpaceframeStep) {
-      let model = this.stationFrameStep.model;
+      const model = this.stationFrameStep.model;
       model.talents.forEach((t) => {
         if (t instanceof SelectedTalent) {
           result.push(t);
@@ -315,12 +317,12 @@ export class Station extends Construct {
   }
 
   hasBaseTalent(talentName: string) {
-    let talents = this.baseTalents.filter((t) => t.name === talentName);
+    const talents = this.baseTalents.filter((t) => t.name === talentName);
     return talents.length > 0;
   }
 
   hasTalent(talentName: string) {
-    let talents = this.talents.filter((t) => t.name === talentName);
+    const talents = this.talents.filter((t) => t.name === talentName);
     return talents.length > 0;
   }
 
@@ -333,12 +335,12 @@ export class Station extends Construct {
   }
 
   determineWeapons() {
-    let result = [];
+    const result = [];
     if (this.stationFrameStep instanceof StandardStationSpaceframeStep) {
-      let model = this.stationFrameStep.model;
+      const model = this.stationFrameStep.model;
       result.push(...model.weapons);
     }
-    let talentWeapons = this.additionalTalents
+    const talentWeapons = this.additionalTalents
       .filter((t) => t.weapon != null)
       .map((t) => t.weapon);
 
@@ -349,7 +351,7 @@ export class Station extends Construct {
   }
 
   get talents(): SelectedTalent[] {
-    let result = this.baseTalents;
+    const result = this.baseTalents;
     result.push(...this.additionalTalents);
     return result;
   }
@@ -373,12 +375,12 @@ export class Station extends Construct {
   }
 
   get rankedTalents(): SelectedTalent[] {
-    let talents = this.talents;
-    let duplicates = [];
-    let result = [];
+    const talents = this.talents;
+    const duplicates = [];
+    const result = [];
     talents.forEach((t) => {
       if (t.talentModel.maxRank > 1 && !duplicates.includes(t.name)) {
-        let temp = t.copy();
+        const temp = t.copy();
         temp.multiple = this.getRankForTalent(t.name);
         duplicates.push(t.name);
         result.push(temp);
@@ -390,7 +392,7 @@ export class Station extends Construct {
   }
 
   getDistinctTalentNameList() {
-    let result = [];
+    const result = [];
     this.talents.forEach((t) => {
       if (!result.includes(t.name)) {
         result.push(t.name);
@@ -408,7 +410,7 @@ export class Station extends Construct {
       }
       return dice;
     } else if (this.version === 1) {
-      let security = this.departments[Department.Security];
+      const security = this.departments[Department.Security];
       let dice = weapon.dice + security;
       if (weapon.scaleApplies) {
         dice += this.scale;
@@ -449,7 +451,7 @@ export class Station extends Construct {
       let ports = Math.floor(this.scale / 2);
 
       if (this.hasTalent('Docking Capacity')) {
-        let rank = this.getRankForTalent('Docking Capacity');
+        const rank = this.getRankForTalent('Docking Capacity');
         ports = 1 + Math.floor((rank * this.scale) / 2);
       }
 
@@ -464,7 +466,7 @@ export class Station extends Construct {
       let scale = Math.floor(this.scale / 2);
 
       if (this.hasTalent('Docking Capacity')) {
-        let rank = this.getRankForTalent('Docking Capacity');
+        const rank = this.getRankForTalent('Docking Capacity');
         scale += 2 * rank;
       }
 

--- a/WebTools/src/common/translationKey.ts
+++ b/WebTools/src/common/translationKey.ts
@@ -1,5 +1,5 @@
 export const makeKey = (prefix: string, ...keys: string[]) => {
-  let options = keys
+  const options = keys
     .map((key) => {
       let middle = key.substring(0, 1).toLowerCase() + key.substring(1);
       if (key.toLocaleUpperCase() === key) {

--- a/WebTools/src/components/StatView.tsx
+++ b/WebTools/src/components/StatView.tsx
@@ -11,7 +11,7 @@ interface IStatViewProperties {
 
 export class StatView extends React.Component<IStatViewProperties, {}> {
   render() {
-    let value =
+    const value =
       this.props.value || this.props.showZero ? (
         <div
           className={

--- a/WebTools/src/components/allCharacterValues.tsx
+++ b/WebTools/src/components/allCharacterValues.tsx
@@ -16,7 +16,7 @@ import InstructionText from './instructionText';
 
 const AllCharacterValues: React.FC<ICharacterProperties> = ({ character }) => {
   const randomValue = (context: StepContext) => {
-    let value = randomUniqueValue(
+    const value = randomUniqueValue(
       character.values,
       character.speciesStep?.species,
       character.educationStep?.primaryDiscipline,

--- a/WebTools/src/components/characterProfile.tsx
+++ b/WebTools/src/components/characterProfile.tsx
@@ -71,7 +71,7 @@ class CharacterProfile extends React.Component<ICharacterSheetProperties, {}> {
       return <div key={i}>{st.displayName}</div>;
     });
 
-    let equipment = c.equipmentAndImplants.map((e, i) => {
+    const equipment = c.equipmentAndImplants.map((e, i) => {
       if (c.version > 1 && e instanceof Implant) {
         return <div key={i}>{e.localizedName2e}</div>;
       } else {
@@ -91,7 +91,7 @@ class CharacterProfile extends React.Component<ICharacterSheetProperties, {}> {
       }
     }
 
-    let careerEvents = c.careerEvents.map((e, i) => {
+    const careerEvents = c.careerEvents.map((e, i) => {
       return (
         <div key={i}>
           {
@@ -102,7 +102,7 @@ class CharacterProfile extends React.Component<ICharacterSheetProperties, {}> {
       );
     });
 
-    let containerClass = this.props.showProfile
+    const containerClass = this.props.showProfile
       ? 'sheet-container sheet-container-visible pe-3'
       : 'sheet-container sheet-container-hidden pe-3';
     const era = c.era == null ? null : Eras.instance.getEra(c.era);

--- a/WebTools/src/components/characterSheetDialog.tsx
+++ b/WebTools/src/components/characterSheetDialog.tsx
@@ -56,22 +56,22 @@ const _CharacterSheetDialog: React.FC<ICharacterSheetDialogProperties> = ({
   const toggleTag = (tag: SheetTag, active: boolean) => {
     if (active) {
       if (tags.indexOf(tag) < 0) {
-        let newTags = [...tags];
+        const newTags = [...tags];
         newTags.push(tag);
         setTags(newTags);
 
-        let sheets = filteredSheets(newTags);
+        const sheets = filteredSheets(newTags);
         if (sheets.length && sheets.indexOf(selection) < 0) {
           setSelection(sheets[0]);
         }
       }
     } else {
       if (tags.indexOf(tag) >= 0) {
-        let newTags = [...tags];
+        const newTags = [...tags];
         newTags.splice(newTags.indexOf(tag), 1);
         setTags(newTags);
 
-        let sheets = filteredSheets(newTags);
+        const sheets = filteredSheets(newTags);
         if (sheets.length && sheets.indexOf(selection) < 0) {
           setSelection(sheets[0]);
         }
@@ -89,7 +89,7 @@ const _CharacterSheetDialog: React.FC<ICharacterSheetDialogProperties> = ({
     });
   };
 
-  let allTags = [];
+  const allTags = [];
   sheets.forEach((s) =>
     s.getTags().forEach((t) => {
       if (allTags.indexOf(t) < 0) {
@@ -102,7 +102,7 @@ const _CharacterSheetDialog: React.FC<ICharacterSheetDialogProperties> = ({
       t(makeKey('SheetTag.', SheetTag[t2])),
     ),
   );
-  let filtered = filteredSheets(tags);
+  const filtered = filteredSheets(tags);
 
   const sheetList = filtered.map((s, i) => {
     const selected =
@@ -167,8 +167,8 @@ const _CharacterSheetDialog: React.FC<ICharacterSheetDialogProperties> = ({
 
 class CharacterSheetDialogControl {
   show(sheets: ICharacterSheet[], suffix: string, c: Construct) {
-    let browserLanguage = getNavigatorLanguage();
-    let filteredSheets = sheets.filter(
+    const browserLanguage = getNavigatorLanguage();
+    const filteredSheets = sheets.filter(
       (s) =>
         s.getLanguage() === 'en' ||
         browserLanguage.indexOf(s.getLanguage()) === 0,

--- a/WebTools/src/components/educationControllers.ts
+++ b/WebTools/src/components/educationControllers.ts
@@ -172,7 +172,7 @@ export class EducationSecondaryDisciplineController implements IDisciplineContro
     ) {
       return this.character.educationStep?.disciplines.length === 0;
     } else {
-      let need =
+      const need =
         this.track.skillsRule.skills.length - this.countRequiredDisciplines();
       return 2 - this.character.educationStep.disciplines.length > need;
     }

--- a/WebTools/src/components/focusHelper.ts
+++ b/WebTools/src/components/focusHelper.ts
@@ -2,7 +2,7 @@ import i18next from 'i18next';
 import { toCamelCase } from '../common/camelCaseUtil';
 
 export const localizedFocus = (focus: string) => {
-  let key = 'Focus.' + toCamelCase(focus);
-  let result = i18next.t(key);
+  const key = 'Focus.' + toCamelCase(focus);
+  const result = i18next.t(key);
   return key === result ? focus : result;
 };

--- a/WebTools/src/components/focusSelectionView.tsx
+++ b/WebTools/src/components/focusSelectionView.tsx
@@ -38,7 +38,7 @@ export const FocusSelectionView: React.FC<IFocusSelectionProperties> = ({
   const selectRandomFocus = () => {
     let done = false;
     while (!done) {
-      let focus =
+      const focus =
         hints != null
           ? localizedFocus(
               FocusRandomTableWithHints(randomFocusDepartment, hints),

--- a/WebTools/src/components/history.tsx
+++ b/WebTools/src/components/history.tsx
@@ -64,7 +64,7 @@ class History extends React.Component<IHistoryProperties, {}> {
 
   renderCharacterHistory() {
     const { t } = this.props;
-    let character = store.getState().character.currentCharacter as Character;
+    const character = store.getState().character.currentCharacter as Character;
     if (character == null) {
       return <div>{t('Lcars.noHistory')}</div>;
     } else {
@@ -104,7 +104,7 @@ class History extends React.Component<IHistoryProperties, {}> {
   }
 
   renderPageTitleLink(page: PageIdentity) {
-    let { t } = this.props;
+    const { t } = this.props;
     return (
       <div
         className="history-item"
@@ -117,7 +117,7 @@ class History extends React.Component<IHistoryProperties, {}> {
   }
 
   renderSoloCharacterHistory() {
-    let character = store.getState().character.currentCharacter as Character;
+    const character = store.getState().character.currentCharacter as Character;
     return (
       <>
         {character?.speciesStep

--- a/WebTools/src/components/mixedSpeciesSelection.tsx
+++ b/WebTools/src/components/mixedSpeciesSelection.tsx
@@ -36,8 +36,8 @@ const MixedSpeciesSelection: React.FC<ICharacterProperties> = ({
     setSecondarySpecies(species);
 
     if (primarySpecies != null) {
-      let speciesModel = SpeciesHelper.getSpeciesByType(primarySpecies);
-      let attributes = speciesModel.isAttributeSelectionRequired
+      const speciesModel = SpeciesHelper.getSpeciesByType(primarySpecies);
+      const attributes = speciesModel.isAttributeSelectionRequired
         ? undefined
         : speciesModel.attributes;
       store.dispatch(
@@ -56,8 +56,8 @@ const MixedSpeciesSelection: React.FC<ICharacterProperties> = ({
   const assignPrimarySepecies = (species: Species) => {
     setPrimarySpecies(species);
 
-    let speciesModel = SpeciesHelper.getSpeciesByType(species);
-    let attributes = speciesModel.isAttributeSelectionRequired
+    const speciesModel = SpeciesHelper.getSpeciesByType(species);
+    const attributes = speciesModel.isAttributeSelectionRequired
       ? undefined
       : speciesModel.attributes;
     store.dispatch(

--- a/WebTools/src/components/outlineImage.tsx
+++ b/WebTools/src/components/outlineImage.tsx
@@ -21,8 +21,8 @@ const OutlineImage: React.FC<IOutlineImageProperties> = ({
     dimensionY = 260;
   }
 
-  let width = size === 'lg' ? dimensionX * 1.8 : dimensionX;
-  let height = size === 'lg' ? dimensionY * 1.8 : dimensionY;
+  const width = size === 'lg' ? dimensionX * 1.8 : dimensionX;
+  const height = size === 'lg' ? dimensionY * 1.8 : dimensionY;
 
   if (starship) {
     const svg = SpaceframeOutline.renderFullSvg(starship);

--- a/WebTools/src/components/pageHeader.tsx
+++ b/WebTools/src/components/pageHeader.tsx
@@ -8,7 +8,7 @@ interface IPageHeaderProperties extends WithTranslation {
 }
 
 export const getPageTitle = (t, page) => {
-  let key = makeKey('Page.title.', PageIdentity[page]);
+  const key = makeKey('Page.title.', PageIdentity[page]);
 
   if (key !== t(key)) {
     return t(key);

--- a/WebTools/src/components/randomLcarsReadout.tsx
+++ b/WebTools/src/components/randomLcarsReadout.tsx
@@ -11,7 +11,7 @@ export class RandomLcarsReadout extends React.Component<
   {}
 > {
   render() {
-    let value = createRandomValue(5) + '-' + createRandomValue(6);
+    const value = createRandomValue(5) + '-' + createRandomValue(6);
     return (
       <div className="lcar-text" aria-hidden="true">
         {value}

--- a/WebTools/src/components/registryNumberGenerator.tsx
+++ b/WebTools/src/components/registryNumberGenerator.tsx
@@ -77,11 +77,11 @@ class RegistryNumberGenerator {
     let lower = 0;
     let upper = 999999;
 
-    let keys = Object.keys(this.serviceYearRegistryNumbers);
+    const keys = Object.keys(this.serviceYearRegistryNumbers);
     keys.sort();
 
-    for (let key of keys) {
-      let year = parseInt(key);
+    for (const key of keys) {
+      const year = parseInt(key);
       if (serviceYear > year) {
         lower = this.serviceYearRegistryNumbers[key];
       }
@@ -93,7 +93,7 @@ class RegistryNumberGenerator {
 
     let result = null;
     while (result == null) {
-      let temp = Math.floor(Math.random() * (upper - lower)) + lower;
+      const temp = Math.floor(Math.random() * (upper - lower)) + lower;
       if (this.importantRegistryNumbers[temp] == null) {
         result = temp;
       }
@@ -109,9 +109,9 @@ class RegistryNumberGenerator {
   generateRandom(numberOfDigits: number) {
     let result = '';
     while (result.length < numberOfDigits) {
-      let random = Math.floor(Math.random() * 10);
+      const random = Math.floor(Math.random() * 10);
       if (!(random === 0 && result.length === 0)) {
-        let digit = RegistryNumberGenerator.NUMBERS.substring(
+        const digit = RegistryNumberGenerator.NUMBERS.substring(
           random,
           random + 1,
         );

--- a/WebTools/src/components/selectablePill.tsx
+++ b/WebTools/src/components/selectablePill.tsx
@@ -9,7 +9,7 @@ export const SelectablePill: React.FC<ISelectablePillProperties> = ({
   name,
   onClick,
 }) => {
-  let [active, setActive] = useState(false);
+  const [active, setActive] = useState(false);
 
   return (
     <button

--- a/WebTools/src/components/selectedTalentDescriptionView.tsx
+++ b/WebTools/src/components/selectedTalentDescriptionView.tsx
@@ -83,7 +83,7 @@ export const WarriorsSpiritSelectionView: React.FC<
   );
 
   const options = () => {
-    let result = [];
+    const result = [];
     result.push(new DropDownElement('', t('Common.select.choose')));
     result.push(new DropDownElement(SpecialWeapon.BatLeth, "Bat'leth"));
     result.push(new DropDownElement(SpecialWeapon.MekLeth, "Mek'leth"));
@@ -194,7 +194,7 @@ export const WisdomOfYearsSelectionView: React.FC<
         }}
         value={valueSelection ?? ''}
         onRandomClicked={() => {
-          let value = randomValue(character);
+          const value = randomValue(character);
           setValueSelection(value);
           onValueSelection(value);
         }}
@@ -211,7 +211,7 @@ export const AugmentedAbilitySelectionView: React.FC<
     Attribute | undefined
   >(initialSelection);
 
-  let selectedAttributes = character.talents
+  const selectedAttributes = character.talents
     .filter(
       (t) =>
         t.talent === TALENT_NAME_AUGMENTED_ABILITY &&
@@ -282,7 +282,7 @@ export const DefensiveTrainingAttackTypeSelectionView: React.FC<
     AttackType | undefined
   >(initialSelection as AttackType);
   const options = () => {
-    let result = [];
+    const result = [];
     result.push(new DropDownElement('', t('Common.select.choose')));
     result.push(
       new DropDownElement(AttackType.Melee, t('Weapon.common.melee')),
@@ -329,7 +329,7 @@ export const CollaborationDepartmentSelectionView: React.FC<
     Department | undefined
   >(initialSelection);
 
-  let selectedDepartments = character.talents
+  const selectedDepartments = character.talents
     .filter(
       (t) =>
         t.talent === TALENT_NAME_COLLABORATION &&
@@ -374,7 +374,7 @@ export const BoldOrCautiousDepartmentSelectionView: React.FC<
   const [departmentSelection, setDepartmentSelection] = useState<
     Department | undefined
   >(initialSelection);
-  let selectedDepartments = character.talents
+  const selectedDepartments = character.talents
     .filter(
       (t) =>
         [TALENT_NAME_BOLD, TALENT_NAME_CAUTIOUS].includes(t.talent) &&
@@ -420,7 +420,7 @@ export const BorgImplantsSelectionView: React.FC<
           <CheckBox
             isChecked={implantSelections.includes(implant.type)}
             onChanged={(val) => {
-              let temp = [...implantSelections];
+              const temp = [...implantSelections];
               if (temp.includes(implant.type)) {
                 temp.splice(temp.indexOf(implant.type), 1);
               } else {
@@ -472,7 +472,7 @@ export const ExpandedProgramSelectionView: React.FC<
         label={t('Construct.other.focus1')}
         value={selection[0] ?? ''}
         addFocus={(f) => {
-          let temp = [...selection];
+          const temp = [...selection];
           if (temp?.length) {
             temp[0] = f;
           } else {

--- a/WebTools/src/components/simpleSpeciesSelection.tsx
+++ b/WebTools/src/components/simpleSpeciesSelection.tsx
@@ -24,7 +24,7 @@ export class SimpleSpeciesSelection extends React.Component<
   }
 
   render() {
-    var species = this.props.species.map((s, i) => {
+    const species = this.props.species.map((s, i) => {
       const attributes =
         s.id === Species.Ktarian ? (
           <div key={'species-' + s.id}>

--- a/WebTools/src/components/simpleTalentSelectionList.tsx
+++ b/WebTools/src/components/simpleTalentSelectionList.tsx
@@ -58,7 +58,7 @@ const SimpleTalentSelectionList: React.FC<ISimpleTalentSelectionProperties> = ({
   const talentList = talents.map((t, i) => {
     let prerequisites = undefined;
     t.prerequisites.forEach((p) => {
-      let desc = p.describe();
+      const desc = p.describe();
       if (desc) {
         if (prerequisites == null) {
           prerequisites = desc;
@@ -71,11 +71,11 @@ const SimpleTalentSelectionList: React.FC<ISimpleTalentSelectionProperties> = ({
       prerequisites = <div style={{ fontWeight: 'bold' }}>{prerequisites}</div>;
     }
 
-    let description =
+    const description =
       construct.version === 1
         ? (t as TalentModel).localizedDescription
         : (t as TalentModel).localizedDescription2e;
-    let lines = description.split('\n').map((l, i) => {
+    const lines = description.split('\n').map((l, i) => {
       return (
         <div className={i === 0 ? '' : 'mt-2'} key={'d-' + i}>
           {replaceDiceWithArrowhead(l)}

--- a/WebTools/src/components/singleTalentSelectionList.tsx
+++ b/WebTools/src/components/singleTalentSelectionList.tsx
@@ -133,7 +133,7 @@ const XSelectionView: React.FC<IXSelectedTalentChoiceProperties> = ({
   const [x, setX] = useState<number | undefined>(selection.x);
 
   const assignX = (x: number) => {
-    let temp = selection?.copy();
+    const temp = selection?.copy();
     if (temp) {
       temp.x = x;
     }
@@ -172,7 +172,7 @@ export const DepartmentSelectedTalentChoice: React.FC<
       character={construct as Character}
       isChecked={(d) => selection.department === d}
       onSelectDepartment={(d) => {
-        let temp = selection?.copy();
+        const temp = selection?.copy();
         if (temp) {
           temp.department = d;
         }
@@ -182,7 +182,7 @@ export const DepartmentSelectedTalentChoice: React.FC<
         if (d === selection.department) {
           return true;
         } else {
-          let departments = (construct as Character).talents
+          const departments = (construct as Character).talents
             .filter(
               (t) => talentNames?.includes(t.talent) && t.department != null,
             )
@@ -202,7 +202,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
 }) => {
   let prerequisites = undefined;
   talent.talentModel.prerequisites.forEach((p) => {
-    let desc = p.describe();
+    const desc = p.describe();
     if (desc) {
       if (prerequisites == null) {
         prerequisites = desc;
@@ -224,7 +224,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
   };
 
   const specialWeaponOptions = () => {
-    let result = [];
+    const result = [];
     result.push(new DropDownElement('', t('Common.select.choose')));
     result.push(new DropDownElement(SpecialWeapon.BatLeth, "Bat'leth"));
     result.push(new DropDownElement(SpecialWeapon.MekLeth, "Mek'leth"));
@@ -257,7 +257,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
             character={construct as Character}
             isChecked={(a) => selection.department === a}
             onSelectDepartment={(d) => {
-              let temp = selection?.copy();
+              const temp = selection?.copy();
               if (temp) {
                 temp.department = d;
               }
@@ -269,7 +269,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
               } else if (d === selection.department) {
                 return true;
               } else {
-                let departments = (construct as Character).talents
+                const departments = (construct as Character).talents
                   .filter(
                     (t) =>
                       t.talent === TALENT_NAME_IM_A_DOCTOR_NOT_A &&
@@ -293,7 +293,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
             character={construct as Character}
             isChecked={(a) => selection.attribute === a}
             onSelectAttribute={(a) => {
-              let temp = selection?.copy();
+              const temp = selection?.copy();
               if (temp) {
                 temp.attribute = a;
               }
@@ -303,7 +303,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
               if (a === selection.attribute) {
                 return true;
               } else {
-                let attributes = (construct as Character).talents
+                const attributes = (construct as Character).talents
                   .filter(
                     (t) =>
                       t.talent === TALENT_NAME_AUGMENTED_ABILITY &&
@@ -343,7 +343,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
             character={construct as Character}
             isChecked={(a) => selection.attribute === a}
             onSelectAttribute={(a) => {
-              let temp = selection?.copy();
+              const temp = selection?.copy();
               if (temp) {
                 temp.attribute = a;
               }
@@ -379,7 +379,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
             starship={construct as Starship}
             isChecked={(d) => selection.department === d}
             onSelectDepartment={(d) => {
-              let temp = selection?.copy();
+              const temp = selection?.copy();
               if (temp) {
                 temp.department = d;
               }
@@ -400,7 +400,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
             starship={starship}
             isChecked={(d) => selection.department === d}
             onSelectDepartment={(d) => {
-              let temp = selection?.copy();
+              const temp = selection?.copy();
               if (temp) {
                 temp.department = d;
               }
@@ -422,7 +422,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
             starship={starship}
             isChecked={(s) => selection.system === s}
             onSelectSystem={(s) => {
-              let temp = selection?.copy();
+              const temp = selection?.copy();
               if (temp) {
                 temp.system = s;
               }
@@ -444,7 +444,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
               id="customName"
               value={selection.customTalentName}
               onChange={(n) => {
-                let temp = selection?.copy();
+                const temp = selection?.copy();
                 if (temp) {
                   temp.customTalentName = n;
                 }
@@ -459,8 +459,8 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
               value={selection.customTalentDescription}
               placeholder={t('Common.text.description')}
               onChange={(e) => {
-                let description = e.target.value;
-                let temp = selection?.copy();
+                const description = e.target.value;
+                const temp = selection?.copy();
                 if (temp) {
                   temp.customTalentDescription = description;
                 }
@@ -475,7 +475,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
 
   const renderAdditionalPropulsionSystem = () => {
     const getItems = () => {
-      let result = [new DropDownElement('', '')];
+      const result = [new DropDownElement('', '')];
       result.push(
         ...PropulsionSystemModel.types.map(
           (t) => new DropDownElement(t.type, t.localizedName),
@@ -491,7 +491,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
             items={getItems()}
             defaultValue={selection.selection as PropulsionSystemType}
             onChange={(s) => {
-              let temp = selection?.copy();
+              const temp = selection?.copy();
               if (temp) {
                 if (s === '') {
                   temp.selection = undefined;
@@ -522,7 +522,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
     };
 
     const showModal = () => {
-      let starship = construct as Starship;
+      const starship = construct as Starship;
       let mode =
         starship.version === 1
           ? AddWeaponMode.IncludeMines
@@ -539,7 +539,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
           onClose={() => closeModal()}
           version={construct.version}
           addWeapon={(w) => {
-            let temp = selection?.copy();
+            const temp = selection?.copy();
             if (temp) {
               temp.weapon = w;
               onSelection(temp);
@@ -573,7 +573,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
             character={construct as Character}
             isChecked={(d) => selection.department === d}
             onSelectDepartment={(d) => {
-              let temp = selection?.copy();
+              const temp = selection?.copy();
               if (temp) {
                 temp.department = d;
               }
@@ -583,7 +583,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
               if (d === selection.department) {
                 return true;
               } else {
-                let departments = (construct as Character).talents
+                const departments = (construct as Character).talents
                   .filter(
                     (t) =>
                       [TALENT_NAME_BOLD, TALENT_NAME_CAUTIOUS].includes(
@@ -601,7 +601,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
   };
 
   const renderDefensiveTrainingSelection = () => {
-    let options = [];
+    const options = [];
     options.push(new DropDownElement('', t('Common.select.choose')));
     options.push(
       new DropDownElement(AttackType.Melee, t('Weapon.common.melee')),
@@ -614,7 +614,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
         items={options}
         defaultValue={selection?.selection ?? ''}
         onChange={(value) => {
-          let temp = selection?.copy();
+          const temp = selection?.copy();
           if (temp) {
             temp.selection = value as AttackType;
           }
@@ -636,7 +636,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
             <CheckBox
               isChecked={selection.implants.includes(implant.type)}
               onChanged={(val) => {
-                let temp = selection.copy();
+                const temp = selection.copy();
                 if (temp.implants?.includes(implant.type)) {
                   temp.implants.splice(temp.implants.indexOf(implant.type), 1);
                 } else {
@@ -692,7 +692,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
             <FocusSelectionView
               value={selection.focuses[0] ?? ''}
               addFocus={(f) => {
-                let temp = selection?.copy();
+                const temp = selection?.copy();
                 if (temp) {
                   if (temp.focuses?.length) {
                     temp.focuses[0] = f;
@@ -707,19 +707,19 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
             <ValueInput
               value={selection.value ?? ''}
               onValueChanged={(v) => {
-                let temp = selection?.copy();
+                const temp = selection?.copy();
                 if (temp) {
                   temp.value = v;
                 }
                 onSelection(temp);
               }}
               onRandomClicked={() => {
-                let value = randomUniqueValue(
+                const value = randomUniqueValue(
                   (construct as Character).values ?? [],
                   (construct as Character).speciesStep?.species,
                   (construct as Character).educationStep?.primaryDiscipline,
                 );
-                let temp = selection?.copy();
+                const temp = selection?.copy();
                 if (temp) {
                   temp.value = value;
                 }
@@ -741,7 +741,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
               label={t('Construct.other.focus1')}
               value={selection.focuses[0] ?? ''}
               addFocus={(f) => {
-                let temp = selection?.copy();
+                const temp = selection?.copy();
                 if (temp) {
                   if (temp.focuses?.length) {
                     temp.focuses[0] = f;
@@ -757,7 +757,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
               label={t('Construct.other.focus2')}
               value={selection.focuses[1] ?? ''}
               addFocus={(f) => {
-                let temp = selection?.copy();
+                const temp = selection?.copy();
                 if (temp) {
                   if (!temp.focuses?.length) {
                     temp.focuses = ['', f];
@@ -813,7 +813,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
               items={specialWeaponOptions()}
               defaultValue={selection?.selection ?? ''}
               onChange={(value) => {
-                let temp = selection?.copy();
+                const temp = selection?.copy();
                 if (temp) {
                   temp.selection = value as SpecialWeapon;
                 }
@@ -833,7 +833,7 @@ export const TalentSelectionRow: React.FC<ITalentSelectionRowProperties> = ({
                 <FocusSelectionView
                   character={construct as Character}
                   addFocus={(f) => {
-                    let temp = selection?.copy();
+                    const temp = selection?.copy();
                     if (temp) {
                       temp.focuses = [f];
                     }

--- a/WebTools/src/components/speciesAbilityView.tsx
+++ b/WebTools/src/components/speciesAbilityView.tsx
@@ -31,7 +31,7 @@ export const SpeciesAbilityView: React.FC<ISpeciesAbilityProperties> = ({
   const selectRandomFocus = (index: number) => {
     let done = false;
     while (!done) {
-      let focus = localizedFocus(FocusRandomTableWithHints(skill));
+      const focus = localizedFocus(FocusRandomTableWithHints(skill));
       if (character.focuses.indexOf(focus) < 0) {
         done = true;
         store.dispatch(setCharacterSpeciesAbilityFocus(focus, index));

--- a/WebTools/src/components/speciesSelection.tsx
+++ b/WebTools/src/components/speciesSelection.tsx
@@ -49,7 +49,7 @@ const SpeciesSelection: React.FC<ISpeciesSelectionProperties> = ({
   const [mode, setMode] = useState(RandomMode.All);
   const [searchTerm, setSearchTerm] = useState<string>();
 
-  let overrideCheckbox = Character.isSpeciesListLimited(character) ? (
+  const overrideCheckbox = Character.isSpeciesListLimited(character) ? (
     <CheckBox
       isChecked={allowAllSpecies}
       text="Allow any species (GM's decision)"
@@ -63,29 +63,29 @@ const SpeciesSelection: React.FC<ISpeciesSelectionProperties> = ({
     false,
     character,
   );
-  let visibleSpeciesOptions =
+  const visibleSpeciesOptions =
     randomSpecies != null
       ? [SpeciesHelper.getSpeciesByType(randomSpecies)]
       : speciesOptions;
 
   const determineRandomSpecies = (mode: RandomMode): Species => {
     if (mode === RandomMode.Core) {
-      let speciesSelection = SpeciesHelper.generateSpecies();
+      const speciesSelection = SpeciesHelper.generateSpecies();
       return speciesSelection;
     } else if (mode === RandomMode.AlphaQuadrant) {
-      let speciesSelection = SpeciesHelper.generateFromAlphaQuadrantTable();
+      const speciesSelection = SpeciesHelper.generateFromAlphaQuadrantTable();
       return speciesSelection;
     } else if (mode === RandomMode.BetaQuadrant) {
-      let speciesSelection = SpeciesHelper.generateFromBetaQuadrantTable();
+      const speciesSelection = SpeciesHelper.generateFromBetaQuadrantTable();
       return speciesSelection;
     } else if (mode === RandomMode.GammaQuadrant) {
-      let speciesSelection = SpeciesHelper.generateFromGammaQuadrantTable();
+      const speciesSelection = SpeciesHelper.generateFromGammaQuadrantTable();
       return speciesSelection;
     } else if (mode === RandomMode.DeltaQuadrant) {
-      let speciesSelection = SpeciesHelper.generateFromDeltaQuadrantTable();
+      const speciesSelection = SpeciesHelper.generateFromDeltaQuadrantTable();
       return speciesSelection;
     } else {
-      let speciesSelection =
+      const speciesSelection =
         speciesOptions[Math.floor(speciesOptions.length * Math.random())];
       return speciesSelection.id;
     }
@@ -109,7 +109,7 @@ const SpeciesSelection: React.FC<ISpeciesSelectionProperties> = ({
     }
   };
 
-  let species = visibleSpeciesOptions
+  const species = visibleSpeciesOptions
     .filter(
       (s) =>
         searchTerm == null ||
@@ -148,7 +148,7 @@ const SpeciesSelection: React.FC<ISpeciesSelectionProperties> = ({
 
       let speciesAbility = null;
       if (character.version > 1) {
-        let ability = SpeciesAbilityList.instance.getBySpecies(s.id);
+        const ability = SpeciesAbilityList.instance.getBySpecies(s.id);
         if (
           ability != null &&
           (ability.source == null || hasSource(ability.source))

--- a/WebTools/src/components/starshipFreeformTalentSelectionView.tsx
+++ b/WebTools/src/components/starshipFreeformTalentSelectionView.tsx
@@ -76,7 +76,7 @@ export const StarshipFreeformTalentSelectionView: React.FC<
             starship={starship}
             isChecked={(d) => selectedTalent.department === d}
             onSelectDepartment={(d) => {
-              let temp = selectedTalent?.copy();
+              const temp = selectedTalent?.copy();
               if (temp) {
                 temp.department = d;
               }
@@ -94,7 +94,7 @@ export const StarshipFreeformTalentSelectionView: React.FC<
               id="customName"
               value={selectedTalent.customTalentName}
               onChange={(n) => {
-                let temp = selectedTalent?.copy();
+                const temp = selectedTalent?.copy();
                 if (temp) {
                   temp.customTalentName = n;
                 }
@@ -108,8 +108,8 @@ export const StarshipFreeformTalentSelectionView: React.FC<
               value={selectedTalent.customTalentDescription}
               placeholder={t('Common.text.description')}
               onChange={(e) => {
-                let description = e.target.value;
-                let temp = selectedTalent?.copy();
+                const description = e.target.value;
+                const temp = selectedTalent?.copy();
                 if (temp) {
                   temp.customTalentDescription = description;
                 }
@@ -126,7 +126,7 @@ export const StarshipFreeformTalentSelectionView: React.FC<
             starship={starship}
             isChecked={(d) => selectedTalent.department === d}
             onSelectDepartment={(d) => {
-              let temp = selectedTalent?.copy();
+              const temp = selectedTalent?.copy();
               if (temp) {
                 temp.department = d;
               }
@@ -143,7 +143,7 @@ export const StarshipFreeformTalentSelectionView: React.FC<
             starship={starship}
             isChecked={(d) => selectedTalent.system === d}
             onSelectSystem={(s) => {
-              let temp = selectedTalent?.copy();
+              const temp = selectedTalent?.copy();
               if (temp) {
                 temp.system = s;
               }
@@ -156,7 +156,7 @@ export const StarshipFreeformTalentSelectionView: React.FC<
       selectedTalent?.name === TALENT_NAME_ADDITIONAL_PROPULSION_SYSTEM
     ) {
       const getItems = () => {
-        let result = [new DropDownElement('', '')];
+        const result = [new DropDownElement('', '')];
         result.push(
           ...PropulsionSystemModel.types.map(
             (t) => new DropDownElement(t.type, t.localizedName),
@@ -171,7 +171,7 @@ export const StarshipFreeformTalentSelectionView: React.FC<
             items={getItems()}
             defaultValue={selectedTalent.selection as PropulsionSystemType}
             onChange={(s) => {
-              let temp = selectedTalent?.copy();
+              const temp = selectedTalent?.copy();
               if (temp) {
                 if (s === '') {
                   temp.selection = undefined;
@@ -219,7 +219,7 @@ export const StarshipFreeformTalentSelectionView: React.FC<
             onClose={() => closeModal()}
             version={starship.version}
             addWeapon={(w) => {
-              let temp = selectedTalent?.copy();
+              const temp = selectedTalent?.copy();
               if (temp) {
                 temp.weapon = w;
                 setSelectedTalent(temp);

--- a/WebTools/src/components/starshipProfile.tsx
+++ b/WebTools/src/components/starshipProfile.tsx
@@ -23,8 +23,8 @@ const StarshipProfile: React.FC<IStarshipProfileProperties> = ({
   close,
 }) => {
   const { t } = useTranslation();
-  let starship = store.getState().starship?.starship as Starship;
-  let containerClass = showProfile
+  const starship = store.getState().starship?.starship as Starship;
+  const containerClass = showProfile
     ? 'sheet-container sheet-container-visible pe-3'
     : 'sheet-container sheet-container-hidden pe-3';
   const eraModel = era != null ? Eras.instance.getEra(era) : null;
@@ -32,7 +32,7 @@ const StarshipProfile: React.FC<IStarshipProfileProperties> = ({
   const talents = starship?.talents
     .filter((t) => !t.talentModel.isSpecialRule(starship.version))
     .map((t, i) => {
-      let name =
+      const name =
         starship?.stereotype === Stereotype.SoloStarship
           ? t.talentModel.localizedNameForSource(Source.CaptainsLog)
           : t.displayName;
@@ -42,7 +42,7 @@ const StarshipProfile: React.FC<IStarshipProfileProperties> = ({
   const specialRules = starship?.talents
     .filter((t) => t.talentModel.isSpecialRule(starship.version))
     .map((t, i) => {
-      let name =
+      const name =
         starship?.stereotype === Stereotype.SoloStarship
           ? t.talentModel.localizedNameForSource(Source.CaptainsLog)
           : t.displayName;

--- a/WebTools/src/components/valueInputWithRandomOption.tsx
+++ b/WebTools/src/components/valueInputWithRandomOption.tsx
@@ -23,7 +23,7 @@ const ValueInputWithRandom: React.FC<IValueInputWithRandom> = ({
   labelName,
 }) => {
   const randomValue = () => {
-    let value = randomUniqueValue(
+    const value = randomUniqueValue(
       character.values,
       character.speciesStep?.species,
       department,

--- a/WebTools/src/components/weaponView.tsx
+++ b/WebTools/src/components/weaponView.tsx
@@ -16,7 +16,7 @@ const WeaponView: React.FC<IWeaponViewProperties> = ({
   const { t } = useTranslation();
 
   const renderInjuryAndDetails = () => {
-    let result =
+    const result =
       version > 1
         ? weapon.injuryTypeEffectsAndQualities
         : weapon.effectsAndQualitiesAsString;

--- a/WebTools/src/creature/model/creature.ts
+++ b/WebTools/src/creature/model/creature.ts
@@ -150,7 +150,7 @@ export class Creature extends Construct {
   }
 
   getAllTraits() {
-    let result = [...this.additionalTraits];
+    const result = [...this.additionalTraits];
     if (this.creatureType?.id === CreatureType.Plant) {
       result.push('Flora');
     } else {

--- a/WebTools/src/creature/model/creatureGenerator.ts
+++ b/WebTools/src/creature/model/creatureGenerator.ts
@@ -56,10 +56,10 @@ export const CreatureGenerator = async (
   }
   result.creatureType = CreatureTypeHelper.instance.getTypeById(creatureType);
 
-  let diet = createRandomDiet();
+  const diet = createRandomDiet();
   result.diet = DietTypeHelper.instance.getTypeById(diet);
 
-  let size = generateRandomCreatureSize();
+  const size = generateRandomCreatureSize();
   result.size = CreatureSizeHelper.instance.getTypeById(size);
 
   result.naturalAttacks = generateRandomNaturalAttacks(diet);
@@ -70,16 +70,16 @@ export const CreatureGenerator = async (
     result.additionalTalents.push(new SelectedTalent(TALENT_NAME_FLIGHT));
   }
   if (result.size?.id === CreatureSize.Swarm) {
-    let selectedTalent = new SelectedTalent(TALENT_NAME_SWARM_X);
+    const selectedTalent = new SelectedTalent(TALENT_NAME_SWARM_X);
     selectedTalent.x = determineXIfNecessary(selectedTalent.talentModel);
     result.additionalTalents.push(selectedTalent);
   }
 
-  let skillImprovements = 3;
-  let skills = [Department.Security, Department.Security, Department.Command];
+  const skillImprovements = 3;
+  const skills = [Department.Security, Department.Security, Department.Command];
   for (let i = 0; i < skillImprovements; i++) {
-    let index = Math.floor(Math.random() * skills.length);
-    let skill = skills[index];
+    const index = Math.floor(Math.random() * skills.length);
+    const skill = skills[index];
 
     result.departments[skill] += 1;
   }
@@ -88,8 +88,8 @@ export const CreatureGenerator = async (
     result.departments[Department.Security] += 1;
   }
 
-  let attributeImprovementBySize = [26, 26, 28, 28, 30, 32];
-  let attributeImprovement = attributeImprovementBySize[result.size.id];
+  const attributeImprovementBySize = [26, 26, 28, 28, 30, 32];
+  const attributeImprovement = attributeImprovementBySize[result.size.id];
   let attributes = [
     Attribute.Control,
     Attribute.Control,
@@ -109,8 +109,8 @@ export const CreatureGenerator = async (
     Attribute.Reason,
   ];
   for (let i = 0; i < attributeImprovement; i++) {
-    let index = Math.floor(Math.random() * attributes.length);
-    let attribute = attributes[index];
+    const index = Math.floor(Math.random() * attributes.length);
+    const attribute = attributes[index];
 
     result.attributes[attribute] += 1;
     if (result.attributes[attribute] >= 11) {
@@ -169,7 +169,7 @@ const addAllTalentSelection = (
 };
 
 const generateCreatureDescription = async (creature: Creature) => {
-  let data = {
+  const data = {
     type: CreatureType[creature.creatureType.id],
     name: creature.name,
     habitat:
@@ -180,11 +180,11 @@ const generateCreatureDescription = async (creature: Creature) => {
     locomotion: creature.locomotion.map((l) => l.description),
   };
 
-  let textEncoder = new TextEncoder();
-  let body = textEncoder.encode(JSON.stringify(data));
+  const textEncoder = new TextEncoder();
+  const body = textEncoder.encode(JSON.stringify(data));
 
   try {
-    let response = await fetch('/api/creature_description', {
+    const response = await fetch('/api/creature_description', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -193,7 +193,7 @@ const generateCreatureDescription = async (creature: Creature) => {
     });
 
     if (response.status === 200) {
-      let responseJson = await response.json();
+      const responseJson = await response.json();
 
       return responseJson?.description;
     } else {

--- a/WebTools/src/creature/model/creatureSize.ts
+++ b/WebTools/src/creature/model/creatureSize.ts
@@ -47,12 +47,12 @@ export class CreatureSizeHelper {
   }
 
   getTypeById(id: CreatureSize) {
-    let items = this.items.filter((h) => h.id === id);
+    const items = this.items.filter((h) => h.id === id);
     return items?.length ? items[0] : undefined;
   }
 
   getTypeByIdName(name: string) {
-    let items = this.items.filter((h) => CreatureSize[h.id] === name);
+    const items = this.items.filter((h) => CreatureSize[h.id] === name);
     return items?.length ? items[0] : undefined;
   }
 }

--- a/WebTools/src/creature/model/creatureTalents.ts
+++ b/WebTools/src/creature/model/creatureTalents.ts
@@ -655,7 +655,7 @@ const appendWithNoDuplicates = (
   array1: SelectedTalent[],
   array2: SelectedTalent[],
 ) => {
-  let result = [...array1];
+  const result = [...array1];
 
   array2.forEach((t) => {
     if (result.filter((i) => i.talent === t.talent).length) {

--- a/WebTools/src/creature/model/creatureType.ts
+++ b/WebTools/src/creature/model/creatureType.ts
@@ -52,12 +52,12 @@ export class CreatureTypeHelper {
   }
 
   getTypeById(id: CreatureType) {
-    let items = this.items.filter((h) => h.id === id);
+    const items = this.items.filter((h) => h.id === id);
     return items?.length ? items[0] : undefined;
   }
 
   getTypeByIdName(name: string) {
-    let items = this.items.filter((h) => CreatureType[h.id] === name);
+    const items = this.items.filter((h) => CreatureType[h.id] === name);
     return items?.length ? items[0] : undefined;
   }
 }

--- a/WebTools/src/creature/model/diet.ts
+++ b/WebTools/src/creature/model/diet.ts
@@ -47,12 +47,12 @@ export class DietTypeHelper {
   }
 
   getTypeById(id: DietType) {
-    let items = this.items.filter((h) => h.id === id);
+    const items = this.items.filter((h) => h.id === id);
     return items?.length ? items[0] : undefined;
   }
 
   getTypeByIdName(name: string) {
-    let items = this.items.filter((h) => DietType[h.id] === name);
+    const items = this.items.filter((h) => DietType[h.id] === name);
     return items?.length ? items[0] : undefined;
   }
 }

--- a/WebTools/src/creature/model/habitat.ts
+++ b/WebTools/src/creature/model/habitat.ts
@@ -59,12 +59,12 @@ export class HabitatHelper {
   }
 
   getTypeById(id: Habitat) {
-    let items = this.items.filter((h) => h.id === id);
+    const items = this.items.filter((h) => h.id === id);
     return items?.length ? items[0] : undefined;
   }
 
   getTypeByIdName(name: string) {
-    let items = this.items.filter((h) => Habitat[h.id] === name);
+    const items = this.items.filter((h) => Habitat[h.id] === name);
     return items?.length ? items[0] : undefined;
   }
 }

--- a/WebTools/src/creature/model/locomotion.ts
+++ b/WebTools/src/creature/model/locomotion.ts
@@ -67,12 +67,12 @@ export class LocomotionTypeHelper {
   }
 
   getTypeById(id: LocomotionType) {
-    let items = this.items.filter((h) => h.id === id);
+    const items = this.items.filter((h) => h.id === id);
     return items?.length ? items[0] : undefined;
   }
 
   getTypeByIdName(name: string) {
-    let items = this.items.filter((h) => LocomotionType[h.id] === name);
+    const items = this.items.filter((h) => LocomotionType[h.id] === name);
     return items?.length ? items[0] : undefined;
   }
 }

--- a/WebTools/src/creature/model/naturalAttacks.ts
+++ b/WebTools/src/creature/model/naturalAttacks.ts
@@ -176,7 +176,9 @@ export class NaturalAttacksHelper {
   }
 
   getTypeByIdName(name: string) {
-    let item = this.allAttackTypes().filter((a) => NaturalAttacks[a] === name);
+    const item = this.allAttackTypes().filter(
+      (a) => NaturalAttacks[a] === name,
+    );
     return item?.length ? item[0] : undefined;
   }
 }

--- a/WebTools/src/creature/page/randomCreatureConfigurationPage.tsx
+++ b/WebTools/src/creature/page/randomCreatureConfigurationPage.tsx
@@ -38,7 +38,7 @@ const RandomCreatureConfigurationPage: React.FC<
   const [includeDescription, setIncludeDescription] = useState<boolean>(true);
 
   useEffect(() => {
-    let value = window.localStorage.getItem('settings.ai');
+    const value = window.localStorage.getItem('settings.ai');
     setIncludeDescription(value !== 'false');
   }, []);
 
@@ -48,7 +48,7 @@ const RandomCreatureConfigurationPage: React.FC<
   };
 
   const getHabitatTypes = () => {
-    let result = [
+    const result = [
       new DropDownElement('', t('RandomCreatureConfiguration.anyHabitat')),
     ];
     result.push(
@@ -65,7 +65,7 @@ const RandomCreatureConfigurationPage: React.FC<
   };
 
   const getCreatureTypes = () => {
-    let result = [
+    const result = [
       new DropDownElement('', t('RandomCreatureConfiguration.anyCreatureType')),
     ];
     result.push(
@@ -78,7 +78,7 @@ const RandomCreatureConfigurationPage: React.FC<
 
   const createCreature = async () => {
     setLoading(true);
-    let creature = await CreatureGenerator(
+    const creature = await CreatureGenerator(
       era,
       habitat,
       creatureType,

--- a/WebTools/src/exportpdf/baseFormFillingSheet.ts
+++ b/WebTools/src/exportpdf/baseFormFillingSheet.ts
@@ -20,7 +20,7 @@ export abstract class BaseFormFillingSheet extends BasicGeneratedSheet {
 
   async populate(pdf: PDFDocument, construct: Construct) {
     await super.populate(pdf, construct);
-    let character = construct as Character;
+    const character = construct as Character;
 
     this.populateForm(pdf.getForm(), character);
   }
@@ -61,7 +61,7 @@ export abstract class BaseFormFillingSheet extends BasicGeneratedSheet {
     this.fillWeapons(form, character);
 
     if (character.hasCareerEvents) {
-      let event1 = CareerEventsHelper.getCareerEvent(
+      const event1 = CareerEventsHelper.getCareerEvent(
         character.careerEvents[0]?.id,
         character.type,
         character.version,
@@ -71,7 +71,7 @@ export abstract class BaseFormFillingSheet extends BasicGeneratedSheet {
       }
 
       if (character.careerEvents && character.careerEvents.length > 1) {
-        let event2 = CareerEventsHelper.getCareerEvent(
+        const event2 = CareerEventsHelper.getCareerEvent(
           character.careerEvents[1]?.id,
           character.type,
           character.version,
@@ -114,7 +114,7 @@ export abstract class BaseFormFillingSheet extends BasicGeneratedSheet {
   }
 
   fillSkills(form: PDFForm, character: Character) {
-    let departments = character.departments;
+    const departments = character.departments;
     DepartmentsHelper.instance.getDepartments().forEach((d, i) => {
       this.fillField(form, Department[d], '' + departments[d]);
     });
@@ -241,12 +241,12 @@ export abstract class BaseFormFillingSheet extends BasicGeneratedSheet {
     minFontSize: number = 8,
   ) {
     Object.keys(this.statLocations).forEach((key) => {
-      let block = this.statLocations[key];
+      const block = this.statLocations[key];
       if (key === 'Construct.other.protection' && character.version === 1) {
         key = 'Construct.other.resistance';
       }
       const originalText = i18next.t(key).toLocaleUpperCase();
-      let text = originalText;
+      const text = originalText;
       let width = this.headingFont.widthOfTextAtSize(text, fontSize);
       while (width > block.width) {
         fontSize -= 0.25;
@@ -258,7 +258,7 @@ export abstract class BaseFormFillingSheet extends BasicGeneratedSheet {
     });
 
     Object.keys(this.statLocations).forEach((key) => {
-      let block = this.statLocations[key];
+      const block = this.statLocations[key];
       if (key === 'Construct.other.protection' && character.version === 1) {
         key = 'Construct.other.resistance';
       }
@@ -274,10 +274,10 @@ export abstract class BaseFormFillingSheet extends BasicGeneratedSheet {
         text += '...';
       }
 
-      let height = this.headingFont.heightAtSize(fontSize, {
+      const height = this.headingFont.heightAtSize(fontSize, {
         descender: false,
       });
-      let offset = Math.max(0, block.height - height) / 2;
+      const offset = Math.max(0, block.height - height) / 2;
 
       let x = block.start.x;
       if (textAlign === TextAlign.Right) {

--- a/WebTools/src/exportpdf/baseTngGeneratedCharacterSheet.ts
+++ b/WebTools/src/exportpdf/baseTngGeneratedCharacterSheet.ts
@@ -92,7 +92,7 @@ export abstract class BaseTNGGeneratedCharacterSheet extends BaseFormFillingShee
   async populate(pdf: PDFDocument, construct: Construct) {
     await super.populate(pdf, construct);
 
-    let character = construct as Character;
+    const character = construct as Character;
 
     const page = pdf.getPage(0);
 
@@ -107,9 +107,9 @@ export abstract class BaseTNGGeneratedCharacterSheet extends BaseFormFillingShee
   }
 
   createDeterminationCheckmarks(pdf: PDFDocument, page: PDFPage) {
-    let form = pdf.getForm();
+    const form = pdf.getForm();
     this.determinationPills.forEach((block, i) => {
-      let checkbox = form.createCheckBox('Determination ' + (i + 1));
+      const checkbox = form.createCheckBox('Determination ' + (i + 1));
       checkbox.addToPage(page, {
         x: block.start.x + 4,
         y: page.getHeight() - block.start.y - (block.height - 1),
@@ -153,8 +153,10 @@ export abstract class BaseTNGGeneratedCharacterSheet extends BaseFormFillingShee
 
     text += suffix;
 
-    let height = this.headingFont.heightAtSize(fontSize, { descender: false });
-    let offset = Math.max(0, block.height - height) / 2;
+    const height = this.headingFont.heightAtSize(fontSize, {
+      descender: false,
+    });
+    const offset = Math.max(0, block.height - height) / 2;
 
     page.drawText(text, {
       x: rightJustify ? block.end.x - width - 2 : block.start.x,
@@ -170,11 +172,11 @@ export abstract class BaseTNGGeneratedCharacterSheet extends BaseFormFillingShee
     construct: Construct,
     colour: SimpleColor = BaseTNGGeneratedCharacterSheet.darkPurpleColour,
   ) {
-    let minWidth = Math.min.apply(
+    const minWidth = Math.min.apply(
       Math,
       Object.keys(this.detailLabels).map((key) => this.detailLabels[key].width),
     );
-    let fontSize = this.determineIdealFontWidth(
+    const fontSize = this.determineIdealFontWidth(
       Object.keys(this.detailLabels).map((key) =>
         i18next.t(key).toLocaleUpperCase(),
       ),
@@ -211,8 +213,8 @@ export abstract class BaseTNGGeneratedCharacterSheet extends BaseFormFillingShee
     character: Character,
     colour: SimpleColor = BaseTNGGeneratedCharacterSheet.purpleColour,
   ) {
-    let form = pdf.getForm();
-    let { height, width } = this.pillSize;
+    const form = pdf.getForm();
+    const { height, width } = this.pillSize;
     let amount = character.stress;
 
     if (character.stereotype === Stereotype.Npc && character.version !== 1) {
@@ -228,7 +230,7 @@ export abstract class BaseTNGGeneratedCharacterSheet extends BaseFormFillingShee
           borderWidth: 1,
         });
       } else {
-        let checkbox = form.createCheckBox('Stress ' + (i + 1));
+        const checkbox = form.createCheckBox('Stress ' + (i + 1));
         checkbox.addToPage(page, {
           x: pill.x + (width - 9.5) / 2,
           y: page.getHeight() - pill.y - (height - 0.6),
@@ -247,7 +249,7 @@ export abstract class BaseTNGGeneratedCharacterSheet extends BaseFormFillingShee
     const table = this.subTitleLocations;
     Object.keys(table).forEach((key) => {
       let fontSize = originalFontSize;
-      let block = table[key];
+      const block = table[key];
       if (key === 'departments' && character.version === 1) {
         key = 'disciplines';
       } else if (key === 'talents' && character.stereotype === Stereotype.Npc) {
@@ -263,7 +265,7 @@ export abstract class BaseTNGGeneratedCharacterSheet extends BaseFormFillingShee
       const originalText = i18next
         .t('Construct.other.' + key)
         .toLocaleUpperCase();
-      let text = originalText;
+      const text = originalText;
       let width = this.headingFont.widthOfTextAtSize(text, fontSize);
       while (width > block.width) {
         fontSize -= 0.25;

--- a/WebTools/src/exportpdf/bullet2eWriter.ts
+++ b/WebTools/src/exportpdf/bullet2eWriter.ts
@@ -10,8 +10,11 @@ export const bullet2EWriter = (
   paragraph: Paragraph,
   colour: SimpleColor = SimpleColor.from('#000000'),
 ) => {
-  let column = paragraph.startColumn;
-  let location = column.untranslateLocation(page, paragraph.lines[0].location);
+  const column = paragraph.startColumn;
+  const location = column.untranslateLocation(
+    page,
+    paragraph.lines[0].location,
+  );
 
   page.moveTo(column.start.x, page.getHeight() - (location.y + 3));
   page.drawSvgPath(bulletPath, {

--- a/WebTools/src/exportpdf/checkMarkMaker.ts
+++ b/WebTools/src/exportpdf/checkMarkMaker.ts
@@ -20,7 +20,7 @@ export class CheckMarkMaker {
     colour: SimpleColor,
   ) {
     pills.forEach((column) => {
-      let x = column.translatedStart(this.page).x;
+      const x = column.translatedStart(this.page).x;
       const y = column.translatedStart(this.page).y;
 
       this.page.moveTo(x, y);
@@ -34,9 +34,9 @@ export class CheckMarkMaker {
   }
 
   createCheckMarks(pills: Column[], prefix: string = 'Determination ') {
-    let form = this.pdf.getForm();
+    const form = this.pdf.getForm();
     pills.forEach((block, i) => {
-      let checkbox = form.createCheckBox(prefix + (i + 1));
+      const checkbox = form.createCheckBox(prefix + (i + 1));
       checkbox.addToPage(this.page, {
         x: block.start.x + 2,
         y: this.page.getHeight() - block.start.y - (block.height - 1),

--- a/WebTools/src/exportpdf/column.ts
+++ b/WebTools/src/exportpdf/column.ts
@@ -44,7 +44,7 @@ export class Column {
   }
 
   contains(point: XYLocation, page: PDFPage) {
-    let untranslatedPoint = this.untranslateLocation(page, point);
+    const untranslatedPoint = this.untranslateLocation(page, point);
     return (
       this.round(untranslatedPoint.x) >= this.start.x &&
       this.round(untranslatedPoint.x) <= this.start.x + this.width &&
@@ -53,14 +53,14 @@ export class Column {
     );
   }
   translatedStart(page: PDFPage) {
-    let x = this.start.x;
-    let y = page.getSize().height - this.start.y;
+    const x = this.start.x;
+    const y = page.getSize().height - this.start.y;
     return new XYLocation(x, y);
   }
 
   untranslateLocation(page: PDFPage, location: XYLocation) {
-    let x = location.x;
-    let y = page.getSize().height - location.y;
+    const x = location.x;
+    const y = page.getSize().height - location.y;
     return new XYLocation(x, y);
   }
 

--- a/WebTools/src/exportpdf/fontLibrary.ts
+++ b/WebTools/src/exportpdf/fontLibrary.ts
@@ -15,7 +15,7 @@ export class FontLibrary {
   }
 
   fontByType(type: FontType) {
-    let result = this.fonts[type];
+    const result = this.fonts[type];
     if (result == null) {
       console.log('Cannot find ' + FontType[type]);
       console.log(Object.keys(this.fonts));

--- a/WebTools/src/exportpdf/generated2eBaseSheet.ts
+++ b/WebTools/src/exportpdf/generated2eBaseSheet.ts
@@ -89,13 +89,13 @@ export abstract class BaseNonForm2eSheet extends BasicGeneratedSheet {
       textBlock = TextBlock.create(text, font, false);
     }
 
-    let y = column.end.y - 1 - (column.height - textBlock.height) / 2;
-    let x = column.start.x + (column.width - textBlock.width);
+    const y = column.end.y - 1 - (column.height - textBlock.height) / 2;
+    const x = column.start.x + (column.width - textBlock.width);
     textBlock.writeToPage(x, page.getHeight() - y, page, colour);
   }
 
   determineAllStatLabels(construct: Construct) {
-    let text = [];
+    const text = [];
     if (construct instanceof Character) {
       DepartmentsHelper.instance
         .getDepartments()
@@ -123,7 +123,7 @@ export abstract class BaseNonForm2eSheet extends BasicGeneratedSheet {
     for (let i = 8.5; i >= 5.5; i -= 0.25) {
       let ok = true;
       for (const t of text) {
-        let block = TextBlock.create(
+        const block = TextBlock.create(
           t,
           new FontSpecification(this.boldFont, i),
         );
@@ -151,8 +151,8 @@ export abstract class BaseNonForm2eSheet extends BasicGeneratedSheet {
     let lead = (block.width - textBlock.width) / 2;
     lead = Math.min(12, lead - 4);
 
-    let x = block.start.x + lead + 4;
-    let y = block.end.y - 1 - (block.height - textBlock.height) / 2;
+    const x = block.start.x + lead + 4;
+    const y = block.end.y - 1 - (block.height - textBlock.height) / 2;
     textBlock.writeToPage(
       x,
       page.getHeight() - y,
@@ -173,7 +173,7 @@ export abstract class BaseNonForm2eSheet extends BasicGeneratedSheet {
       color: BaseNonForm2eSheet.greyColour.asPdfRbg(),
     });
 
-    let end = block.start.x + lead + 4 + textBlock.width + 4;
+    const end = block.start.x + lead + 4 + textBlock.width + 4;
     if (end < block.end.x) {
       page.drawLine({
         start: { x: end, y: page.getHeight() - (y + 3 - block.height / 2) },
@@ -197,8 +197,8 @@ export abstract class BaseNonForm2eSheet extends BasicGeneratedSheet {
     column: Column,
     colour: SimpleColor = tealColour2e,
   ) {
-    let bold = new FontOptions(9, FontType.Bold);
-    let standard = new FontOptions(9);
+    const bold = new FontOptions(9, FontType.Bold);
+    const standard = new FontOptions(9);
     let paragraph = null;
     let bottom = column.start;
 

--- a/WebTools/src/exportpdf/generated2eHalfPageSheet.ts
+++ b/WebTools/src/exportpdf/generated2eHalfPageSheet.ts
@@ -47,12 +47,12 @@ export class BasicGeneratedHalfPageCharacterSheet extends BaseNonForm2eSheet {
   async populate(pdf: PDFDocument, construct: Construct) {
     await super.populate(pdf, construct);
 
-    let character = construct as Character;
+    const character = construct as Character;
 
     const page = pdf.getPage(0);
     this.writeCharacterName(page, character);
 
-    let bottom = this.writeCharacterDetails(page, character);
+    const bottom = this.writeCharacterDetails(page, character);
 
     let remainingColumn = this.mainBlock.bottomAfter(
       bottom.y - this.mainBlock.start.y + 16,
@@ -119,7 +119,7 @@ export class BasicGeneratedHalfPageCharacterSheet extends BaseNonForm2eSheet {
       'M 2.835,0 C 1.269,0 0,1.269 0,2.835 V 9 c 0,1.565 1.269,2.835 2.835,2.835 h 66.567 c 1.565,0 2.835,-1.27 2.835,-2.835 V 2.835 C 72.237,1.269 70.967,0 69.402,0 Z';
 
     const rowHeight = 16;
-    let labels = {};
+    const labels = {};
     [
       Attribute.Control,
       Attribute.Fitness,
@@ -128,11 +128,11 @@ export class BasicGeneratedHalfPageCharacterSheet extends BaseNonForm2eSheet {
       Attribute.Insight,
       Attribute.Reason,
     ].forEach((a, i) => {
-      let location = new XYLocation(
+      const location = new XYLocation(
         boxes.x + (i % 3) * 81,
         boxes.y + Math.floor(i / 3) * rowHeight,
       );
-      let x = location.x;
+      const x = location.x;
       const y = page.getHeight() - location.y;
       page.moveTo(x, y);
       page.drawSvgPath(statFrame, {
@@ -140,7 +140,7 @@ export class BasicGeneratedHalfPageCharacterSheet extends BaseNonForm2eSheet {
         borderWidth: 0.5,
       });
 
-      let labelColumn = new Column(x + 2, location.y, 11.8, 72.2 * 0.8);
+      const labelColumn = new Column(x + 2, location.y, 11.8, 72.2 * 0.8);
       const key = i18next.t(makeKey('Construct.attribute.', Attribute[a]));
       labels[key] = labelColumn;
 
@@ -178,11 +178,11 @@ export class BasicGeneratedHalfPageCharacterSheet extends BaseNonForm2eSheet {
       Department.Security,
       Department.Science,
     ].forEach((s, i) => {
-      let location = new XYLocation(
+      const location = new XYLocation(
         boxes.x + (i % 3) * 81,
         boxes.y + Math.floor(i / 3) * rowHeight,
       );
-      let x = location.x;
+      const x = location.x;
       const y = page.getHeight() - location.y;
       page.moveTo(x, y);
       page.drawSvgPath(statFrame, {
@@ -190,7 +190,7 @@ export class BasicGeneratedHalfPageCharacterSheet extends BaseNonForm2eSheet {
         borderWidth: 0.5,
       });
 
-      let labelColumn = new Column(x + 2, location.y, 11.8, 72.2 * 0.8);
+      const labelColumn = new Column(x + 2, location.y, 11.8, 72.2 * 0.8);
       const key = makeKey('Construct.discipline.', Department[s]);
       labels[key] = labelColumn;
 
@@ -224,7 +224,7 @@ export class BasicGeneratedHalfPageCharacterSheet extends BaseNonForm2eSheet {
     character: Character,
     column: Column,
   ) {
-    let stressBox =
+    const stressBox =
       'm 1,0 h 7.5 c 0.554,0 1,0.446 1,1 v 7.5 c 0,0.554 -0.446,1 -1,1 H 1 C 0.446,9.5 0,9.054 0,8.5 V 1 C 0,0.446 0.446,0 1,0 Z';
 
     let x = column.translatedStart(page).x;
@@ -236,7 +236,7 @@ export class BasicGeneratedHalfPageCharacterSheet extends BaseNonForm2eSheet {
         borderWidth: 0.5,
       });
 
-      let checkbox = form.createCheckBox('Stress ' + (i + 1));
+      const checkbox = form.createCheckBox('Stress ' + (i + 1));
       checkbox.addToPage(page, {
         x: x + 0.5,
         y: y - 9,
@@ -339,7 +339,7 @@ export class BasicGeneratedHalfPageCharacterSheet extends BaseNonForm2eSheet {
   }
 
   writeSpeciesAbility(page: PDFPage, character: Character, column: Column) {
-    let items = assembleWritableItems(character);
+    const items = assembleWritableItems(character);
 
     if (character.version > 1 && items.length > 0) {
       if (items.length === 1 && items[0] instanceof SpeciesAbility) {
@@ -349,7 +349,7 @@ export class BasicGeneratedHalfPageCharacterSheet extends BaseNonForm2eSheet {
           column.topBefore(13),
         );
         column = column.bottomAfter(16);
-        let paragraph = new Paragraph(page, column, this.fonts);
+        const paragraph = new Paragraph(page, column, this.fonts);
         paragraph.append(
           character.speciesStep.ability.name + ': ',
           new FontOptions(9, FontType.Bold),
@@ -380,7 +380,7 @@ export class BasicGeneratedHalfPageCharacterSheet extends BaseNonForm2eSheet {
   writeCharacterName(page: PDFPage, character: Character) {
     if (character.name?.length) {
       let name = character.name;
-      let rank = character.rank?.localizedAbbreviation;
+      const rank = character.rank?.localizedAbbreviation;
       if (rank) {
         name = rank + ' ' + name;
       }

--- a/WebTools/src/exportpdf/generated2eStarshipSheet.ts
+++ b/WebTools/src/exportpdf/generated2eStarshipSheet.ts
@@ -104,7 +104,7 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
     previousParagraph: Paragraph,
     colour: SimpleColor,
   ) {
-    let resistanceParagraph = previousParagraph.nextParagraph(1);
+    const resistanceParagraph = previousParagraph.nextParagraph(1);
     resistanceParagraph.append(
       i18next.t('Construct.other.resistance').toLocaleUpperCase() + ': ',
       new FontSpecification(this.boldFont, 9),
@@ -126,7 +126,7 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
       new FontSpecification(this.textFont, 9),
     );
 
-    let crewParagraph = previousParagraph.nextParagraph(1);
+    const crewParagraph = previousParagraph.nextParagraph(1);
     crewParagraph.append(
       i18next.t('Construct.other.crewSupport').toLocaleUpperCase() + ': ',
       new FontSpecification(this.boldFont, 9),
@@ -147,15 +147,16 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
         30 <
         previousParagraph.column.width
     ) {
-      let availableMiddleSpace =
+      const availableMiddleSpace =
         previousParagraph.column.width -
         resistanceParagraph.lines[0].width -
         crewParagraph.lines[0].width;
-      let centreX =
+      const centreX =
         resistanceParagraph.lines[0].width +
         availableMiddleSpace / 2 -
         scaleParagraph.lines[0].width / 2;
-      let endX = previousParagraph.column.width - crewParagraph.lines[0].width;
+      const endX =
+        previousParagraph.column.width - crewParagraph.lines[0].width;
 
       resistanceParagraph.write();
 
@@ -189,7 +190,7 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
       );
       scaleParagraph.write();
 
-      let crewParagraph = scaleParagraph.nextParagraph(0);
+      const crewParagraph = scaleParagraph.nextParagraph(0);
       crewParagraph.append(
         i18next.t('Construct.other.crewSupport').toLocaleUpperCase() + ': ',
         new FontSpecification(this.boldFont, 9),
@@ -232,7 +233,7 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
   async populate(pdf: PDFDocument, construct: Construct) {
     await super.populate(pdf, construct);
 
-    let starship = construct as Starship;
+    const starship = construct as Starship;
     let page = pdf.getPage(0);
 
     const colour = this.deriveSheetColour(construct);
@@ -283,14 +284,14 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
       starship.spaceframeModel?.serviceYear != null &&
       starship.serviceYear != null
     ) {
-      let yearsOfService = i18next.t('Construct.other.yearsOfService', {
+      const yearsOfService = i18next.t('Construct.other.yearsOfService', {
         count: Math.max(
           0,
           starship.serviceYear - starship.spaceframeModel.serviceYear,
         ),
         interpolation: { escapeValue: false },
       });
-      let numberOfRefits = i18next.t('Construct.other.numberOfRefits', {
+      const numberOfRefits = i18next.t('Construct.other.numberOfRefits', {
         count: starship.numberOfRefits,
         interpolation: { escapeValue: false },
       });
@@ -346,14 +347,14 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
     paragraph.append(starship.getAllTraits(), new FontOptions(9));
     paragraph.write();
 
-    let bottom = this.writeThreeColumnDerivedStats(
+    const bottom = this.writeThreeColumnDerivedStats(
       page,
       starship,
       paragraph,
       colour,
     );
 
-    let statFontSize = this.determineFontSizeForWidth(
+    const statFontSize = this.determineFontSizeForWidth(
       this.determineAllStatLabels(starship),
       72.2 * 0.8 - 2,
     );
@@ -364,7 +365,7 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
       new Column(bottom.x, bottom.y + 16, 13, column.width),
     );
 
-    let systemsBoxes = new XYLocation(bottom.x, bottom.y + 16 + 13 + 4);
+    const systemsBoxes = new XYLocation(bottom.x, bottom.y + 16 + 13 + 4);
     // these sheets use an unusual order
     [
       System.Comms,
@@ -374,11 +375,11 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
       System.Sensors,
       System.Weapons,
     ].forEach((s, i) => {
-      let location = new XYLocation(
+      const location = new XYLocation(
         systemsBoxes.x + (i % 3) * 77.9,
         systemsBoxes.y + Math.floor(i / 3) * 15.4,
       );
-      let x = location.x;
+      const x = location.x;
       const y = page.getHeight() - location.y;
       page.moveTo(x, y);
       page.drawSvgPath(Generated2eStarshipSheet.starshipStatFrame, {
@@ -386,7 +387,7 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
         borderWidth: 0.5,
       });
 
-      let column = new Column(x, location.y, 11.8, 72.2 * 0.8);
+      const column = new Column(x, location.y, 11.8, 72.2 * 0.8);
       this.writeLabel(
         page,
         i18next.t(makeKey('Construct.system.', System[s])),
@@ -414,7 +415,7 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
         column.width,
       ),
     );
-    let departmentBoxes = new XYLocation(
+    const departmentBoxes = new XYLocation(
       systemsBoxes.x,
       systemsBoxes.y + 15.4 * 2 + 16 + 13 + 4,
     );
@@ -428,11 +429,11 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
       Department.Security,
       Department.Science,
     ].forEach((d, i) => {
-      let location = new XYLocation(
+      const location = new XYLocation(
         departmentBoxes.x + (i % 3) * 77.9,
         departmentBoxes.y + Math.floor(i / 3) * 15.4,
       );
-      let x = location.x;
+      const x = location.x;
       const y = page.getHeight() - location.y;
       page.moveTo(x, y);
       page.drawSvgPath(Generated2eStarshipSheet.starshipStatFrame, {
@@ -440,7 +441,7 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
         borderWidth: 0.5,
       });
 
-      let column = new Column(x, location.y, 11.8, 72.2 * 0.8);
+      const column = new Column(x, location.y, 11.8, 72.2 * 0.8);
       const key = makeKey('Construct.department.', Department[d]);
       this.writeLabel(
         page,
@@ -459,7 +460,7 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
       );
     });
 
-    let attacksArea = new XYLocation(
+    const attacksArea = new XYLocation(
       departmentBoxes.x,
       departmentBoxes.y + 15.4 * 2 + 16,
     );
@@ -482,7 +483,7 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
       remainingColumn.bottomAfter(16).topBefore(13),
     );
     remainingColumn = remainingColumn.bottomAfter(16 + 13 + 4);
-    let bottomOfShields = this.writeShieldsBoxes(
+    const bottomOfShields = this.writeShieldsBoxes(
       page,
       pdf.getForm(),
       starship,
@@ -498,7 +499,7 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
       remainingColumn,
     );
 
-    let talentsColumn = remainingColumn.bottomAfter(13 + 4);
+    const talentsColumn = remainingColumn.bottomAfter(13 + 4);
 
     let finalColumn = await this.writeTalents(
       page,
@@ -509,7 +510,7 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
 
     if (this.hasSpecialRules(starship) && finalColumn) {
       if (finalColumn.height <= 50 && finalColumn.isNextColumnAvailable) {
-        let newColumn = finalColumn.advanceToNextColumn(page);
+        const newColumn = finalColumn.advanceToNextColumn(page);
         page = newColumn.page;
         finalColumn = newColumn.column;
       } else {
@@ -672,7 +673,7 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
     starship: Starship,
     column: Column,
   ) {
-    let stressBox =
+    const stressBox =
       'm 1,0 h 7.5 c 0.554,0 1,0.446 1,1 v 7.5 c 0,0.554 -0.446,1 -1,1 H 1 C 0.446,9.5 0,9.054 0,8.5 V 1 C 0,0.446 0.446,0 1,0 Z';
 
     let x = column.translatedStart(page).x;
@@ -698,7 +699,7 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
         borderWidth: borderWidth,
       });
 
-      let checkbox = form.createCheckBox('Shield ' + (i + 1));
+      const checkbox = form.createCheckBox('Shield ' + (i + 1));
       checkbox.addToPage(page, {
         x: x + 0.5,
         y: y - 9,
@@ -729,8 +730,8 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
     column: Column,
     colour: SimpleColor,
   ) {
-    let talents = assembleStarshipTalents(starship, false);
-    let writer = new TalentWriter(
+    const talents = assembleStarshipTalents(starship, false);
+    const writer = new TalentWriter(
       page,
       this.fonts,
       starship.version,
@@ -748,8 +749,8 @@ export class Generated2eStarshipSheet extends BaseNonForm2eSheet {
     column: Column,
     colour: SimpleColor,
   ) {
-    let talents = assembleStarshipTalents(starship, true);
-    let writer = new TalentWriter(
+    const talents = assembleStarshipTalents(starship, true);
+    const writer = new TalentWriter(
       page,
       this.fonts,
       starship.version,

--- a/WebTools/src/exportpdf/generated2eTentCard.ts
+++ b/WebTools/src/exportpdf/generated2eTentCard.ts
@@ -80,7 +80,7 @@ export class BasicGeneratedTentCardCharacterSheet extends BaseNonForm2eSheet {
   async populate(pdf: PDFDocument, construct: Construct) {
     await super.populate(pdf, construct);
     const page = pdf.getPage(0);
-    let character = construct as Character;
+    const character = construct as Character;
 
     await this.drawImage(pdf, page, character);
     this.writeFront(page, character);
@@ -99,7 +99,7 @@ export class BasicGeneratedTentCardCharacterSheet extends BaseNonForm2eSheet {
 
   async drawImage(pdf: PDFDocument, page: PDFPage, character: Character) {
     if (character.token) {
-      let tokenBytes = await TokenHelper.renderToken(character.token);
+      const tokenBytes = await TokenHelper.renderToken(character.token);
       const image = await pdf.embedPng(tokenBytes);
 
       const imageSize = 72 * 1.5;
@@ -139,7 +139,7 @@ export class BasicGeneratedTentCardCharacterSheet extends BaseNonForm2eSheet {
       );
     }
 
-    let columns = {
+    const columns = {
       'Construct.attribute.control': new Column(211.6, 235.4, 18.1, 60),
       'Construct.attribute.daring': new Column(211.6, 258.2, 18.1, 60),
       'Construct.attribute.fitness': new Column(294.6, 235.4, 18.1, 60),
@@ -179,14 +179,14 @@ export class BasicGeneratedTentCardCharacterSheet extends BaseNonForm2eSheet {
 
       let text = '';
       if (key.includes('Construct.attribute.')) {
-        let attribute = AttributesHelper.getAttributeByName(
+        const attribute = AttributesHelper.getAttributeByName(
           key.substring('Construct.attribute.'.length),
         );
         text = '' + character.attributes[attribute];
       }
 
       if (key.includes('Construct.discipline.')) {
-        let department = DepartmentsHelper.instance.getDepartmentByName(
+        const department = DepartmentsHelper.instance.getDepartmentByName(
           key.substring('Construct.discipline.'.length),
         );
         text = '' + character.departments[department];
@@ -206,7 +206,7 @@ export class BasicGeneratedTentCardCharacterSheet extends BaseNonForm2eSheet {
   }
 
   writeStressBoxes(page: PDFPage, character: Character, column: Column) {
-    let stressBox =
+    const stressBox =
       'm 1,0 h 7.5 c 0.554,0 1,0.446 1,1 v 7.5 c 0,0.554 -0.446,1 -1,1 H 1 C 0.446,9.5 0,9.054 0,8.5 V 1 C 0,0.446 0.446,0 1,0 Z';
 
     let x = column.translatedStart(page).x;
@@ -271,7 +271,7 @@ export class BasicGeneratedTentCardCharacterSheet extends BaseNonForm2eSheet {
         }
 
         if (talent && talent.talent.maxRank > 1) {
-          let rank = talent.rank;
+          const rank = talent.rank;
           talentName = i18next.t('Talent.text.rank', {
             talentName: talentName,
             rank: rank,
@@ -301,7 +301,7 @@ export class BasicGeneratedTentCardCharacterSheet extends BaseNonForm2eSheet {
     paragraph?.append(i18next.t('Construct.other.values') + ':', bold);
     paragraph?.write();
 
-    let values = character.values;
+    const values = character.values;
     values.forEach((value) => {
       paragraph = paragraph?.nextParagraph();
 
@@ -361,8 +361,8 @@ export class BasicGeneratedTentCardCharacterSheet extends BaseNonForm2eSheet {
       name = i18next.t('Construct.other.unnamedCharacter').toLocaleUpperCase();
     }
 
-    let divisionColour = divisionColour2e(character.era, character.division);
-    let fontSize = determineIdealFontWidth(
+    const divisionColour = divisionColour2e(character.era, character.division);
+    const fontSize = determineIdealFontWidth(
       [name],
       this.frontNameColumn.width,
       55,
@@ -370,7 +370,7 @@ export class BasicGeneratedTentCardCharacterSheet extends BaseNonForm2eSheet {
       this.fonts.fontByType(FontType.Bold),
     );
 
-    let nameBlock = TextBlock.create(
+    const nameBlock = TextBlock.create(
       name ?? '',
       new FontSpecification(this.fonts.fontByType(FontType.Bold), fontSize),
       false,
@@ -385,7 +385,7 @@ export class BasicGeneratedTentCardCharacterSheet extends BaseNonForm2eSheet {
     );
 
     if (character.rank?.localizedName != null) {
-      let rankBlock = TextBlock.create(
+      const rankBlock = TextBlock.create(
         character.rank?.localizedName?.toLocaleUpperCase() ?? '',
         new FontSpecification(this.fonts.fontByType(FontType.Bold), 35),
         false,
@@ -400,7 +400,7 @@ export class BasicGeneratedTentCardCharacterSheet extends BaseNonForm2eSheet {
     }
 
     if (character.pronouns?.length) {
-      let pronounsBlock = TextBlock.create(
+      const pronounsBlock = TextBlock.create(
         character.pronouns ?? '',
         new FontSpecification(this.fonts.fontByType(FontType.Bold), 30),
         false,
@@ -428,7 +428,7 @@ export class BasicGeneratedTentCardCharacterSheet extends BaseNonForm2eSheet {
     let name = i18next.t('Construct.other.unnamedCharacter');
     if (character.name?.length) {
       name = character.name;
-      let rank = character.rank?.localizedAbbreviation;
+      const rank = character.rank?.localizedAbbreviation;
       if (rank) {
         name = rank + ' ' + name;
       }

--- a/WebTools/src/exportpdf/generatedSafetypChecklistSheet.ts
+++ b/WebTools/src/exportpdf/generatedSafetypChecklistSheet.ts
@@ -49,7 +49,7 @@ export class GeneratedSafetyChecklistSheet extends BaseNonForm2eSheet {
     evaluation: { [category: string]: SafetyEvaluationType },
   ) {
     await this.initializeFonts(pdf);
-    let page = pdf.getPage(0);
+    const page = pdf.getPage(0);
 
     new PortraitSheetDecorations().drawSheetDecorations(page, tealColour2e);
     this.writeName(
@@ -64,9 +64,9 @@ export class GeneratedSafetyChecklistSheet extends BaseNonForm2eSheet {
     column = column.bottomAfter(20);
 
     SafetySections.instance.sections.forEach((section) => {
-      let temp = column.columnWithAtLeast(60, page);
+      const temp = column.columnWithAtLeast(60, page);
       column = temp.column;
-      let heading = new Paragraph(page, column, this.fonts);
+      const heading = new Paragraph(page, column, this.fonts);
       heading.append(
         section.localizedName.toLocaleUpperCase(),
         new FontSpecification(this.headingFont, 9),
@@ -86,7 +86,7 @@ export class GeneratedSafetyChecklistSheet extends BaseNonForm2eSheet {
     column: Column,
   ) {
     const evaluationColumnWidth = 30;
-    let th1 = new Paragraph(
+    const th1 = new Paragraph(
       page,
       new Column(
         column.start.x + column.width - 3 * evaluationColumnWidth,
@@ -96,7 +96,7 @@ export class GeneratedSafetyChecklistSheet extends BaseNonForm2eSheet {
       ),
       this.fonts,
     );
-    let th2 = new Paragraph(
+    const th2 = new Paragraph(
       page,
       new Column(
         column.start.x + column.width - 2 * evaluationColumnWidth,
@@ -106,7 +106,7 @@ export class GeneratedSafetyChecklistSheet extends BaseNonForm2eSheet {
       ),
       this.fonts,
     );
-    let th3 = new Paragraph(
+    const th3 = new Paragraph(
       page,
       new Column(
         column.start.x + column.width - 1 * evaluationColumnWidth,
@@ -139,7 +139,7 @@ export class GeneratedSafetyChecklistSheet extends BaseNonForm2eSheet {
 
     this.writeLine(page, column.start.x, th1.bottom.y + 5, column.width);
 
-    let columnWidth = column.width - 3 * evaluationColumnWidth;
+    const columnWidth = column.width - 3 * evaluationColumnWidth;
     column = column.bottomAfter(25);
     let paragraphColumn = new Column(
       column.start.x,
@@ -150,24 +150,24 @@ export class GeneratedSafetyChecklistSheet extends BaseNonForm2eSheet {
     );
 
     section.categories.forEach((c) => {
-      let paragraph = new Paragraph(page, paragraphColumn, this.fonts);
+      const paragraph = new Paragraph(page, paragraphColumn, this.fonts);
       paragraph.append(
         i18next.t(makeKey('SafetySection.category.', c)),
         new FontOptions(8),
       );
       paragraph.write();
 
-      let type = evaluation[c];
+      const type = evaluation[c];
       switch (type) {
         case SafetyEvaluationType.AlwaysOk:
           {
-            let tempColumn = new Column(
+            const tempColumn = new Column(
               paragraphColumn.start.x + paragraphColumn.width,
               paragraphColumn.start.y,
               20,
               evaluationColumnWidth,
             );
-            let evaluationParagraph = new Paragraph(
+            const evaluationParagraph = new Paragraph(
               page,
               tempColumn,
               this.fonts,
@@ -183,7 +183,7 @@ export class GeneratedSafetyChecklistSheet extends BaseNonForm2eSheet {
           break;
         case SafetyEvaluationType.YellowAlert:
           {
-            let tempColumn = new Column(
+            const tempColumn = new Column(
               paragraphColumn.start.x +
                 paragraphColumn.width +
                 evaluationColumnWidth,
@@ -191,7 +191,7 @@ export class GeneratedSafetyChecklistSheet extends BaseNonForm2eSheet {
               20,
               evaluationColumnWidth,
             );
-            let evaluationParagraph = new Paragraph(
+            const evaluationParagraph = new Paragraph(
               page,
               tempColumn,
               this.fonts,
@@ -206,7 +206,7 @@ export class GeneratedSafetyChecklistSheet extends BaseNonForm2eSheet {
           }
           break;
         case SafetyEvaluationType.RedAlert: {
-          let tempColumn = new Column(
+          const tempColumn = new Column(
             paragraphColumn.start.x +
               paragraphColumn.width +
               2 * evaluationColumnWidth,
@@ -214,7 +214,11 @@ export class GeneratedSafetyChecklistSheet extends BaseNonForm2eSheet {
             20,
             evaluationColumnWidth,
           );
-          let evaluationParagraph = new Paragraph(page, tempColumn, this.fonts);
+          const evaluationParagraph = new Paragraph(
+            page,
+            tempColumn,
+            this.fonts,
+          );
           evaluationParagraph.textAlignment = TextAlign.Centre;
           evaluationParagraph.append(
             CHALLENGE_DICE_NOTATION,
@@ -264,10 +268,12 @@ export class GeneratedSafetyChecklistSheet extends BaseNonForm2eSheet {
   }
 
   writePreamble(page: PDFPage, column: Column) {
-    let preambleText = i18next.t('SafetyChecklist.instruction');
-    let preambleParagraphs = preambleText.split('\n').filter((t) => t?.length);
+    const preambleText = i18next.t('SafetyChecklist.instruction');
+    const preambleParagraphs = preambleText
+      .split('\n')
+      .filter((t) => t?.length);
     let paragraph = new Paragraph(page, column, this.fonts);
-    let paragraphs = [paragraph];
+    const paragraphs = [paragraph];
     preambleParagraphs.forEach((p, i) => {
       if (i > 0) {
         paragraph = paragraph?.nextParagraph();

--- a/WebTools/src/exportpdf/generatedTngPortraitA4CharacterSheet.ts
+++ b/WebTools/src/exportpdf/generatedTngPortraitA4CharacterSheet.ts
@@ -197,7 +197,7 @@ export class GeneratedTngPortraitA4CharacterSheet extends BaseTNGGeneratedCharac
   }
 
   writeWeaponLabels(page: PDFPage) {
-    let fontSize = this.determineIdealFontWidth(
+    const fontSize = this.determineIdealFontWidth(
       [
         i18next.t('Weapon.common.name').toLocaleUpperCase(),
         i18next.t('Weapon.common.qualities').toLocaleUpperCase(),
@@ -208,9 +208,9 @@ export class GeneratedTngPortraitA4CharacterSheet extends BaseTNGGeneratedCharac
       this.headingFont,
     );
 
-    let offset = 697.6 - 643.6;
+    const offset = 697.6 - 643.6;
     for (let i = 0; i < 3; i++) {
-      let block = new Column(164.9, 643.6 + offset * i, 10.1, 50.3);
+      const block = new Column(164.9, 643.6 + offset * i, 10.1, 50.3);
       this.writeLabel(
         page,
         i18next.t('Weapon.common.name').toLocaleUpperCase(),
@@ -221,7 +221,7 @@ export class GeneratedTngPortraitA4CharacterSheet extends BaseTNGGeneratedCharac
         true,
       );
 
-      let block2 = new Column(164.9, 666.6 + offset * i, 10.1, 50.3);
+      const block2 = new Column(164.9, 666.6 + offset * i, 10.1, 50.3);
       this.writeLabel(
         page,
         i18next.t('Weapon.common.qualities').toLocaleUpperCase(),
@@ -236,9 +236,9 @@ export class GeneratedTngPortraitA4CharacterSheet extends BaseTNGGeneratedCharac
 
   fillTalents(form: PDFForm, character: Character) {
     let i = 1;
-    let handledTalents = [];
+    const handledTalents = [];
     character.talents.forEach((t) => {
-      let talent = t.talentModel;
+      const talent = t.talentModel;
       if (handledTalents.includes(talent.name)) {
         // skip it
       } else if (talent && talent.maxRank > 1) {

--- a/WebTools/src/exportpdf/generatedTngPortraitCharacterSheet.ts
+++ b/WebTools/src/exportpdf/generatedTngPortraitCharacterSheet.ts
@@ -199,7 +199,7 @@ export class GeneratedTngPortraitCharacterSheet extends BaseTNGGeneratedCharacte
   }
 
   writeWeaponLabels(page: PDFPage) {
-    let fontSize = this.determineIdealFontWidth(
+    const fontSize = this.determineIdealFontWidth(
       [
         i18next.t('Weapon.common.name').toLocaleUpperCase(),
         i18next.t('Weapon.common.qualities').toLocaleUpperCase(),
@@ -210,9 +210,9 @@ export class GeneratedTngPortraitCharacterSheet extends BaseTNGGeneratedCharacte
       this.headingFont,
     );
 
-    let offset = 680.6 - 626.1;
+    const offset = 680.6 - 626.1;
     for (let i = 0; i < 4; i++) {
-      let block = new Column(173.3, 626.1 + offset * i, 10.1, 41.5);
+      const block = new Column(173.3, 626.1 + offset * i, 10.1, 41.5);
       this.writeLabel(
         page,
         i18next.t('Weapon.common.name').toLocaleUpperCase(),
@@ -223,7 +223,7 @@ export class GeneratedTngPortraitCharacterSheet extends BaseTNGGeneratedCharacte
         true,
       );
 
-      let block2 = new Column(173.3, 650.6 + offset * i, 10.1, 41.5);
+      const block2 = new Column(173.3, 650.6 + offset * i, 10.1, 41.5);
       this.writeLabel(
         page,
         i18next.t('Weapon.common.qualities').toLocaleUpperCase(),
@@ -238,9 +238,9 @@ export class GeneratedTngPortraitCharacterSheet extends BaseTNGGeneratedCharacte
 
   fillTalents(form: PDFForm, character: Character) {
     let i = 1;
-    let handledTalents = [];
+    const handledTalents = [];
     character.talents.forEach((t) => {
-      let talent = t.talentModel;
+      const talent = t.talentModel;
       if (handledTalents.includes(talent.name)) {
         // skip it
       } else if (talent && talent.maxRank > 1) {

--- a/WebTools/src/exportpdf/generatedsheet.ts
+++ b/WebTools/src/exportpdf/generatedsheet.ts
@@ -92,7 +92,7 @@ export abstract class BasicGeneratedSheet implements ICharacterSheet {
     if (construct.name == null || construct.name.length === 0) {
       return suffix + '.pdf';
     } else {
-      var escaped = construct.name
+      const escaped = construct.name
         .replace(/\\/g, '_')
         .replace(/\//g, '_')
         .replace(/\s/g, '_');
@@ -134,21 +134,22 @@ export abstract class BasicGeneratedSheet implements ICharacterSheet {
         new FontSpecification(headingFont, 10),
         false,
       );
-      let y = nameColumn.end.y - 3 - (nameColumn.height - textBlock.height) / 2;
-      let x = nameColumn.start.x;
+      const y =
+        nameColumn.end.y - 3 - (nameColumn.height - textBlock.height) / 2;
+      const x = nameColumn.start.x;
 
       const triangle =
         'M 59.14167,59.12397 V 49.110298 l 8.671875,5.009766 z m 0.580078,-1.001953 6.9375,-4.001953 -6.9375,-4.007813 z';
 
-      let width = textBlock.width;
-      let widthOfTab = Math.max(120, width + 50);
-      let startOffset = 42.537;
+      const width = textBlock.width;
+      const widthOfTab = Math.max(120, width + 50);
+      const startOffset = 42.537;
 
-      let farthestEdge = widthOfTab + startOffset;
-      let circle1 = farthestEdge - (226.5918 - 221.51591);
-      let circle2 = farthestEdge - (226.5918 - 215.25391);
+      const farthestEdge = widthOfTab + startOffset;
+      const circle1 = farthestEdge - (226.5918 - 221.51591);
+      const circle2 = farthestEdge - (226.5918 - 215.25391);
 
-      let curvePath =
+      const curvePath =
         'M 53.876953 44.523438 C 47.614953 44.523438 42.537109 49.601281 42.537109 55.863281 L 42.537109 83.523438 L 42.958984 83.523438 L 42.958984 74.53125 C 42.958984 68.55425 47.821828 63.693359 53.798828 63.693359 ' +
         'L ' +
         farthestEdge +
@@ -185,17 +186,17 @@ export abstract class BasicGeneratedSheet implements ICharacterSheet {
 }
 
 export const assembleWritableItems = (character: Character) => {
-  let result: (ReadableTalentModel | RoleModel | SpeciesAbilityAndOptions)[] =
+  const result: (ReadableTalentModel | RoleModel | SpeciesAbilityAndOptions)[] =
     [];
 
   if (character.role != null) {
-    let role = RolesHelper.instance.getRole(character.role, character.type);
+    const role = RolesHelper.instance.getRole(character.role, character.type);
     if (role) {
       result.push(role);
     }
 
     if (character.secondaryRole != null) {
-      let role = RolesHelper.instance.getRole(
+      const role = RolesHelper.instance.getRole(
         character.secondaryRole,
         character.type,
       );
@@ -218,7 +219,7 @@ export const assembleWritableItems = (character: Character) => {
     );
   }
 
-  let handledTalents = [];
+  const handledTalents = [];
   character.talents.forEach((t) => {
     const talent = t.talentModel;
     if (talent && !handledTalents.includes(t.talent)) {
@@ -271,14 +272,14 @@ export const assembleWritableItems = (character: Character) => {
         readableTalent.attributes = character.talents
           .filter((s) => s.talent === talent.name && s.attribute != null)
           .map((s) => s.attribute);
-        let temp = character.talents.filter(
+        const temp = character.talents.filter(
           (s) => s.talent === talent.name && s.x != null,
         );
         if (temp.length) {
           readableTalent.x = temp[0].x;
         }
       } else if (talent.isXQualified) {
-        let temp = character.talents.filter(
+        const temp = character.talents.filter(
           (s) => s.talent === talent.name && s.x != null,
         );
         if (temp.length) {
@@ -296,13 +297,13 @@ export const assembleStarshipTalents = (
   starship: Starship | Station,
   includeSpecialRules: boolean = false,
 ) => {
-  let result: (ReadableTalentModel | RoleModel | SpeciesAbilityAndOptions)[] =
+  const result: (ReadableTalentModel | RoleModel | SpeciesAbilityAndOptions)[] =
     [];
-  let specialRules: (
+  const specialRules: (
     ReadableTalentModel | RoleModel | SpeciesAbilityAndOptions
   )[] = [];
 
-  let handledTalents = [];
+  const handledTalents = [];
   starship.talents.forEach((t) => {
     const talent = t.talentModel;
     if (talent && !handledTalents.includes(t.talent)) {
@@ -344,7 +345,7 @@ export const assembleStarshipTalents = (
           'Upgraded Systems (Service Record)',
         ].includes(talent.name)
       ) {
-        let temp = starship.talents.filter(
+        const temp = starship.talents.filter(
           (s) => s.talent === talent.name && s.system != null,
         );
         if (temp.length) {

--- a/WebTools/src/exportpdf/gmTrackerSheet.ts
+++ b/WebTools/src/exportpdf/gmTrackerSheet.ts
@@ -97,7 +97,7 @@ export class GmTrackerPdfSheet {
   async populate(pdf: PDFDocument, characters: Character[]) {
     await this.initializeFonts(pdf);
     let page = pdf.getPage(0);
-    let decorations = new PortraitSheetDecorations();
+    const decorations = new PortraitSheetDecorations();
     decorations.drawSheetDecorations(page, tealColour2e);
     decorations.writeName(
       page,
@@ -110,14 +110,14 @@ export class GmTrackerPdfSheet {
     let blankCopy = await pdf.copyPages(pdf, [0]);
 
     for (let i = 0; i < characters.length; i++) {
-      let c = characters[i];
-      let column = GmTrackerPdfSheet.COLUMNS[i % 3];
+      const c = characters[i];
+      const column = GmTrackerPdfSheet.COLUMNS[i % 3];
       if (i > 0 && i % 3 === 0) {
         page = pdf.addPage(blankCopy[0]);
         blankCopy = await pdf.copyPages(pdf, [pdf.getPages().length - 1]);
       }
 
-      let headerColumn = column.topBefore(13);
+      const headerColumn = column.topBefore(13);
       let name = c.nameAndAbbreviatedRank;
       if (
         c.stereotype === Stereotype.Npc &&
@@ -132,7 +132,7 @@ export class GmTrackerPdfSheet {
       }
       this.writeSubTitle(new PageArea(headerColumn, page), name);
       let column1 = column.bottomAfter(13);
-      let column2 = new Column(
+      const column2 = new Column(
         column1.start.x + column1.width - 220,
         column1.start.y,
         column1.height,
@@ -146,7 +146,7 @@ export class GmTrackerPdfSheet {
         column2,
       );
 
-      let descriptionParagraph = new Paragraph(page, column1, this.fonts);
+      const descriptionParagraph = new Paragraph(page, column1, this.fonts);
       descriptionParagraph.append(
         c.speciesName + (c.assignment?.length ? ',' : ''),
         new FontOptions(9),
@@ -156,11 +156,11 @@ export class GmTrackerPdfSheet {
       }
       descriptionParagraph.write();
 
-      let statArea = descriptionParagraph.nextArea(page).bottomAfter(10);
+      const statArea = descriptionParagraph.nextArea(page).bottomAfter(10);
       column1 = this.writeStatBoxes(statArea, c).column;
 
       if (c.isStressTrackPresent) {
-        let heading = new Paragraph(page, column1, this.fonts);
+        const heading = new Paragraph(page, column1, this.fonts);
         heading.append(
           i18next.t('Construct.other.stress').toLocaleUpperCase() + ':',
           new FontOptions(9, FontType.Bold),
@@ -176,7 +176,7 @@ export class GmTrackerPdfSheet {
         );
         column1 = column1.bottomAfter(8, page);
       } else if (c.isPersonalThreatTrackPresent) {
-        let heading = new Paragraph(page, column1, this.fonts);
+        const heading = new Paragraph(page, column1, this.fonts);
         heading.append(
           i18next.t('Construct.other.personalThreat').toLocaleUpperCase() + ':',
           new FontOptions(9, FontType.Bold),
@@ -194,7 +194,7 @@ export class GmTrackerPdfSheet {
       }
 
       column1 = column1.columnWithAtLeast(20, page)?.column;
-      let heading = new Paragraph(page, column1, this.fonts);
+      const heading = new Paragraph(page, column1, this.fonts);
       heading.append(
         i18next.t('Construct.other.attacks').toLocaleUpperCase() + ':',
         new FontOptions(9, FontType.Bold),
@@ -258,7 +258,7 @@ export class GmTrackerPdfSheet {
       'M 2.835,0 C 1.269,0 0,1.269 0,2.835 V 9 c 0,1.565 1.269,2.835 2.835,2.835 h 66.567 c 1.565,0 2.835,-1.27 2.835,-2.835 V 2.835 C 72.237,1.269 70.967,0 69.402,0 Z';
 
     const rowHeight = 16;
-    let labels = {};
+    const labels = {};
     [
       Attribute.Control,
       Attribute.Fitness,
@@ -267,11 +267,11 @@ export class GmTrackerPdfSheet {
       Attribute.Insight,
       Attribute.Reason,
     ].forEach((a, i) => {
-      let location = new XYLocation(
+      const location = new XYLocation(
         boxes.x + (i % 3) * 81,
         boxes.y + Math.floor(i / 3) * rowHeight,
       );
-      let x = location.x;
+      const x = location.x;
       const y = area.page.getHeight() - location.y;
       area.page.moveTo(x, y);
       area.page.drawSvgPath(statFrame, {
@@ -279,7 +279,7 @@ export class GmTrackerPdfSheet {
         borderWidth: 0.5,
       });
 
-      let labelColumn = new Column(x + 2, location.y, 11.8, 72.2 * 0.8);
+      const labelColumn = new Column(x + 2, location.y, 11.8, 72.2 * 0.8);
       const key = i18next.t(makeKey('Construct.attribute.', Attribute[a]));
       labels[key] = labelColumn;
 
@@ -302,11 +302,11 @@ export class GmTrackerPdfSheet {
       Department.Security,
       Department.Science,
     ].forEach((s, i) => {
-      let location = new XYLocation(
+      const location = new XYLocation(
         boxes.x + (i % 3) * 81,
         boxes.y + Math.floor(i / 3) * rowHeight,
       );
-      let x = location.x;
+      const x = location.x;
       const y = area.page.getHeight() - location.y;
       area.page.moveTo(x, y);
       area.page.drawSvgPath(statFrame, {
@@ -314,7 +314,7 @@ export class GmTrackerPdfSheet {
         borderWidth: 0.5,
       });
 
-      let labelColumn = new Column(x + 2, location.y, 11.8, 72.2 * 0.8);
+      const labelColumn = new Column(x + 2, location.y, 11.8, 72.2 * 0.8);
       const key = makeKey('Construct.discipline.', Department[s]);
       labels[key] = labelColumn;
 
@@ -353,8 +353,8 @@ export class GmTrackerPdfSheet {
     let lead = (block.width - textBlock.width) / 2;
     lead = Math.min(12, lead - 4);
 
-    let x = block.start.x + lead + 4;
-    let y = block.end.y - 1 - (block.height - textBlock.height) / 2;
+    const x = block.start.x + lead + 4;
+    const y = block.end.y - 1 - (block.height - textBlock.height) / 2;
     textBlock.writeToPage(
       x,
       area.page.getHeight() - y,
@@ -375,7 +375,7 @@ export class GmTrackerPdfSheet {
       color: greyColour2e.asPdfRbg(),
     });
 
-    let end = block.start.x + lead + 4 + textBlock.width + 4;
+    const end = block.start.x + lead + 4 + textBlock.width + 4;
     if (end < block.end.x) {
       area.page.drawLine({
         start: {
@@ -418,8 +418,8 @@ export class GmTrackerPdfSheet {
       textBlock = TextBlock.create(text, font, false);
     }
 
-    let y = column.end.y - 1 - (column.height - textBlock.height) / 2;
-    let x = column.start.x + (column.width - textBlock.width);
+    const y = column.end.y - 1 - (column.height - textBlock.height) / 2;
+    const x = column.start.x + (column.width - textBlock.width);
     textBlock.writeToPage(x, page.getHeight() - y, page, colour);
   }
 
@@ -429,7 +429,7 @@ export class GmTrackerPdfSheet {
     stress: number,
     index: number,
   ) {
-    let stressBox =
+    const stressBox =
       'm 1,0 h 7.5 c 0.554,0 1,0.446 1,1 v 7.5 c 0,0.554 -0.446,1 -1,1 H 1 C 0.446,9.5 0,9.054 0,8.5 V 1 C 0,0.446 0.446,0 1,0 Z';
 
     let x = area.column.translatedStart(area.page).x;
@@ -441,7 +441,7 @@ export class GmTrackerPdfSheet {
         borderWidth: 0.5,
       });
 
-      let checkbox = form.createCheckBox(
+      const checkbox = form.createCheckBox(
         'Stress-' + (index + 1) + ' ' + (i + 1),
       );
       checkbox.addToPage(area.page, {
@@ -476,8 +476,8 @@ export class GmTrackerPdfSheet {
     column: Column,
     colour: SimpleColor = tealColour2e,
   ) {
-    let bold = new FontOptions(9, FontType.Bold);
-    let standard = new FontOptions(9);
+    const bold = new FontOptions(9, FontType.Bold);
+    const standard = new FontOptions(9);
     let paragraph = null;
     let bottom = column;
 

--- a/WebTools/src/exportpdf/labelWriter.ts
+++ b/WebTools/src/exportpdf/labelWriter.ts
@@ -45,10 +45,10 @@ export const labelWriter = (
   let fontSize = originalFontSize;
 
   Object.keys(locations).forEach((key) => {
-    let block = locations[key];
+    const block = locations[key];
     key = changeLabelForVersion(key, version);
     const originalText = i18next.t(key).toLocaleUpperCase();
-    let text = originalText + suffix;
+    const text = originalText + suffix;
     let width = font.widthOfTextAtSize(text, fontSize);
     while (width > block.width) {
       fontSize -= 0.25;
@@ -60,7 +60,7 @@ export const labelWriter = (
   });
 
   Object.keys(locations).forEach((key) => {
-    let column = locations[key];
+    const column = locations[key];
     key = changeLabelForVersion(key, version);
 
     const originalText = i18next.t(key).toLocaleUpperCase();
@@ -100,7 +100,7 @@ export const simpleLabelWriter = (
   textAlign: TextAlign = TextAlign.Left,
   verticalAlignment: VerticalAlignment = VerticalAlignment.Baseline,
 ) => {
-  let width = font.widthOfTextAtSize(text, fontSize);
+  const width = font.widthOfTextAtSize(text, fontSize);
   let x = column.start.x;
   if (textAlign === TextAlign.Centre) {
     x = column.start.x + (column.width - width) / 2;

--- a/WebTools/src/exportpdf/landscape2eCharacterSheet.ts
+++ b/WebTools/src/exportpdf/landscape2eCharacterSheet.ts
@@ -146,12 +146,12 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
     const page2Column2 = new Column(226.5, 72.6, 479.3, 158.1, page2Column3);
     const page2Column1 = new Column(55.6, 72.6, 479.3, 158.1, page2Column2);
 
-    let talentsColumn3 = new Column(390.6, 361, 200, 162, () => {
+    const talentsColumn3 = new Column(390.6, 361, 200, 162, () => {
       const page = pdf.addPage(additionalPages[0]);
       return new PageArea(page2Column1, page);
     });
-    let talentsColumn2 = new Column(221.7, 361, 200, 162, talentsColumn3);
-    let talentsColumn1 = new Column(51.5, 361, 200, 162, talentsColumn2);
+    const talentsColumn2 = new Column(221.7, 361, 200, 162, talentsColumn3);
+    const talentsColumn1 = new Column(51.5, 361, 200, 162, talentsColumn2);
 
     return {
       logColumns: [logPage2Column1, logPage2Column2],
@@ -182,7 +182,7 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
     this.writeTitle(secondPage, colour);
 
     this.writeLabels(page, construct as Character);
-    let { firstColumn, logColumns, page2 } = await this.fixedTextColumns(
+    const { firstColumn, logColumns, page2 } = await this.fixedTextColumns(
       [secondPage],
       pdf,
     );
@@ -207,7 +207,7 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
           Landscape2eCharacterSheet.page2Column3X === nextArea.column.start.x)
       ) {
         y = nextArea.column.start.y;
-        let newLayoutColumn =
+        const newLayoutColumn =
           Landscape2eCharacterSheet.page2Column1X === nextArea.column.start.x
             ? logColumns[0]
             : logColumns[1];
@@ -219,7 +219,7 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
         nextArea != null &&
         Landscape2eCharacterSheet.page2Column2X === nextArea.column.start.x
       ) {
-        let newLayoutColumn = logColumns[1];
+        const newLayoutColumn = logColumns[1];
         nextArea = new PageArea(newLayoutColumn, nextArea.page);
       } else if (
         nextArea != null &&
@@ -248,7 +248,7 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
 
   async fillCharacterImage(pdf: PDFDocument, character: Character) {
     if (character.token) {
-      let tokenBytes = await TokenHelper.renderToken(character.token);
+      const tokenBytes = await TokenHelper.renderToken(character.token);
       const image = await pdf.embedPng(tokenBytes);
       try {
         pdf.getForm().getButton('Image35_af_image').setImage(image);
@@ -264,7 +264,7 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
     nextArea: PageArea,
     colour: SimpleColor,
   ) {
-    let header = {
+    const header = {
       'Sheet.text.log.title': nextArea.column.topBefore(10),
     };
     labelWriter(
@@ -278,14 +278,14 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
     );
     nextArea = nextArea.bottomAfter(23);
 
-    let logEntries = character.logEntries;
+    const logEntries = character.logEntries;
 
     let paragraph = new Paragraph(nextArea.page, nextArea.column, this.fonts);
-    let paragraphs: Paragraph[] = [];
+    const paragraphs: Paragraph[] = [];
     paragraphs.push(paragraph);
     let indent = 0;
     for (let i = 1; i <= logEntries.length; i++) {
-      let box = TextBlock.create(
+      const box = TextBlock.create(
         '' + i + '. ',
         new FontSpecification(this.fonts.fontByType(FontType.Bold), 9),
         0,
@@ -312,7 +312,7 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
         text += '\n**' + i18next.t('Common.text.notes') + ':** ' + l.notes;
       }
 
-      let descriptionParagraphs = text.split('\n');
+      const descriptionParagraphs = text.split('\n');
       descriptionParagraphs.forEach((p, i) => {
         if (i > 0) {
           paragraph = paragraph?.nextParagraph();
@@ -320,12 +320,12 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
             paragraphs.push(paragraph);
           }
         }
-        let temp = paragraph;
+        const temp = paragraph;
         paragraph?.append(p, new FontOptions(9));
         if (temp && i === 0) {
-          let height = temp.lines[0]?.height();
-          let y = temp.page.getHeight() - temp.lines[0]?.location.y;
-          let column = temp.lines[0]?.column;
+          const height = temp.lines[0]?.height();
+          const y = temp.page.getHeight() - temp.lines[0]?.location.y;
+          const column = temp.lines[0]?.column;
           if (height != null && y != null && column != null) {
             simpleLabelWriter(
               temp.page,
@@ -691,7 +691,7 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
     );
 
     if (construct.stereotype === Stereotype.Npc && construct.version !== 1) {
-      let paragraph = new Paragraph(
+      const paragraph = new Paragraph(
         page,
         new Column(411.2, 220.6, 12, 41.4),
         this.fonts,
@@ -751,7 +751,7 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
     column: Column,
   ) {
     if (character.description?.length) {
-      let subHeadings = {
+      const subHeadings = {
         'Construct.other.description': column.topBefore(9.5),
       };
       column = column.bottomAfter(12);
@@ -766,8 +766,8 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
       );
 
       let paragraph = new Paragraph(page, column, this.fonts);
-      let descriptionParagraphs = character.description.split('\n');
-      let paragraphs = [paragraph];
+      const descriptionParagraphs = character.description.split('\n');
+      const paragraphs = [paragraph];
       descriptionParagraphs.forEach((p, i) => {
         if (i > 0) {
           paragraph = paragraph?.nextParagraph();
@@ -781,9 +781,9 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
       paragraphs.forEach((p) => p.write());
 
       if (paragraphs.length) {
-        let last = paragraphs.filter((p) => p.lines?.length).slice(-1)[0];
+        const last = paragraphs.filter((p) => p.lines?.length).slice(-1)[0];
         if (last) {
-          let bottom = last.bottom;
+          const bottom = last.bottom;
           column = last.endColumn.bottomAfter(
             bottom.y - last.endColumn.start.y,
           );
@@ -795,7 +795,7 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
       }
     }
 
-    let temp = column.columnWithAtLeast(35, page);
+    const temp = column.columnWithAtLeast(35, page);
     column = temp.column;
     page = temp.page;
 
@@ -803,7 +803,7 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
       character.stereotype === Stereotype.Npc ||
       character.stereotype === Stereotype.SupportingCharacter
     ) {
-      let subHeadings = {
+      const subHeadings = {
         'Construct.other.specialRules': column.topBefore(9.5),
       };
       column = column.bottomAfter(12);
@@ -817,7 +817,7 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
         TextAlign.Centre,
       );
     } else {
-      let subHeadings = { 'Construct.other.talents': column.topBefore(9.5) };
+      const subHeadings = { 'Construct.other.talents': column.topBefore(9.5) };
       column = column.bottomAfter(12);
       labelWriter(
         page,
@@ -831,7 +831,7 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
     }
 
     const writer = new TalentWriter(page, this.fonts, character.version);
-    let lastArea = await writer.writeTalentsPageArea(
+    const lastArea = await writer.writeTalentsPageArea(
       assembleWritableItems(character),
       column,
       8,
@@ -852,20 +852,20 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
   }
 
   createStressBoxes(page: PDFPage, pdf: PDFDocument, character: Character) {
-    let columns = [];
-    let startX = 464.9;
-    let startY = 221.3;
-    let gap = 478.8 - startX;
+    const columns = [];
+    const startX = 464.9;
+    const startY = 221.3;
+    const gap = 478.8 - startX;
 
-    let availableVerticalSpace = 4 * gap;
+    const availableVerticalSpace = 4 * gap;
     if (character.isStressTrackPresent) {
-      let numberOfLines = Math.ceil(character.stress / 5);
+      const numberOfLines = Math.ceil(character.stress / 5);
 
-      let verticalOffset = (availableVerticalSpace - numberOfLines * gap) / 2;
+      const verticalOffset = (availableVerticalSpace - numberOfLines * gap) / 2;
 
       for (let i = 0; i < character.stress; i++) {
-        let x = startX + gap * (i % 5);
-        let y = startY + gap * Math.floor(i / 5) + verticalOffset;
+        const x = startX + gap * (i % 5);
+        const y = startY + gap * Math.floor(i / 5) + verticalOffset;
         columns.push(new Column(x, y, 9.5, 9.5));
       }
 
@@ -878,12 +878,12 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
       character.stereotype === Stereotype.Npc &&
       character.version !== 1
     ) {
-      let numberOfLines = Math.ceil(character.personalThreat / 5);
+      const numberOfLines = Math.ceil(character.personalThreat / 5);
 
-      let verticalOffset = (availableVerticalSpace - numberOfLines * gap) / 2;
+      const verticalOffset = (availableVerticalSpace - numberOfLines * gap) / 2;
       for (let i = 0; i < character.personalThreat; i++) {
-        let x = startX + gap * (i % 5);
-        let y = startY + gap * Math.floor(i / 5) + verticalOffset;
+        const x = startX + gap * (i % 5);
+        const y = startY + gap * Math.floor(i / 5) + verticalOffset;
         columns.push(new Column(x, y, 9.5, 9.5));
       }
 
@@ -919,12 +919,12 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
     const triangle =
       'M 60.232529,54.856579 V 44.842907 l 8.671875,5.009766 z m 0.580078,-1.001953 6.9375,-4.001953 -6.9375,-4.007813 z';
 
-    let widthOfTab = Math.max(146.205, width + 35);
-    let startOffset = 54.966797;
+    const widthOfTab = Math.max(146.205, width + 35);
+    const startOffset = 54.966797;
 
-    let farthestEdge = widthOfTab + startOffset;
-    let circle1 = farthestEdge - (189.83203 - 184.75613);
-    let circle2 = farthestEdge - (189.83203 - 178.49414);
+    const farthestEdge = widthOfTab + startOffset;
+    const circle1 = farthestEdge - (189.83203 - 184.75613);
+    const circle2 = farthestEdge - (189.83203 - 178.49414);
 
     const tab =
       'M 54.966797 40.257812 ' +
@@ -975,7 +975,7 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
   populateForm(form: PDFForm, character: Character) {
     form.getFields().forEach((f) => {
       if (f instanceof PDFTextField) {
-        let textField = f as PDFTextField;
+        const textField = f as PDFTextField;
         if (
           textField.isMultiline() &&
           (textField.getText() == null || textField.getText().length === 0)
@@ -1052,7 +1052,7 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
     const describer = new WeaponDescriber(construct.version, true);
 
     if (construct instanceof Character) {
-      let attacks = construct
+      const attacks = construct
         .determineWeapons()
         .map(
           (w) =>

--- a/WebTools/src/exportpdf/landscape2eCreatureSheet.ts
+++ b/WebTools/src/exportpdf/landscape2eCreatureSheet.ts
@@ -62,7 +62,7 @@ export class Landscape2eCreatureSheet extends BaseNonForm2eSheet {
   async populate(pdf: PDFDocument, construct: Construct) {
     await super.populate(pdf, construct);
 
-    let page = pdf.getPage(0);
+    const page = pdf.getPage(0);
 
     new LandscapeSheetDecorations().drawSheetDecorations(page, tealColour2e);
     this.writeTitle(construct.name, page, tealColour2e);
@@ -200,7 +200,7 @@ export class Landscape2eCreatureSheet extends BaseNonForm2eSheet {
       'M 2.835,0 C 1.269,0 0,1.269 0,2.835 V 9 c 0,1.565 1.269,2.835 2.835,2.835 h 60.567 c 1.565,0 2.835,-1.27 2.835,-2.835 V 2.835 C 66.237,1.269 64.967,0 63.402,0 Z';
 
     const rowHeight = 16;
-    let labels = {};
+    const labels = {};
     const width = 74;
     [
       Attribute.Control,
@@ -210,11 +210,11 @@ export class Landscape2eCreatureSheet extends BaseNonForm2eSheet {
       Attribute.Insight,
       Attribute.Reason,
     ].forEach((a, i) => {
-      let location = new XYLocation(
+      const location = new XYLocation(
         boxes.x + (i % 3) * width,
         boxes.y + Math.floor(i / 3) * rowHeight,
       );
-      let x = location.x;
+      const x = location.x;
       const y = area.page.getHeight() - location.y;
       area.page.moveTo(x, y);
       area.page.drawSvgPath(statFrame, {
@@ -222,7 +222,7 @@ export class Landscape2eCreatureSheet extends BaseNonForm2eSheet {
         borderWidth: 0.5,
       });
 
-      let labelColumn = new Column(x + 2, location.y, 11.8, 64.5 * 0.8);
+      const labelColumn = new Column(x + 2, location.y, 11.8, 64.5 * 0.8);
       const key = i18next.t(makeKey('Construct.attribute.', Attribute[a]));
       labels[key] = labelColumn;
 
@@ -260,11 +260,11 @@ export class Landscape2eCreatureSheet extends BaseNonForm2eSheet {
       Department.Security,
       Department.Science,
     ].forEach((s, i) => {
-      let location = new XYLocation(
+      const location = new XYLocation(
         boxes.x + (i % 3) * width,
         boxes.y + Math.floor(i / 3) * rowHeight,
       );
-      let x = location.x;
+      const x = location.x;
       const y = area.page.getHeight() - location.y;
       area.page.moveTo(x, y);
       area.page.drawSvgPath(statFrame, {
@@ -272,7 +272,7 @@ export class Landscape2eCreatureSheet extends BaseNonForm2eSheet {
         borderWidth: 0.5,
       });
 
-      let labelColumn = new Column(x + 2, location.y, 11.8, 64.5 * 0.8);
+      const labelColumn = new Column(x + 2, location.y, 11.8, 64.5 * 0.8);
       const key = makeKey('Construct.discipline.', Department[s]);
       labels[key] = labelColumn;
 
@@ -303,8 +303,8 @@ export class Landscape2eCreatureSheet extends BaseNonForm2eSheet {
   writeDescription(area: PageArea, creature: Creature): PageArea {
     if (creature.description?.length) {
       let paragraph = new Paragraph(area.page, area.column, this.fonts);
-      let descriptionParagraphs = creature.description.split('\n');
-      let paragraphs = [paragraph];
+      const descriptionParagraphs = creature.description.split('\n');
+      const paragraphs = [paragraph];
       descriptionParagraphs.forEach((p, i) => {
         if (i > 0) {
           paragraph = paragraph?.nextParagraph();
@@ -318,7 +318,7 @@ export class Landscape2eCreatureSheet extends BaseNonForm2eSheet {
       paragraphs.forEach((p) => p.write());
 
       if (paragraphs.length) {
-        let last = paragraphs.filter((p) => p.lines?.length).slice(-1)[0];
+        const last = paragraphs.filter((p) => p.lines?.length).slice(-1)[0];
         if (last) {
           area = paragraph.nextArea(area.page).bottomAfter(10);
         }
@@ -352,12 +352,12 @@ export class Landscape2eCreatureSheet extends BaseNonForm2eSheet {
     const triangle =
       'M 60.232529,54.856579 V 44.842907 l 8.671875,5.009766 z m 0.580078,-1.001953 6.9375,-4.001953 -6.9375,-4.007813 z';
 
-    let widthOfTab = Math.max(146.205, width + 35);
-    let startOffset = 54.966797;
+    const widthOfTab = Math.max(146.205, width + 35);
+    const startOffset = 54.966797;
 
-    let farthestEdge = widthOfTab + startOffset;
-    let circle1 = farthestEdge - (189.83203 - 184.75613);
-    let circle2 = farthestEdge - (189.83203 - 178.49414);
+    const farthestEdge = widthOfTab + startOffset;
+    const circle1 = farthestEdge - (189.83203 - 184.75613);
+    const circle2 = farthestEdge - (189.83203 - 178.49414);
 
     const tab =
       'M 54.966797 40.257812 ' +
@@ -407,7 +407,7 @@ export class Landscape2eCreatureSheet extends BaseNonForm2eSheet {
 }
 
 export const assembleCreatureTalents = (creature: Creature) => {
-  let result: (ReadableTalentModel | RoleModel | SpeciesAbilityAndOptions)[] =
+  const result: (ReadableTalentModel | RoleModel | SpeciesAbilityAndOptions)[] =
     [];
 
   creature.talents.forEach((t) => {

--- a/WebTools/src/exportpdf/landscapeGeneratedCharacterSheet.ts
+++ b/WebTools/src/exportpdf/landscapeGeneratedCharacterSheet.ts
@@ -140,7 +140,7 @@ export class LandscapeGeneratedCharacterSheet extends BaseTNGGeneratedCharacterS
   async populate(pdf: PDFDocument, construct: Construct) {
     await super.populate(pdf, construct);
 
-    let character = construct as Character;
+    const character = construct as Character;
 
     const page = pdf.getPage(0);
 
@@ -191,7 +191,7 @@ export class LandscapeGeneratedCharacterSheet extends BaseTNGGeneratedCharacterS
   }
 
   writeWeaponLabels(page: PDFPage) {
-    let fontSize = this.determineIdealFontWidth(
+    const fontSize = this.determineIdealFontWidth(
       [
         i18next.t('Weapon.common.name').toLocaleUpperCase(),
         i18next.t('Weapon.common.qualities').toLocaleUpperCase(),
@@ -202,9 +202,9 @@ export class LandscapeGeneratedCharacterSheet extends BaseTNGGeneratedCharacterS
       this.headingFont,
     );
 
-    let offset = 460.3 - 414.6;
+    const offset = 460.3 - 414.6;
     for (let i = 0; i < 4; i++) {
-      let block = new Column(32.5, 414.6 + offset * i, 10.1, 38.1);
+      const block = new Column(32.5, 414.6 + offset * i, 10.1, 38.1);
       this.writeLabel(
         page,
         i18next.t('Weapon.common.name').toLocaleUpperCase(),
@@ -215,7 +215,7 @@ export class LandscapeGeneratedCharacterSheet extends BaseTNGGeneratedCharacterS
         true,
       );
 
-      let block2 = new Column(32.5, 434.6 + offset * i, 10.1, 38.1);
+      const block2 = new Column(32.5, 434.6 + offset * i, 10.1, 38.1);
       this.writeLabel(
         page,
         i18next.t('Weapon.common.qualities').toLocaleUpperCase(),

--- a/WebTools/src/exportpdf/pageArea.ts
+++ b/WebTools/src/exportpdf/pageArea.ts
@@ -11,7 +11,7 @@ export class PageArea {
   }
 
   bottomAfter(deltaY: number) {
-    let column = this.column.bottomAfter(deltaY, this.page);
+    const column = this.column.bottomAfter(deltaY, this.page);
     return column == null ? null : new PageArea(column, this.page);
   }
 

--- a/WebTools/src/exportpdf/paragraph.ts
+++ b/WebTools/src/exportpdf/paragraph.ts
@@ -59,14 +59,14 @@ export class Line {
   }
   append(block: TextBlock) {
     if (this.blocks.length) {
-      let lastBlock = this.blocks[this.blocks.length - 1];
+      const lastBlock = this.blocks[this.blocks.length - 1];
       if (
         block.font === lastBlock.font &&
         block.fontSize === lastBlock.fontSize &&
         block.colour?.asHex() === lastBlock.colour?.asHex() &&
         block.descender === lastBlock.descender
       ) {
-        let newBlock = TextBlock.create(
+        const newBlock = TextBlock.create(
           lastBlock.text + block.text,
           new FontSpecification(block.font, block.fontSize),
           block.descender,
@@ -102,7 +102,7 @@ export class Line {
     } else {
       const result = this.column.advanceToNextColumn(this.page);
       if (result) {
-        let location = result.column.translatedStart(result.page);
+        const location = result.column.translatedStart(result.page);
         return new Line(
           location,
           result.page,
@@ -158,7 +158,7 @@ export class Paragraph {
 
   get startColumn(): Column {
     if (this.lines?.length) {
-      let firstLine = this.lines[0];
+      const firstLine = this.lines[0];
       return firstLine.column;
     } else {
       return this.column;
@@ -167,7 +167,7 @@ export class Paragraph {
 
   get endColumn(): Column {
     if (this.lines?.length) {
-      let lastLine = this.lines[this.lines.length - 1];
+      const lastLine = this.lines[this.lines.length - 1];
       return lastLine.column;
     } else {
       return this.column;
@@ -176,7 +176,7 @@ export class Paragraph {
 
   get endPage(): PDFPage {
     if (this.lines?.length) {
-      let lastLine = this.lines[this.lines.length - 1];
+      const lastLine = this.lines[this.lines.length - 1];
       return lastLine.page;
     } else {
       return this.page;
@@ -185,7 +185,7 @@ export class Paragraph {
 
   private currentLine() {
     if (this.lines.length === 0) {
-      let column = this.column;
+      const column = this.column;
       let start = this.start;
       if (start == null) {
         start = column.translatedStart(this.page);
@@ -200,8 +200,8 @@ export class Paragraph {
     if (this.lines?.length === 1) {
       return false;
     } else if (this.lines?.length) {
-      let firstLine = this.lines[0];
-      let lastLine = this.lines[this.lines.length - 1];
+      const firstLine = this.lines[0];
+      const lastLine = this.lines[this.lines.length - 1];
 
       return !(
         firstLine.column.start.x === lastLine.column.start.x &&
@@ -229,7 +229,7 @@ export class Paragraph {
       fontSpecification = font as FontSpecification;
     } else {
       options = font as FontOptions;
-      let pdfFont = this.fontLibrary.fontByType(options.fontType);
+      const pdfFont = this.fontLibrary.fontByType(options.fontType);
       fontSpecification = new FontSpecification(pdfFont, options.size);
     }
     this.lines = this.createLines(
@@ -253,15 +253,15 @@ export class Paragraph {
 
   // Provide the remaining column area "underneath" the paragraph.
   nextColumn() {
-    let bottom = this.bottom;
-    let column = this.endColumn;
+    const bottom = this.bottom;
+    const column = this.endColumn;
     return column?.bottomAfter(bottom.y - column.start.y);
   }
 
   nextArea(currentPage: PDFPage, minimumHeight?: number): PageArea | undefined {
     if (this.lines?.length) {
-      let column = this.nextColumn();
-      let page = this.lines[this.lines.length - 1].page;
+      const column = this.nextColumn();
+      const page = this.lines[this.lines.length - 1].page;
 
       if (minimumHeight != null) {
         return column.columnWithAtLeast(minimumHeight, page);
@@ -284,8 +284,8 @@ export class Paragraph {
       );
 
       if (newLocation && line.column) {
-        let currentColumn = line.column;
-        let newLine = new Line(
+        const currentColumn = line.column;
+        const newLine = new Line(
           newLocation,
           this.endPage,
           currentColumn,
@@ -316,7 +316,7 @@ export class Paragraph {
 
   get bottom() {
     if (this.lines.length > 0) {
-      let line = this.lines[this.lines.length - 1];
+      const line = this.lines[this.lines.length - 1];
       return this.column.untranslateLocation(this.page, line.bottom());
     } else {
       return this.column.start;
@@ -330,11 +330,11 @@ export class Paragraph {
     page: PDFPage,
     colour?: SimpleColor,
   ) {
-    let result: Line[] = [...this.lines];
+    const result: Line[] = [...this.lines];
     let fontSpec = initialFont;
     let fontType = options?.fontType;
     if (result.length === 0) {
-      let temp = this.currentLine();
+      const temp = this.currentLine();
       if (temp != null) {
         result.push(temp);
       }
@@ -343,7 +343,7 @@ export class Paragraph {
     let tokens = textTokenizer(text);
     let skipSpace = false;
     for (let t = 0; t < tokens.length; t++) {
-      let token = tokens[t];
+      const token = tokens[t];
       if (token === '_' || token === '**') {
         skipSpace = true;
         if (options != null) {
@@ -351,13 +351,13 @@ export class Paragraph {
             fontType = options.fontType;
             fontSpec = initialFont;
           } else if (token === '**') {
-            let font = this.fontLibrary.fontByType(FontType.Bold);
+            const font = this.fontLibrary.fontByType(FontType.Bold);
             if (font != null) {
               fontType = FontType.Bold;
               fontSpec = new FontSpecification(font, options.size);
             }
           } else if (token === '_') {
-            let font = this.fontLibrary.fontByType(FontType.Italic);
+            const font = this.fontLibrary.fontByType(FontType.Italic);
             if (font != null) {
               fontType = FontType.Italic;
               fontSpec = new FontSpecification(font, options.size);
@@ -365,7 +365,7 @@ export class Paragraph {
           }
         }
       } else if (token === CHALLENGE_DICE_NOTATION) {
-        let block = TextBlock.create(
+        const block = TextBlock.create(
           'A',
           new FontSpecification(
             this.fontLibrary.fontByType(FontType.Symbol),
@@ -384,7 +384,7 @@ export class Paragraph {
             line.append(block);
 
             // maybe the latest changes required a column change
-            let newLine = line.moveToNextColumnIfNecessary();
+            const newLine = line.moveToNextColumnIfNecessary();
             if (newLine == null) {
               // skip it
             } else if (newLine !== line) {
@@ -395,7 +395,7 @@ export class Paragraph {
           }
         }
       } else {
-        let words = token.split(/\s+/);
+        const words = token.split(/\s+/);
         for (let i = 0; i < words.length; i++) {
           let line = result[result.length - 1];
 
@@ -406,7 +406,7 @@ export class Paragraph {
             } else {
               skipSpace = false;
             }
-            let block = TextBlock.create(word, fontSpec, false, colour);
+            const block = TextBlock.create(word, fontSpec, false, colour);
 
             if (block.width < line.availableWidth()) {
               line.append(block);
@@ -425,7 +425,7 @@ export class Paragraph {
             }
 
             // maybe the latest changes required a column change
-            let newLine = line.moveToNextColumnIfNecessary();
+            const newLine = line.moveToNextColumnIfNecessary();
             if (newLine != null && newLine !== line) {
               result[result.length - 1] = newLine;
             }

--- a/WebTools/src/exportpdf/portrait2eStationSheet.ts
+++ b/WebTools/src/exportpdf/portrait2eStationSheet.ts
@@ -82,7 +82,7 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
 
   writeStationName(page: PDFPage, station: Station, colour: SimpleColor) {
     if (station.name?.length) {
-      let name = station.name;
+      const name = station.name;
       this.writeName(page, name, colour, this.headingFont, this.nameColumn);
     } else {
       this.writeName(
@@ -102,7 +102,7 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
     previousParagraph: Paragraph,
     colour: SimpleColor,
   ) {
-    let resistanceParagraph = previousParagraph.nextParagraph(1);
+    const resistanceParagraph = previousParagraph.nextParagraph(1);
     resistanceParagraph.append(
       i18next.t('Construct.other.protection').toLocaleUpperCase() + ': ',
       new FontSpecification(this.boldFont, 9),
@@ -124,7 +124,7 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
       new FontSpecification(this.textFont, 9),
     );
 
-    let crewParagraph = previousParagraph.nextParagraph(1);
+    const crewParagraph = previousParagraph.nextParagraph(1);
     crewParagraph.append(
       i18next.t('Construct.other.crewSupport').toLocaleUpperCase() + ': ',
       new FontSpecification(this.boldFont, 9),
@@ -145,15 +145,16 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
         30 <
         previousParagraph.column.width
     ) {
-      let availableMiddleSpace =
+      const availableMiddleSpace =
         previousParagraph.column.width -
         resistanceParagraph.lines[0].width -
         crewParagraph.lines[0].width;
-      let centreX =
+      const centreX =
         resistanceParagraph.lines[0].width +
         availableMiddleSpace / 2 -
         scaleParagraph.lines[0].width / 2;
-      let endX = previousParagraph.column.width - crewParagraph.lines[0].width;
+      const endX =
+        previousParagraph.column.width - crewParagraph.lines[0].width;
 
       resistanceParagraph.write();
 
@@ -187,7 +188,7 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
       );
       scaleParagraph.write();
 
-      let crewParagraph = scaleParagraph.nextParagraph(0);
+      const crewParagraph = scaleParagraph.nextParagraph(0);
       crewParagraph.append(
         i18next.t('Construct.other.crewSupport').toLocaleUpperCase() + ': ',
         new FontSpecification(this.boldFont, 9),
@@ -230,8 +231,8 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
   async populate(pdf: PDFDocument, construct: Construct) {
     await super.populate(pdf, construct);
 
-    let station = construct as Station;
-    let page = pdf.getPage(0);
+    const station = construct as Station;
+    const page = pdf.getPage(0);
 
     const colour = this.deriveSheetColour(construct);
     new PortraitSheetDecorations().drawSheetDecorations(page, colour);
@@ -298,7 +299,7 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
     if (station.missionProfileStep?.type != null) {
       paragraph = paragraph.nextParagraph(1);
 
-      let profile = MissionProfiles.instance.getStationMissionProfileByType(
+      const profile = MissionProfiles.instance.getStationMissionProfileByType(
         station.missionProfileStep.type,
       );
       paragraph.append(
@@ -320,14 +321,14 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
     paragraph.append(station.allTraitsAsString, new FontOptions(9));
     paragraph.write();
 
-    let bottomArea = this.writeThreeColumnDerivedStats(
+    const bottomArea = this.writeThreeColumnDerivedStats(
       page,
       station,
       paragraph,
       colour,
     );
 
-    let dockingParagraph = new Paragraph(
+    const dockingParagraph = new Paragraph(
       page,
       bottomArea.areaWithAtLeast(50).column,
       this.fonts,
@@ -343,17 +344,17 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
     );
     dockingParagraph.write();
 
-    let statFontSize = this.determineFontSizeForWidth(
+    const statFontSize = this.determineFontSizeForWidth(
       this.determineAllStatLabels(station),
       72.2 * 0.8 - 2,
     );
 
-    let statsArea = dockingParagraph.endColumn.columnWithAtLeast(25, page);
+    const statsArea = dockingParagraph.endColumn.columnWithAtLeast(25, page);
 
-    let statsColumn = statsArea.column.bottomAfter(16 + 4, page);
+    const statsColumn = statsArea.column.bottomAfter(16 + 4, page);
     this.writeSubTitle(page, i18next.t('Construct.other.systems'), statsColumn);
 
-    let systemsBoxes = statsColumn.bottomAfter(13 + 4).start;
+    const systemsBoxes = statsColumn.bottomAfter(13 + 4).start;
     // these sheets use an unusual order
     [
       System.Comms,
@@ -363,11 +364,11 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
       System.Sensors,
       System.Weapons,
     ].forEach((s, i) => {
-      let location = new XYLocation(
+      const location = new XYLocation(
         systemsBoxes.x + (i % 3) * 77.9,
         systemsBoxes.y + Math.floor(i / 3) * 15.4,
       );
-      let x = location.x;
+      const x = location.x;
       const y = page.getHeight() - location.y;
       page.moveTo(x, y);
       page.drawSvgPath(Generated2eStarshipSheet.starshipStatFrame, {
@@ -375,7 +376,7 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
         borderWidth: 0.5,
       });
 
-      let column = new Column(x, location.y, 11.8, 72.2 * 0.8);
+      const column = new Column(x, location.y, 11.8, 72.2 * 0.8);
       this.writeLabel(
         page,
         i18next.t(makeKey('Construct.system.', System[s])),
@@ -403,7 +404,7 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
         column.width,
       ),
     );
-    let departmentBoxes = new XYLocation(
+    const departmentBoxes = new XYLocation(
       systemsBoxes.x,
       systemsBoxes.y + 15.4 * 2 + 16 + 13 + 4,
     );
@@ -417,11 +418,11 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
       Department.Security,
       Department.Science,
     ].forEach((d, i) => {
-      let location = new XYLocation(
+      const location = new XYLocation(
         departmentBoxes.x + (i % 3) * 77.9,
         departmentBoxes.y + Math.floor(i / 3) * 15.4,
       );
-      let x = location.x;
+      const x = location.x;
       const y = page.getHeight() - location.y;
       page.moveTo(x, y);
       page.drawSvgPath(Generated2eStarshipSheet.starshipStatFrame, {
@@ -429,7 +430,7 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
         borderWidth: 0.5,
       });
 
-      let column = new Column(x, location.y, 11.8, 72.2 * 0.8);
+      const column = new Column(x, location.y, 11.8, 72.2 * 0.8);
       const key = makeKey('Construct.department.', Department[d]);
       this.writeLabel(
         page,
@@ -448,7 +449,7 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
       );
     });
 
-    let attacksArea = new XYLocation(
+    const attacksArea = new XYLocation(
       departmentBoxes.x,
       departmentBoxes.y + 15.4 * 2 + 16,
     );
@@ -471,7 +472,7 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
       remainingColumn.bottomAfter(16).topBefore(13),
     );
     remainingColumn = remainingColumn.bottomAfter(16 + 13 + 4);
-    let bottomOfShields = this.writeShieldsBoxes(
+    const bottomOfShields = this.writeShieldsBoxes(
       page,
       pdf.getForm(),
       station,
@@ -487,7 +488,7 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
       remainingColumn,
     );
 
-    let talentsColumn = remainingColumn.bottomAfter(13 + 4);
+    const talentsColumn = remainingColumn.bottomAfter(13 + 4);
 
     //let finalColumn =
     await this.writeTalents(page, station, talentsColumn, colour);
@@ -639,7 +640,7 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
     station: Station,
     column: Column,
   ) {
-    let stressBox =
+    const stressBox =
       'm 1,0 h 7.5 c 0.554,0 1,0.446 1,1 v 7.5 c 0,0.554 -0.446,1 -1,1 H 1 C 0.446,9.5 0,9.054 0,8.5 V 1 C 0,0.446 0.446,0 1,0 Z';
 
     let x = column.translatedStart(page).x;
@@ -665,7 +666,7 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
         borderWidth: borderWidth,
       });
 
-      let checkbox = form.createCheckBox('Shield ' + (i + 1));
+      const checkbox = form.createCheckBox('Shield ' + (i + 1));
       checkbox.addToPage(page, {
         x: x + 0.5,
         y: y - 9,
@@ -696,8 +697,8 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
     column: Column,
     colour: SimpleColor,
   ) {
-    let talents = assembleStarshipTalents(station, false);
-    let writer = new TalentWriter(
+    const talents = assembleStarshipTalents(station, false);
+    const writer = new TalentWriter(
       page,
       this.fonts,
       station.version,
@@ -715,8 +716,8 @@ export class Portrait2eStationSheet extends BaseNonForm2eSheet {
     column: Column,
     colour: SimpleColor,
   ) {
-    let talents = assembleStarshipTalents(starship, true);
-    let writer = new TalentWriter(
+    const talents = assembleStarshipTalents(starship, true);
+    const writer = new TalentWriter(
       page,
       this.fonts,
       starship.version,

--- a/WebTools/src/exportpdf/portraitSheetDecorations.ts
+++ b/WebTools/src/exportpdf/portraitSheetDecorations.ts
@@ -60,21 +60,22 @@ export class PortraitSheetDecorations {
         new FontSpecification(headingFont, 10),
         false,
       );
-      let y = nameColumn.end.y - 3 - (nameColumn.height - textBlock.height) / 2;
-      let x = nameColumn.start.x;
+      const y =
+        nameColumn.end.y - 3 - (nameColumn.height - textBlock.height) / 2;
+      const x = nameColumn.start.x;
 
       const triangle =
         'M 59.14167,59.12397 V 49.110298 l 8.671875,5.009766 z m 0.580078,-1.001953 6.9375,-4.001953 -6.9375,-4.007813 z';
 
-      let width = textBlock.width;
-      let widthOfTab = Math.max(120, width + 50);
-      let startOffset = 42.537;
+      const width = textBlock.width;
+      const widthOfTab = Math.max(120, width + 50);
+      const startOffset = 42.537;
 
-      let farthestEdge = widthOfTab + startOffset;
-      let circle1 = farthestEdge - (226.5918 - 221.51591);
-      let circle2 = farthestEdge - (226.5918 - 215.25391);
+      const farthestEdge = widthOfTab + startOffset;
+      const circle1 = farthestEdge - (226.5918 - 221.51591);
+      const circle2 = farthestEdge - (226.5918 - 215.25391);
 
-      let curvePath =
+      const curvePath =
         'M 53.876953 44.523438 C 47.614953 44.523438 42.537109 49.601281 42.537109 55.863281 L 42.537109 83.523438 L 42.958984 83.523438 L 42.958984 74.53125 C 42.958984 68.55425 47.821828 63.693359 53.798828 63.693359 ' +
         'L ' +
         farthestEdge +

--- a/WebTools/src/exportpdf/sheets.ts
+++ b/WebTools/src/exportpdf/sheets.ts
@@ -112,7 +112,7 @@ abstract class BasicSheet implements ICharacterSheet {
     if (construct.name == null || construct.name.length === 0) {
       return suffix + '.pdf';
     } else {
-      var escaped = construct.name
+      const escaped = construct.name
         .replace(/\\/g, '_')
         .replace(/\//g, '_')
         .replace(/\s/g, '_');
@@ -121,7 +121,7 @@ abstract class BasicSheet implements ICharacterSheet {
   }
 
   fillWeapons(form: PDFForm, construct: Construct) {
-    var weapons = construct.determineWeapons();
+    const weapons = construct.determineWeapons();
     weapons.forEach((w, i) => {
       this.fillWeapon(form, w, i + 1, construct);
     });
@@ -168,7 +168,7 @@ abstract class BasicSheet implements ICharacterSheet {
 
 abstract class BasicStarshipSheet extends BasicSheet {
   populateForm(form: PDFForm, construct: Construct) {
-    let starship = construct as Starship;
+    const starship = construct as Starship;
     this.fillField(form, 'Name', starship.name);
     if (starship.serviceYear != null) {
       this.fillField(form, 'Service Date', starship.serviceYear.toString());
@@ -189,7 +189,7 @@ abstract class BasicStarshipSheet extends BasicSheet {
       this.fillField(form, 'Mission Profile', missionProfile.localizedName);
     }
 
-    let power = starship.power;
+    const power = starship.power;
     if (power) {
       this.fillField(
         form,
@@ -239,13 +239,13 @@ abstract class BasicStarshipSheet extends BasicSheet {
     }
 
     let i = 1;
-    for (let t of talents) {
+    for (const t of talents) {
       this.fillField(form, 'Talent ' + i, t);
       i++;
     }
 
     i = 1;
-    for (let s of specialRules) {
+    for (const s of specialRules) {
       if (s === 'Mission Pod' && starship.missionPodModel != null) {
         this.fillField(
           form,
@@ -260,13 +260,13 @@ abstract class BasicStarshipSheet extends BasicSheet {
   }
 
   fillShields(form: PDFForm, shields: number) {
-    for (var i = 1; i <= 30; i++) {
+    for (let i = 1; i <= 30; i++) {
       this.fillCheckbox(form, 'Shields ' + i, i > shields);
     }
   }
 
   fillSystems(form: PDFForm, construct: Construct) {
-    let starship = construct as Starship;
+    const starship = construct as Starship;
     this.fillFieldWithNumber(
       form,
       'Engines',
@@ -300,7 +300,7 @@ abstract class BasicStarshipSheet extends BasicSheet {
   }
 
   fillDepartments(form: PDFForm, construct: Construct) {
-    let starship = construct as Starship;
+    const starship = construct as Starship;
     this.fillFieldWithNumber(
       form,
       'Command',
@@ -372,7 +372,7 @@ class CaptainsLogStarshipSheet extends BasicStarshipSheet {
 
   async populate(pdf: PDFDocument, construct: Construct) {
     await super.populate(pdf, construct);
-    let starship = construct as Starship;
+    const starship = construct as Starship;
 
     const { SheetOutlineOptions, SpaceframeOutline } = await import(
       /* webpackChunkName: 'spaceframeOutline' */ '../helpers/spaceframeOutlineHelper'
@@ -407,7 +407,7 @@ class StandardTngStarshipSheet extends BasicStarshipSheet {
 
   async populate(pdf: PDFDocument, construct: Construct) {
     await super.populate(pdf, construct);
-    let starship = construct as Starship;
+    const starship = construct as Starship;
 
     const { SheetOutlineOptions, SpaceframeOutline } = await import(
       /* webpackChunkName: 'spaceframeOutline' */ '../helpers/spaceframeOutlineHelper'
@@ -440,7 +440,7 @@ class StandardTosStarshipSheet extends BasicStarshipSheet {
 
   async populate(pdf: PDFDocument, construct: Construct) {
     await super.populate(pdf, construct);
-    let starship = construct as Starship;
+    const starship = construct as Starship;
 
     const { SheetOutlineOptions, SpaceframeOutline } = await import(
       /* webpackChunkName: 'spaceframeOutline' */ '../helpers/spaceframeOutlineHelper'
@@ -518,13 +518,13 @@ abstract class BasicShortCharacterSheet extends BasicSheet {
   }
 
   populateForm(form: PDFForm, construct: Construct) {
-    let character = construct as Character;
+    const character = construct as Character;
     this.fillName(form, character);
     this.fillField(form, 'Department', this.serializeAssignment(character));
     this.fillField(form, 'Purpose', this.serializeAssignment(character));
     this.fillRank(form, character);
     this.fillSpecies(form, character);
-    let traits = character.baseTraits;
+    const traits = character.baseTraits;
     if (character.additionalTraits) {
       traits.push(character.additionalTraits);
     }
@@ -565,8 +565,8 @@ abstract class BasicShortCharacterSheet extends BasicSheet {
   }
 
   fillStress(form: PDFForm, character: Character) {
-    var stress = character.stress;
-    for (var i = 1; i <= 30; i++) {
+    const stress = character.stress;
+    for (let i = 1; i <= 30; i++) {
       this.fillCheckbox(form, 'Stress ' + i, i > stress);
     }
   }
@@ -652,10 +652,10 @@ abstract class BasicShortCharacterSheet extends BasicSheet {
 
 abstract class BasicFullCharacterSheet extends BasicShortCharacterSheet {
   populateForm(form: PDFForm, construct: Construct) {
-    let character = construct as Character;
+    const character = construct as Character;
     super.populateForm(form, construct);
 
-    let upbringing = character.upbringingStep;
+    const upbringing = character.upbringingStep;
     if (upbringing != null) {
       this.fillUpbringing(form, character);
     }
@@ -699,7 +699,7 @@ abstract class BasicFullCharacterSheet extends BasicShortCharacterSheet {
   fillTalents(form: PDFForm, character: Character) {
     let i = 1;
     character.rankedTalents.forEach((t) => {
-      let talent = t.talentModel;
+      const talent = t.talentModel;
       if (talent && talent.maxRank > 1) {
         this.fillField(form, 'Talent ' + i, t.displayNameWithMultiple);
       } else {
@@ -863,7 +863,7 @@ class KlingonCharacterSheet extends BasicFullCharacterSheet {
   }
 
   formatNameWithoutPronouns(character) {
-    var result = character.name;
+    let result = character.name;
     if (character.lineage) {
       result += ', ' + character.lineage;
     }
@@ -942,10 +942,10 @@ class TwoPageTngCharacterSheet extends BaseTextCharacterSheet {
     // pdf-lib does awful things to empty multi-line fields
     // See: https://github.com/Hopding/pdf-lib/discussions/1196
     const helvetica = await pdf.embedFont(StandardFonts.Helvetica);
-    let form = pdf.getForm();
+    const form = pdf.getForm();
     form.getFields().forEach((f) => {
       if (f instanceof PDFTextField) {
-        let textField = f as PDFTextField;
+        const textField = f as PDFTextField;
         if (
           textField.isMultiline() &&
           (textField.getText() == null || textField.getText().length === 0)
@@ -964,7 +964,7 @@ class TwoPageTngCharacterSheet extends BaseTextCharacterSheet {
     const character = construct as Character;
 
     if (character.hasCareerEvents) {
-      let event1 = CareerEventsHelper.getCareerEvent(
+      const event1 = CareerEventsHelper.getCareerEvent(
         character.careerEvents[0]?.id,
         character.type,
         character.version,
@@ -974,7 +974,7 @@ class TwoPageTngCharacterSheet extends BaseTextCharacterSheet {
       }
 
       if (character.careerEvents && character.careerEvents.length > 1) {
-        let event2 = CareerEventsHelper.getCareerEvent(
+        const event2 = CareerEventsHelper.getCareerEvent(
           character.careerEvents[1]?.id,
           character.type,
           character.version,
@@ -1019,8 +1019,8 @@ class TwoPageTngCharacterSheet extends BaseTextCharacterSheet {
     const paragraphStyle = new FontSpecification(helvetica, 10);
     const symbolStyle = new FontSpecification(symbolFont, 10);
 
-    let column1 = new Column(369, 40, 774 - 40, 585 - 369);
-    let currentColumn = column1;
+    const column1 = new Column(369, 40, 774 - 40, 585 - 369);
+    const currentColumn = column1;
 
     await this.writeRoleAndTalents(
       page2,
@@ -1073,10 +1073,10 @@ class TwoPageTngLandscapeCharacterSheet extends BaseTextCharacterSheet {
 
     // pdf-lib does awful things to empty multi-line fields
     // See: https://github.com/Hopding/pdf-lib/discussions/1196
-    let form = pdf.getForm();
+    const form = pdf.getForm();
     form.getFields().forEach((f) => {
       if (f instanceof PDFTextField) {
-        let textField = f as PDFTextField;
+        const textField = f as PDFTextField;
         if (
           textField.isMultiline() &&
           (textField.getText() == null || textField.getText().length === 0)
@@ -1095,7 +1095,7 @@ class TwoPageTngLandscapeCharacterSheet extends BaseTextCharacterSheet {
     const paragraphStyle = new FontSpecification(helvetica, 8);
     const symbolStyle = new FontSpecification(symbolFont, 8);
 
-    let currentColumn = new Column(573, 45, 563 - 45, 757 - 573);
+    const currentColumn = new Column(573, 45, 563 - 45, 757 - 573);
 
     await this.writeRoleAndTalents(
       page,
@@ -1113,7 +1113,7 @@ class TwoPageTngLandscapeCharacterSheet extends BaseTextCharacterSheet {
 
     this.fillField(form, 'Pronouns', character.pronouns);
     if (character.hasCareerEvents) {
-      let event1 = CareerEventsHelper.getCareerEvent(
+      const event1 = CareerEventsHelper.getCareerEvent(
         character.careerEvents[0]?.id,
         character.type,
         character.version,
@@ -1123,7 +1123,7 @@ class TwoPageTngLandscapeCharacterSheet extends BaseTextCharacterSheet {
       }
 
       if (character.careerEvents && character.careerEvents.length > 1) {
-        let event2 = CareerEventsHelper.getCareerEvent(
+        const event2 = CareerEventsHelper.getCareerEvent(
           character.careerEvents[1]?.id,
           character.type,
           character.version,
@@ -1209,11 +1209,11 @@ class TwoPageKlingonCharacterSheet extends BaseTextCharacterSheet {
 
     // pdf-lib does awful things to empty multi-line fields
     // See: https://github.com/Hopding/pdf-lib/discussions/1196
-    let form = pdf.getForm();
+    const form = pdf.getForm();
     const helvetica = this.formFont;
     form.getFields().forEach((f) => {
       if (f instanceof PDFTextField) {
-        let textField = f as PDFTextField;
+        const textField = f as PDFTextField;
         if (
           textField.isMultiline() &&
           (textField.getText() == null || textField.getText().length === 0)
@@ -1232,7 +1232,7 @@ class TwoPageKlingonCharacterSheet extends BaseTextCharacterSheet {
     const character = construct as Character;
 
     if (character.hasCareerEvents) {
-      let event1 = CareerEventsHelper.getCareerEvent(
+      const event1 = CareerEventsHelper.getCareerEvent(
         character.careerEvents[0]?.id,
         character.type,
         character.version,
@@ -1242,7 +1242,7 @@ class TwoPageKlingonCharacterSheet extends BaseTextCharacterSheet {
       }
 
       if (character.careerEvents && character.careerEvents.length > 1) {
-        let event2 = CareerEventsHelper.getCareerEvent(
+        const event2 = CareerEventsHelper.getCareerEvent(
           character.careerEvents[1]?.id,
           character.type,
           character.version,
@@ -1274,7 +1274,7 @@ class TwoPageKlingonCharacterSheet extends BaseTextCharacterSheet {
   }
 
   formatNameWithoutPronouns(character) {
-    var result = character.name;
+    let result = character.name;
     if (character.lineage) {
       result += ', ' + character.lineage;
     }
@@ -1307,8 +1307,8 @@ class TwoPageKlingonCharacterSheet extends BaseTextCharacterSheet {
     const paragraphStyle = new FontSpecification(helvetica, 10);
     const symbolStyle = new FontSpecification(symbolFont, 10);
 
-    let column1 = new Column(318, 105, 702 - 105, 551 - 318);
-    let currentColumn = column1;
+    const column1 = new Column(318, 105, 702 - 105, 551 - 318);
+    const currentColumn = column1;
 
     await this.writeRoleAndTalents(
       page2,
@@ -1337,13 +1337,13 @@ class CaptainsLogCharacterSheet extends BasicFullCharacterSheet {
   }
 
   populateForm(form: PDFForm, construct: Construct): void {
-    let character = construct as Character;
+    const character = construct as Character;
     super.populateForm(form, construct);
 
     this.fillField(form, 'Pronouns', character.pronouns);
 
     if (character.hasCareerEvents) {
-      let event1 = CareerEventsHelper.getCareerEvent(
+      const event1 = CareerEventsHelper.getCareerEvent(
         character.careerEvents[0]?.id,
         character.type,
         character.version,
@@ -1353,7 +1353,7 @@ class CaptainsLogCharacterSheet extends BasicFullCharacterSheet {
       }
 
       if (character.careerEvents && character.careerEvents.length > 1) {
-        let event2 = CareerEventsHelper.getCareerEvent(
+        const event2 = CareerEventsHelper.getCareerEvent(
           character.careerEvents[1]?.id,
           character.type,
           character.version,

--- a/WebTools/src/exportpdf/spaderCard.ts
+++ b/WebTools/src/exportpdf/spaderCard.ts
@@ -129,7 +129,7 @@ export class SpaderCard {
     if (asset.name == null || asset.name.length === 0) {
       return 'spader-card.pdf';
     } else {
-      var escaped = asset.name
+      const escaped = asset.name
         .replace(/\\/g, '_')
         .replace(/\//g, '_')
         .replace(/\s/g, '_');

--- a/WebTools/src/exportpdf/standard2eCharacterSheet.ts
+++ b/WebTools/src/exportpdf/standard2eCharacterSheet.ts
@@ -95,7 +95,7 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
 
     await this.fillCharacterImage(pdf, construct as Character);
 
-    let character = construct as Character;
+    const character = construct as Character;
     let page2 = null;
     if (character.logEntries?.length) {
       const pdfBytes = await fetch(
@@ -109,11 +109,11 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
 
       if (page2) {
         for (let i = 0; i < Math.ceil(character.logEntries?.length / 18); i++) {
-          let tempPage = pdf.addPage(page2);
+          const tempPage = pdf.addPage(page2);
           const [newPage] = await pdf.copyPages(pdf, [pdf.getPageCount() - 1]);
           page2 = newPage;
 
-          let logEntries = character.logEntries;
+          const logEntries = character.logEntries;
           for (let j = i * 18; j < (i + 1) * 18 && j < logEntries.length; j++) {
             this.fillLogFields(logEntries[j], tempPage, j % 18);
           }
@@ -134,7 +134,7 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
 
   async fillCharacterImage(pdf: PDFDocument, character: Character) {
     if (character.token) {
-      let tokenBytes = await TokenHelper.renderToken(character.token);
+      const tokenBytes = await TokenHelper.renderToken(character.token);
       const image = await pdf.embedPng(tokenBytes);
       try {
         pdf.getForm().getButton('Image2_af_image').setImage(image);
@@ -146,21 +146,21 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
   }
 
   fillLogFields(logEntry: LogEntry, page: PDFPage, index: number) {
-    let height = 31;
-    let gap = 134 - 97 - height;
+    const height = 31;
+    const gap = 134 - 97 - height;
 
-    let y = 97 + index * (height + gap);
+    const y = 97 + index * (height + gap);
 
     if (logEntry.id != null) {
-      let column = new Column(32.9, y, height, 43.1);
-      let paragraph = new Paragraph(page, column, this.fonts);
+      const column = new Column(32.9, y, height, 43.1);
+      const paragraph = new Paragraph(page, column, this.fonts);
       paragraph.textAlignment = TextAlign.Centre;
       paragraph.append(logEntry.id, new FontOptions(9, FontType.Bold));
       paragraph.write();
     }
 
     if (logEntry.adventureTitle?.length) {
-      let column = new Column(81.4, y, height, 176);
+      const column = new Column(81.4, y, height, 176);
       let paragraph = new Paragraph(page, column, this.fonts);
       paragraph.append(
         logEntry.adventureTitle,
@@ -178,7 +178,7 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
     }
 
     if (logEntry.valuesUsed?.length || logEntry.directivesUsed?.length) {
-      let column = new Column(264.7, y, height, 92.2);
+      const column = new Column(264.7, y, height, 92.2);
       let paragraph = new Paragraph(page, column, this.fonts);
       logEntry.valuesUsed?.forEach((v) => {
         if (paragraph) {
@@ -197,8 +197,8 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
     }
 
     if (logEntry.notes?.length) {
-      let column = new Column(365.8, y, height, 212.7);
-      let paragraph = new Paragraph(page, column, this.fonts);
+      const column = new Column(365.8, y, height, 212.7);
+      const paragraph = new Paragraph(page, column, this.fonts);
       paragraph.append(logEntry.notes, new FontOptions(9));
       paragraph.write();
     }
@@ -300,7 +300,7 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
       new Column(360.6, 78.3, 15.8, 552.1 + 29.9 - 360.6),
     ];
 
-    let heading1 = new Paragraph(page, headerLabels[0], new FontLibrary());
+    const heading1 = new Paragraph(page, headerLabels[0], new FontLibrary());
     heading1.textAlignment = TextAlign.Centre;
     heading1.append(
       i18next.t('Sheet.text.log.entryNumber').toLocaleUpperCase(),
@@ -309,7 +309,7 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
     );
     heading1.write();
 
-    let heading2 = new Paragraph(page, headerLabels[1], new FontLibrary());
+    const heading2 = new Paragraph(page, headerLabels[1], new FontLibrary());
     heading2.textAlignment = TextAlign.Centre;
     heading2.append(
       i18next.t('Sheet.text.log.adventureTitle').toLocaleUpperCase(),
@@ -318,7 +318,7 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
     );
     heading2.write();
 
-    let heading3 = new Paragraph(page, headerLabels[2], new FontLibrary());
+    const heading3 = new Paragraph(page, headerLabels[2], new FontLibrary());
     heading3.textAlignment = TextAlign.Centre;
     heading3.append(
       i18next.t('Sheet.text.log.valuesOrDirectivesUsed').toLocaleUpperCase(),
@@ -327,7 +327,7 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
     );
     heading3.write();
 
-    let heading4 = new Paragraph(page, headerLabels[3], new FontLibrary());
+    const heading4 = new Paragraph(page, headerLabels[3], new FontLibrary());
     heading4.textAlignment = TextAlign.Centre;
     heading4.append(
       i18next.t('Sheet.text.log.notes').toLocaleUpperCase(),
@@ -360,13 +360,13 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
     const table = this.subTitleLocations;
     Object.keys(table).forEach((key) => {
       let fontSize = originalFontSize;
-      let block = table[key];
+      const block = table[key];
       if (key === 'Construct.other.departments' && construct.version === 1) {
         key = 'Construct.other.disciplines';
       }
 
       const originalText = i18next.t(key).toLocaleUpperCase();
-      let text = originalText;
+      const text = originalText;
       let width = this.headingFont.widthOfTextAtSize(text, fontSize);
       while (width > block.width) {
         fontSize -= 0.25;
@@ -411,8 +411,10 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
 
     text += suffix;
 
-    let height = this.headingFont.heightAtSize(fontSize, { descender: false });
-    let offset = Math.max(0, block.height - height) / 2;
+    const height = this.headingFont.heightAtSize(fontSize, {
+      descender: false,
+    });
+    const offset = Math.max(0, block.height - height) / 2;
 
     page.drawText(text, {
       x: rightJustify ? block.end.x - width - 2 : block.start.x,
@@ -447,7 +449,7 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
     page: PDFPage,
     colour: SimpleColor = Standard2eCharacterSheet.labelColour,
   ) {
-    let fontSize = this.determineIdealFontWidthForVariableWidth(
+    const fontSize = this.determineIdealFontWidthForVariableWidth(
       Object.keys(this.detailLabels).map((key) =>
         i18next.t(key).toLocaleUpperCase(),
       ),
@@ -457,7 +459,7 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
     );
 
     Object.keys(this.detailLabels).forEach((key) => {
-      let block = this.detailLabels[key];
+      const block = this.detailLabels[key];
       const originalText = i18next.t(key).toLocaleUpperCase();
       this.writeLabel(page, originalText, fontSize, block, colour);
     });
@@ -484,12 +486,12 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
       text += '...';
     }
 
-    let block = TextBlock.create(
+    const block = TextBlock.create(
       text,
       new FontSpecification(this.headingFont, fontSize),
       false,
     );
-    let y = column.end.y - 1 - (column.height - block.height) / 2;
+    const y = column.end.y - 1 - (column.height - block.height) / 2;
 
     page.drawText(text, {
       x: column.start.x,
@@ -521,12 +523,12 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
       text += '...';
     }
 
-    let block = TextBlock.create(
+    const block = TextBlock.create(
       text,
       new FontSpecification(this.headingFont, fontSize),
       false,
     );
-    let y = column.end.y - 1 - (column.height - block.height) / 2;
+    const y = column.end.y - 1 - (column.height - block.height) / 2;
 
     page.drawText(text, {
       x: column.start.x,
@@ -552,7 +554,7 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
   populateForm(form: PDFForm, character: Character) {
     form.getFields().forEach((f) => {
       if (f instanceof PDFTextField) {
-        let textField = f as PDFTextField;
+        const textField = f as PDFTextField;
         if (
           textField.isMultiline() &&
           (textField.getText() == null || textField.getText().length === 0)
@@ -589,8 +591,8 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
     character: Character,
     colour: SimpleColor = Standard2eCharacterSheet.labelColour,
   ) {
-    let form = pdf.getForm();
-    let { height, width } = this.pillSize;
+    const form = pdf.getForm();
+    const { height, width } = this.pillSize;
     this.stressPillLocations.forEach((pill, i) => {
       if (i >= character.stress) {
         page.moveTo(pill.x, page.getHeight() - pill.y);
@@ -600,7 +602,7 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
           borderWidth: 1,
         });
       } else {
-        let checkbox = form.createCheckBox('Stress ' + (i + 1));
+        const checkbox = form.createCheckBox('Stress ' + (i + 1));
         checkbox.addToPage(page, {
           x: pill.x + (width - 9.5) / 2,
           y: page.getHeight() - pill.y - (height - 3),
@@ -667,7 +669,7 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
     const describer = new WeaponDescriber(construct.version, true);
 
     if (construct instanceof Character) {
-      let attacks = construct
+      const attacks = construct
         .determineWeapons()
         .map(
           (w) =>

--- a/WebTools/src/exportpdf/standard2eStarshipSheet.ts
+++ b/WebTools/src/exportpdf/standard2eStarshipSheet.ts
@@ -159,7 +159,7 @@ export class Standard2eStarshipSheet extends BasicGeneratedSheet {
   populateForm(page: PDFPage, form: PDFForm, starship: Starship) {
     form.getFields().forEach((f) => {
       if (f instanceof PDFTextField) {
-        let textField = f as PDFTextField;
+        const textField = f as PDFTextField;
         if (
           textField.isMultiline() &&
           (textField.getText() == null || textField.getText().length === 0)
@@ -256,7 +256,7 @@ export class Standard2eStarshipSheet extends BasicGeneratedSheet {
       new XYLocation(233, 316.9),
       new XYLocation(242.6, 316.9),
     ].forEach((c, i) => {
-      let checkbox = form.createCheckBox('Breach ' + (i + 1));
+      const checkbox = form.createCheckBox('Breach ' + (i + 1));
       checkbox.addToPage(page, {
         x: c.x + 1,
         y: page.getHeight() - c.y - (height - 0.5),
@@ -432,8 +432,8 @@ export class Standard2eStarshipSheet extends BasicGeneratedSheet {
     column: Column,
     colour: SimpleColor,
   ) {
-    let talents = assembleStarshipTalents(starship, false);
-    let writer = new TalentWriter(
+    const talents = assembleStarshipTalents(starship, false);
+    const writer = new TalentWriter(
       page,
       this.fonts,
       starship.version,
@@ -449,8 +449,8 @@ export class Standard2eStarshipSheet extends BasicGeneratedSheet {
     column: Column,
     colour: SimpleColor,
   ) {
-    let talents = assembleStarshipTalents(starship, true);
-    let writer = new TalentWriter(
+    const talents = assembleStarshipTalents(starship, true);
+    const writer = new TalentWriter(
       page,
       this.fonts,
       starship.version,
@@ -483,12 +483,12 @@ export class Standard2eStarshipSheet extends BasicGeneratedSheet {
       text += '...';
     }
 
-    let block = TextBlock.create(
+    const block = TextBlock.create(
       text,
       new FontSpecification(this.headingFont, fontSize),
       false,
     );
-    let y = column.end.y - 1 - (column.height - block.height) / 2;
+    const y = column.end.y - 1 - (column.height - block.height) / 2;
 
     page.drawText(text, {
       x: column.start.x,
@@ -556,8 +556,8 @@ export class Standard2eStarshipSheet extends BasicGeneratedSheet {
     starship: Starship,
     colour: SimpleColor = blueColour2e,
   ) {
-    let form = pdf.getForm();
-    let { height, width } = this.pillSize;
+    const form = pdf.getForm();
+    const { height, width } = this.pillSize;
     this.shieldPillLocations.forEach((pill, i) => {
       if (i >= starship.shields) {
         page.moveTo(pill.x, page.getHeight() - pill.y);
@@ -567,7 +567,7 @@ export class Standard2eStarshipSheet extends BasicGeneratedSheet {
           borderWidth: 1,
         });
       } else {
-        let checkbox = form.createCheckBox('Shield ' + (i + 1));
+        const checkbox = form.createCheckBox('Shield ' + (i + 1));
         checkbox.addToPage(page, {
           x: pill.x + (width - 9.5) / 2,
           y: page.getHeight() - pill.y - (height - 3),
@@ -584,7 +584,7 @@ export class Standard2eStarshipSheet extends BasicGeneratedSheet {
     const describer = new WeaponDescriber(construct.version, true);
 
     if (construct instanceof Starship) {
-      let attacks = construct
+      const attacks = construct
         .determineWeapons()
         .map(
           (w) =>

--- a/WebTools/src/exportpdf/talentWriter.ts
+++ b/WebTools/src/exportpdf/talentWriter.ts
@@ -91,7 +91,7 @@ export class TalentWriter {
     indent: number = 0,
     bulletWriter: (paragraph?: Paragraph) => void = (p) => {},
   ) {
-    let paragraphs = await this.writeTalentsInternal(
+    const paragraphs = await this.writeTalentsInternal(
       talents,
       column,
       fontSize,
@@ -102,9 +102,9 @@ export class TalentWriter {
     paragraphs.forEach((p) => p.write());
 
     if (paragraphs.length) {
-      let last = paragraphs.filter((p) => p.lines?.length).slice(-1)[0];
+      const last = paragraphs.filter((p) => p.lines?.length).slice(-1)[0];
       if (last) {
-        let bottom = last.bottom;
+        const bottom = last.bottom;
         return last.endColumn.bottomAfter(bottom.y - last.endColumn.start.y);
       } else {
         return column;
@@ -122,7 +122,7 @@ export class TalentWriter {
     indent: number = 0,
     bulletWriter: (paragraph?: Paragraph) => void = (p) => {},
   ) {
-    let paragraphs = await this.writeTalentsInternal(
+    const paragraphs = await this.writeTalentsInternal(
       talents,
       column,
       fontSize,
@@ -133,7 +133,7 @@ export class TalentWriter {
     paragraphs.forEach((p) => p.write());
 
     if (paragraphs.length) {
-      let last = paragraphs.filter((p) => p.lines?.length).slice(-1)[0];
+      const last = paragraphs.filter((p) => p.lines?.length).slice(-1)[0];
       if (last) {
         return last.nextArea(this.page);
       } else {
@@ -152,7 +152,7 @@ export class TalentWriter {
     indent: number = 0,
     bulletWriter: (paragraph?: Paragraph) => void = (p) => {},
   ) {
-    let paragraphs: Paragraph[] = [];
+    const paragraphs: Paragraph[] = [];
     let paragraph = new Paragraph(this.page, column, this.fonts);
     paragraph.indent(indent);
     paragraphs.push(paragraph);
@@ -251,7 +251,7 @@ export class TalentWriter {
             talentName = talentName.toLocaleUpperCase();
           }
           if (talent && talent.talent.maxRank > 1) {
-            let rank = talent.rank;
+            const rank = talent.rank;
             talentName = i18next.t('Talent.text.rank', {
               talentName: talentName,
               rank: rank,
@@ -259,7 +259,7 @@ export class TalentWriter {
           }
           if (talent.talent.isXQualified) {
             if (talent.x != null) {
-              let xLocation = talentName.lastIndexOf(' X');
+              const xLocation = talentName.lastIndexOf(' X');
               talentName =
                 talentName.substring(0, xLocation + 1) +
                 talent.x +
@@ -277,7 +277,7 @@ export class TalentWriter {
             this.headingColour,
           );
 
-          let descriptionParagraphs = description.split('\n');
+          const descriptionParagraphs = description.split('\n');
           descriptionParagraphs.forEach((p, i) => {
             if (i > 0) {
               paragraph = paragraph?.nextParagraph();
@@ -356,7 +356,7 @@ export class TalentWriter {
             talent.talent.name === TALENT_NAME_ADDITIONAL_PROPULSION_SYSTEM &&
             talent.selection != null
           ) {
-            let propulsion = PropulsionSystemModel.getByType(
+            const propulsion = PropulsionSystemModel.getByType(
               talent.selection as PropulsionSystemType,
             );
             paragraph = paragraph?.nextParagraph(0);

--- a/WebTools/src/exportpdf/textBlock.ts
+++ b/WebTools/src/exportpdf/textBlock.ts
@@ -26,7 +26,7 @@ export class TextBlock {
       weight = descender;
     }
 
-    let textBlock = new TextBlock();
+    const textBlock = new TextBlock();
     textBlock.text = text;
     const textWidth = fontSpec.font.widthOfTextAtSize(text, fontSpec.size);
     const textHeight =

--- a/WebTools/src/exportpdf/textTokenizer.ts
+++ b/WebTools/src/exportpdf/textTokenizer.ts
@@ -8,10 +8,10 @@ const indexOfToken = (text: string, token: string, start: number) => {
 };
 
 export const textTokenizer = (text: string) => {
-  let result = [];
+  const result = [];
   let start = 0;
   while (start < text?.length) {
-    let indices = [];
+    const indices = [];
     indices.push(indexOfToken(text, CHALLENGE_DICE_NOTATION, start));
     indices.push(indexOfToken(text, '_', start));
     indices.push(indexOfToken(text, '**', start));
@@ -28,7 +28,7 @@ export const textTokenizer = (text: string) => {
       }
     });
 
-    let index = indices[0];
+    const index = indices[0];
 
     if (index.index >= start) {
       if (index.index > start) {

--- a/WebTools/src/exportpdf/tokenHelper.ts
+++ b/WebTools/src/exportpdf/tokenHelper.ts
@@ -17,7 +17,7 @@ export class TokenHelper {
   }
 
   static async createTokenSvg(tokenConfig: TokenConfig) {
-    let token = tokenConfig.token;
+    const token = tokenConfig.token;
     const { TokenSvgBuilder } = await import(
       /* webpackChunkName: 'token' */ '../token/tokenSvgBuilder'
     );
@@ -31,7 +31,7 @@ export class TokenHelper {
   static async renderToken(tokenConfig: TokenConfig) {
     const svg = await TokenHelper.createTokenSvg(tokenConfig);
 
-    let bytes = await TokenHelper.toPngBytes({
+    const bytes = await TokenHelper.toPngBytes({
       width: 800,
       height: 800,
       svg: svg,

--- a/WebTools/src/exportpdf/weaponDescriber.ts
+++ b/WebTools/src/exportpdf/weaponDescriber.ts
@@ -44,7 +44,7 @@ export class WeaponDescriber {
     }
     const dice = diceProvider.getDiceForWeapon(weapon);
 
-    let text =
+    const text =
       type +
       ', ' +
       injuryType +

--- a/WebTools/src/helpers/alliedMilitary.ts
+++ b/WebTools/src/helpers/alliedMilitary.ts
@@ -155,7 +155,7 @@ class AllyHelper {
   }
 
   findOption(type: AlliedMilitaryType) {
-    let temp = this.options.filter((o) => o.type === type);
+    const temp = this.options.filter((o) => o.type === type);
     return temp ? temp[0] : null;
   }
 

--- a/WebTools/src/helpers/attributes.ts
+++ b/WebTools/src/helpers/attributes.ts
@@ -12,7 +12,7 @@ export class Attributes {
     return Attribute[attr];
   }
   getAttributeByName(attr: string) {
-    let options = this.getAllAttributes().filter(
+    const options = this.getAllAttributes().filter(
       (a) =>
         this.getAttributeName(a).toLocaleLowerCase() ===
         attr.toLocaleLowerCase(),

--- a/WebTools/src/helpers/borgImplant.ts
+++ b/WebTools/src/helpers/borgImplant.ts
@@ -28,13 +28,13 @@ export class Implant {
 
   get localizedName() {
     const key = makeKey('Implant.', BorgImplantType[this.type]);
-    let result = i18next.t(key);
+    const result = i18next.t(key);
     return result === key ? this.name : result;
   }
 
   get localizedName2e() {
     const key = makeKey('Implant.', BorgImplantType[this.type], '.2e');
-    let result = i18next.t(key);
+    const result = i18next.t(key);
     return result === key ? this.localizedName : result;
   }
 
@@ -48,7 +48,7 @@ export class Implant {
       BorgImplantType[this.type],
       '.description2e',
     );
-    let result = i18next.t(key);
+    const result = i18next.t(key);
     return result === key ? this.localizedDescription : result;
   }
 }
@@ -130,7 +130,7 @@ export class BorgImplants {
   }
 
   getImplantByType(type: BorgImplantType): Implant | undefined {
-    let i = this.implants.filter((i) => i.type === type);
+    const i = this.implants.filter((i) => i.type === type);
     return i.length > 0 ? i[0] : undefined;
   }
 }

--- a/WebTools/src/helpers/careerEvents.ts
+++ b/WebTools/src/helpers/careerEvents.ts
@@ -61,25 +61,25 @@ export class CareerEventModel {
 
   get localizedName() {
     const key = 'CareerEvent.' + this.prefix + this.roll + '.name';
-    let result = i18next.t(key);
+    const result = i18next.t(key);
     return result === key ? this.name : result;
   }
 
   get localizedDescription() {
     const key = 'CareerEvent.' + this.prefix + this.roll + '.description';
-    let result = i18next.t(key);
+    const result = i18next.t(key);
     return result === key ? this.description : result;
   }
 
   get localizedFocusSuggestion() {
     const key = 'CareerEvent.' + this.prefix + this.roll + '.focusSuggestion';
-    let result = i18next.t(key);
+    const result = i18next.t(key);
     return result === key ? this.focusSuggestions : result;
   }
 
   get localizedTraitDescription() {
     const key = 'CareerEvent.' + this.prefix + this.roll + '.traitDescription';
-    let result = i18next.t(key);
+    const result = i18next.t(key);
     return result === key ? this.traitDescription : result;
   }
 
@@ -92,7 +92,7 @@ export class CareerEventModel {
   }
 
   get sources() {
-    let result: Source[] = [];
+    const result: Source[] = [];
     this.prerequisites
       .filter((p) => p instanceof SourceCharacterPrerequisite)
       .map((s) => s as SourceCharacterPrerequisite)
@@ -1539,7 +1539,7 @@ class CareerEvents {
   ];
 
   getSoloCareerEvents() {
-    let result = [];
+    const result = [];
     for (let i = 0; i < 20; i++) {
       result.push(this._events[i]);
     }
@@ -1557,7 +1557,7 @@ class CareerEvents {
   }
 
   getCareerEventsIncludingUnofficial(character: Character) {
-    let list = this.getCareerEvents(character);
+    const list = this.getCareerEvents(character);
     this._unofficialEvents.forEach((e) => list.push(e));
     return list.sort((e1, e2) => {
       return e1.localizedName.localeCompare(e2.localizedName);
@@ -1571,7 +1571,7 @@ class CareerEvents {
   ): CareerEventModel {
     let event = undefined;
 
-    let list = isKlingonWarrior1e(type, version)
+    const list = isKlingonWarrior1e(type, version)
       ? this._klingonEvents
       : this._events;
     list.forEach((ev) => {
@@ -1592,10 +1592,10 @@ class CareerEvents {
 
   generateEvent(character: Character): CareerEventModel {
     if (character.version === 1 || isKlingonWarriorType(character.type)) {
-      let roll = Math.floor(Math.random() * 20) + 1;
+      const roll = Math.floor(Math.random() * 20) + 1;
       let event = undefined;
 
-      let list = isKlingonWarrior1e(character.type, character.version)
+      const list = isKlingonWarrior1e(character.type, character.version)
         ? this._klingonEvents
         : this._events;
       list.forEach((ev) => {
@@ -1606,8 +1606,8 @@ class CareerEvents {
       });
       return event;
     } else {
-      let events = this.getCareerEvents(character);
-      let roll = Math.floor(Math.random() * events.length);
+      const events = this.getCareerEvents(character);
+      const roll = Math.floor(Math.random() * events.length);
       return events[roll];
     }
   }

--- a/WebTools/src/helpers/careers.ts
+++ b/WebTools/src/helpers/careers.ts
@@ -139,9 +139,9 @@ export class CareersHelper {
     ) {
       return this.getSoloCareerLengths();
     } else {
-      let careers: CareerModel[] = [];
-      let list = this.getList(character.type);
-      for (let career of list) {
+      const careers: CareerModel[] = [];
+      const list = this.getList(character.type);
+      for (const career of list) {
         careers.push(career);
       }
 
@@ -150,7 +150,7 @@ export class CareersHelper {
   }
 
   getSoloCareerLength(careerLength: Career) {
-    let result = this._soloCareerLengths.filter((c) => c.id === careerLength);
+    const result = this._soloCareerLengths.filter((c) => c.id === careerLength);
     return result ? result[0] : undefined;
   }
 

--- a/WebTools/src/helpers/characterPrerequisite.ts
+++ b/WebTools/src/helpers/characterPrerequisite.ts
@@ -111,7 +111,7 @@ export class AnyOfCharacterPrerequisite implements ICharacterPrerequisite {
     if (this._prequisites.length === 0) {
       return true;
     } else {
-      var result = false;
+      let result = false;
       this._prequisites.forEach((req) => {
         result = result || req.isPrerequisiteFulfilled(character);
       });

--- a/WebTools/src/helpers/department.ts
+++ b/WebTools/src/helpers/department.ts
@@ -33,7 +33,7 @@ export class DepartmentsHelper {
   }
 
   getDepartmentByName(name: string): Department | undefined {
-    for (let d of this.getDepartments()) {
+    for (const d of this.getDepartments()) {
       const department = Department[d];
       if (department.toLocaleLowerCase() === name.toLocaleLowerCase()) {
         return d;

--- a/WebTools/src/helpers/diceRoller.ts
+++ b/WebTools/src/helpers/diceRoller.ts
@@ -24,15 +24,15 @@ export class Roller {
       numDice = 2;
     }
 
-    var result = new DiceRollResult();
+    const result = new DiceRollResult();
     result.targetValue = targetValue;
     result.numDice = numDice;
     result.difficulty = difficulty;
     result.successes = 0;
     result.hasRepercusions = false;
 
-    for (var i = 0; i < numDice; i++) {
-      var roll = Math.floor(Math.random() * 20) + 1;
+    for (let i = 0; i < numDice; i++) {
+      const roll = Math.floor(Math.random() * 20) + 1;
       if (roll <= targetValue) {
         result.successes++;
 
@@ -50,13 +50,13 @@ export class Roller {
   }
 
   rollSpecial(numDice: number, bonus: number) {
-    var result = new SpecialDiceRollResult();
+    const result = new SpecialDiceRollResult();
     result.numDice = numDice;
     result.bonus = bonus;
     result.hits = 0;
     result.special = 0;
 
-    for (var i = 0; i < numDice; i++) {
+    for (let i = 0; i < numDice; i++) {
       switch (Math.floor(Math.random() * 6) + 1) {
         case 1:
           result.hits++;

--- a/WebTools/src/helpers/environments.ts
+++ b/WebTools/src/helpers/environments.ts
@@ -375,14 +375,14 @@ class Environments {
   };
 
   getEnvironmentOptions(construct: Construct) {
-    let result = [];
+    const result = [];
     if (construct.stereotype === Stereotype.SoloCharacter) {
       result.push(...Object.values(this._environments));
     } else {
-      let list = isKlingonWarrior1e(construct.type, construct.version)
+      const list = isKlingonWarrior1e(construct.type, construct.version)
         ? this._klingonEnvironments
         : this._environments;
-      for (let environment in list) {
+      for (const environment in list) {
         result.push(list[environment]);
       }
       if (
@@ -401,11 +401,11 @@ class Environments {
 
   getEnvironments(type: CharacterType) {
     let environments: EnvironmentModel[] = [];
-    let environmentList = isKlingonWarriorType(type)
+    const environmentList = isKlingonWarriorType(type)
       ? this._klingonEnvironments
       : this._environments;
-    for (let environment in environmentList) {
-      let env = environmentList[environment];
+    for (const environment in environmentList) {
+      const env = environmentList[environment];
       if (env.id !== Environment.AnotherSpeciesWorld) {
         environments.push(env);
       }
@@ -436,8 +436,8 @@ class Environments {
   }
 
   getEnvironment(env: Environment, construct: Construct) {
-    let environmentList = this.getEnvironmentOptions(construct);
-    let matches = environmentList.filter((e) => e.id === env);
+    const environmentList = this.getEnvironmentOptions(construct);
+    const matches = environmentList.filter((e) => e.id === env);
     return matches?.length ? matches[0] : undefined;
   }
 
@@ -446,7 +446,7 @@ class Environments {
     type: CharacterType,
     version: number,
   ) {
-    let list = isKlingonWarrior1e(type, version)
+    const list = isKlingonWarrior1e(type, version)
       ? Object.values(this._klingonEnvironments)
       : Object.values(this._environments);
     let filtered = list.filter((e) => Environment[e.id] === typeName);
@@ -511,7 +511,7 @@ class Environments {
   }
 
   generateAlternateEnvironment() {
-    let roll = Math.floor(Math.random() * 6);
+    const roll = Math.floor(Math.random() * 6);
     return roll + 6;
   }
 }

--- a/WebTools/src/helpers/equipment.ts
+++ b/WebTools/src/helpers/equipment.ts
@@ -42,8 +42,8 @@ export class EquipmentModel {
     if (this.type === EquipmentType.Other) {
       return this.name;
     } else {
-      let key = makeKey('Equipment.', EquipmentType[this.type]);
-      let result = i18next.t(key);
+      const key = makeKey('Equipment.', EquipmentType[this.type]);
+      const result = i18next.t(key);
       return result === key ? this.name : result;
     }
   }
@@ -119,12 +119,12 @@ export class EquipmentHelper {
   ];
 
   public findByType(type: EquipmentType): EquipmentModel | undefined {
-    let results = this.items.filter((e) => e.type === type);
+    const results = this.items.filter((e) => e.type === type);
     return results.length > 0 ? results[0] : undefined;
   }
 
   public findByTypeName(type: string): EquipmentModel | undefined {
-    let results = this.items.filter((e) => EquipmentType[e.type] === type);
+    const results = this.items.filter((e) => EquipmentType[e.type] === type);
     return results.length > 0 ? results[0] : undefined;
   }
 }

--- a/WebTools/src/helpers/eras.ts
+++ b/WebTools/src/helpers/eras.ts
@@ -83,9 +83,9 @@ class Eras {
   }
 
   getEras() {
-    let eras: EraModel[] = [];
-    for (let era in this._eras) {
-      let er = this._eras[era];
+    const eras: EraModel[] = [];
+    for (const era in this._eras) {
+      const er = this._eras[era];
       eras.push(er);
     }
 
@@ -96,7 +96,7 @@ class Eras {
     return this._eras[era];
   }
   getEraByName(name: string): Era | null {
-    let results = Object.keys(this._eras)
+    const results = Object.keys(this._eras)
       .map((e) => this._eras[e].id)
       .filter((e) => Era[e] === name);
     if (results.length === 1) {

--- a/WebTools/src/helpers/governments.ts
+++ b/WebTools/src/helpers/governments.ts
@@ -96,12 +96,12 @@ class _Governments {
   }
 
   findOption(type: Polity) {
-    let temp = this.options.filter((o) => o.type === type);
+    const temp = this.options.filter((o) => o.type === type);
     return temp ? temp[0] : null;
   }
 
   findTypeByName(name: string) {
-    let results = this.options.filter((o) => Polity[o.type] === name);
+    const results = this.options.filter((o) => Polity[o.type] === name);
     return results.length === 0 ? undefined : results[0].type;
   }
 }

--- a/WebTools/src/helpers/marshaller.ts
+++ b/WebTools/src/helpers/marshaller.ts
@@ -199,7 +199,7 @@ class Marshaller {
   }
 
   encodeStation(station: Station) {
-    let sheet = {
+    const sheet = {
       stereotype: 'station',
       type: CharacterType[station.type],
       era: Era[station.era],
@@ -208,7 +208,7 @@ class Marshaller {
     };
 
     if (station.missionProfileStep?.type) {
-      let temp = {
+      const temp = {
         name: MissionProfile[station.missionProfileStep?.type],
       };
 
@@ -257,7 +257,7 @@ class Marshaller {
   }
 
   encodeCreature(creature: Creature) {
-    let sheet = {
+    const sheet = {
       stereotype: 'creature',
       type: CharacterType[creature.type],
       era: Era[creature.era],
@@ -301,7 +301,7 @@ class Marshaller {
 
     if (creature.locomotion?.length) {
       sheet['locomotion'] = creature.locomotion.map((l) => {
-        let result = {
+        const result = {
           type: LocomotionType[l.type.id],
         };
         if (l.count != null) {
@@ -343,7 +343,7 @@ class Marshaller {
   }
 
   encodeAsset(asset: Asset) {
-    let sheet = {
+    const sheet = {
       stereotype: 'asset',
       type: AssetType[asset.type],
       name: asset.name,
@@ -376,7 +376,7 @@ class Marshaller {
     stereotype: string,
     character: Character,
   ) {
-    let sheet = {
+    const sheet = {
       stereotype: stereotype,
       type: CharacterType[character.type],
       era: Era[character.era],
@@ -447,7 +447,7 @@ class Marshaller {
       };
     }
 
-    let additionalTraits = this.parseTraits(character.additionalTraits);
+    const additionalTraits = this.parseTraits(character.additionalTraits);
     if (additionalTraits?.length) {
       sheet['traits'] = additionalTraits;
     }
@@ -457,12 +457,12 @@ class Marshaller {
 
     if (character.stereotype === Stereotype.Npc) {
       if (character.npcGenerationStep) {
-        let block = {};
+        const block = {};
         if (character.npcGenerationStep.values.length) {
           block['values'] = character.values;
         }
 
-        let talents = this.toTalentList(character.npcGenerationStep.talents);
+        const talents = this.toTalentList(character.npcGenerationStep.talents);
         if (talents?.length) {
           block['talents'] = talents;
         }
@@ -528,7 +528,7 @@ class Marshaller {
 
   encodeToken(tokenConfig: TokenConfig) {
     if (tokenConfig?.token) {
-      let token = {
+      const token = {
         primarySpecies: Species[tokenConfig.token.primarySpecies],
         speciesOption: SpeciesOption[tokenConfig.token.speciesOption],
         uniformEra: UniformEra[tokenConfig.token.uniformEra],
@@ -574,8 +574,8 @@ class Marshaller {
   }
 
   decodeToken(json: any) {
-    let tokenJson = json['token'];
-    let token = TokenModel.createDefault();
+    const tokenJson = json['token'];
+    const token = TokenModel.createDefault();
     token.primarySpecies = SpeciesHelper.getSpeciesTypeByName(
       tokenJson['primarySpecies'],
     );
@@ -649,8 +649,8 @@ class Marshaller {
 
   encodeStarshipImprovements(starship: Starship) {
     if (starship.advancementSteps?.length) {
-      let json = starship.advancementSteps?.map((i) => {
-        let result = { type: 'advancement' };
+      const json = starship.advancementSteps?.map((i) => {
+        const result = { type: 'advancement' };
         result['choice'] = StarshipAdvancementChoice[i.choice];
         if (i.choice === StarshipAdvancementChoice.Department) {
           result['value'] = Department[i.value as Department];
@@ -680,9 +680,9 @@ class Marshaller {
   }
 
   decodeLogEntry(j: any): LogEntry {
-    let id = j.id;
+    const id = j.id;
 
-    let entry = new LogEntry(id);
+    const entry = new LogEntry(id);
     entry.adventureTitle = j.adventureTitle;
     entry.missionDescription = j.missionDescription;
     entry.notes = j.notes;
@@ -692,9 +692,9 @@ class Marshaller {
     }
     if (j.valuesUsed) {
       entry.valuesUsed = j.valuesUsed.map((json) => {
-        let value = json.value;
-        let newValue = json.newValue;
-        let type = ValueUseTypeModel.findTypeByTypeName(json.useType);
+        const value = json.value;
+        const newValue = json.newValue;
+        const type = ValueUseTypeModel.findTypeByTypeName(json.useType);
         return new LogValueEntry(value, type, newValue);
       });
     }
@@ -725,9 +725,9 @@ class Marshaller {
 
   encodeImprovements(character: Character) {
     if (character.improvements?.length) {
-      let json = character.improvements?.map((i) => {
+      const json = character.improvements?.map((i) => {
         if (i instanceof CharacterAdvancementStep) {
-          let result = { type: 'advancement' };
+          const result = { type: 'advancement' };
           result['choice'] = CharacterAdvancementChoice[i.choice];
           if (
             i.choice === CharacterAdvancementChoice.Focus ||
@@ -763,7 +763,7 @@ class Marshaller {
           }
           return result;
         } else if (i instanceof Promotion) {
-          let result = { type: 'promotion' };
+          const result = { type: 'promotion' };
           result['rank'] = {
             name: i.rank.name,
             id: i.rank.id,
@@ -771,7 +771,7 @@ class Marshaller {
           result['modificationType'] = ModificationType[i.type];
           return result;
         } else if (i instanceof ReputationChangeStep) {
-          let result = { type: 'reputation' };
+          const result = { type: 'reputation' };
           result['reputation'] = i.reputation;
           return result;
         } else if (i instanceof LogEntry) {
@@ -804,8 +804,8 @@ class Marshaller {
       character.typeDetails != null &&
       character.typeDetails instanceof AlliedMilitaryDetails
     ) {
-      let typeDetails = character.typeDetails as AlliedMilitaryDetails;
-      let details = {
+      const typeDetails = character.typeDetails as AlliedMilitaryDetails;
+      const details = {
         type: AlliedMilitaryType[typeDetails.alliedMilitary.type],
         typeName: typeDetails.alliedMilitary.name,
         name: typeDetails.name,
@@ -816,8 +816,8 @@ class Marshaller {
       character.typeDetails != null &&
       character.typeDetails instanceof GovernmentDetails
     ) {
-      let typeDetails = character.typeDetails as GovernmentDetails;
-      let details = {
+      const typeDetails = character.typeDetails as GovernmentDetails;
+      const details = {
         type: Polity[typeDetails.government.type],
         typeName: typeDetails.government.name,
         name: typeDetails.name,
@@ -828,8 +828,8 @@ class Marshaller {
       character.typeDetails != null &&
       character.typeDetails instanceof OtherDetails
     ) {
-      let typeDetails = character.typeDetails as OtherDetails;
-      let details = {
+      const typeDetails = character.typeDetails as OtherDetails;
+      const details = {
         name: typeDetails.name,
       };
       return details;
@@ -839,7 +839,7 @@ class Marshaller {
   }
 
   private encodeFullCharacterAsJson(character: Character, stereotype: string) {
-    let sheet = {
+    const sheet = {
       stereotype: stereotype,
       type: CharacterType[character.type],
       era: Era[character.era],
@@ -848,7 +848,7 @@ class Marshaller {
     };
 
     if (character.upbringingStep) {
-      let upbringing = {
+      const upbringing = {
         id: EarlyOutlook[character.upbringingStep.upbringing?.id],
         accepted: character.upbringingStep.acceptedUpbringing,
       };
@@ -909,7 +909,7 @@ class Marshaller {
 
     if (character.careerEvents) {
       sheet['careerEvents'] = character.careerEvents.map((c) => {
-        let e = { id: c.id };
+        const e = { id: c.id };
         if (c.focus) {
           e['focus'] = c.focus;
         }
@@ -938,7 +938,7 @@ class Marshaller {
     }
 
     if (character.educationStep != null) {
-      let education = {};
+      const education = {};
       if (character.educationStep?.track != null) {
         education['track'] = Track[character.educationStep.track];
       }
@@ -984,13 +984,13 @@ class Marshaller {
       sheet['training'] = education;
     }
 
-    let additionalTraits = this.parseTraits(character.additionalTraits);
+    const additionalTraits = this.parseTraits(character.additionalTraits);
     if (additionalTraits?.length) {
       sheet['traits'] = additionalTraits;
     }
 
     if (character.environmentStep != null) {
-      let environment = {
+      const environment = {
         id: Environment[character.environmentStep.environment],
       };
       if (character.environmentStep.otherSpecies != null) {
@@ -1047,7 +1047,7 @@ class Marshaller {
       sheet['house'] = character.house;
     }
     if (character.role != null) {
-      let role = { id: Role[character.role] };
+      const role = { id: Role[character.role] };
       if (character.secondaryRole != null) {
         role['secondaryId'] = Role[character.secondaryRole];
       }
@@ -1062,7 +1062,7 @@ class Marshaller {
   }
 
   toSpeciesJson(character: Character) {
-    let json = { primary: Species[character.speciesStep.species] };
+    const json = { primary: Species[character.speciesStep.species] };
 
     if (
       character.speciesStep.customSpeciesName &&
@@ -1087,7 +1087,7 @@ class Marshaller {
     }
 
     if (character.speciesStep.abilityOptions) {
-      let options = {};
+      const options = {};
       if (character.speciesStep.abilityOptions.focuses?.length) {
         options['focuses'] = [...character.speciesStep.abilityOptions.focuses];
       }
@@ -1114,12 +1114,12 @@ class Marshaller {
   }
 
   toTalentList(talents: SelectedTalent[]) {
-    let result = talents.map((t) => this.talentToJson(t));
+    const result = talents.map((t) => this.talentToJson(t));
     return result;
   }
 
   talentToJson(t: SelectedTalent) {
-    let talent = { name: t.talent };
+    const talent = { name: t.talent };
 
     if (t.isCustom) {
       talent['customTalentName'] = t.customTalentName;
@@ -1184,7 +1184,7 @@ class Marshaller {
   }
 
   toAttributeObject(attributes: number[]) {
-    let result = {};
+    const result = {};
     AttributesHelper.getAllAttributes().forEach((a) => {
       result[Attribute[a]] = attributes[a];
     });
@@ -1192,7 +1192,7 @@ class Marshaller {
   }
 
   getDepartmentByNameObject(departments: number[]) {
-    let result = {};
+    const result = {};
     DepartmentsHelper.instance
       .getDepartments()
       .forEach((d) => (result[Department[d]] = departments[d]));
@@ -1200,7 +1200,7 @@ class Marshaller {
   }
 
   toDepartmentObject(departments: number[]) {
-    let result = {};
+    const result = {};
     DepartmentsHelper.instance
       .getDepartments()
       .forEach((d) => (result[Department[d]] = departments[d]));
@@ -1208,7 +1208,7 @@ class Marshaller {
   }
 
   toSystemsObject(systems: number[]) {
-    let result = {};
+    const result = {};
     allSystems().forEach((s) => (result[System[s]] = systems[s]));
     return result;
   }
@@ -1233,7 +1233,7 @@ class Marshaller {
   }
 
   encodeStarship(starship: Starship) {
-    let sheet = {
+    const sheet = {
       stereotype: this.encodeStarshipStereoType(starship.stereotype),
       type: CharacterType[starship.type],
       era: Era[starship.era],
@@ -1287,7 +1287,7 @@ class Marshaller {
       }
     }
     if (starship.missionProfileStep?.type) {
-      let temp = {
+      const temp = {
         name: MissionProfile[starship.missionProfileStep?.type?.id],
       };
       if (starship.missionProfileStep.system != null) {
@@ -1391,16 +1391,16 @@ class Marshaller {
     if (loadType == null) {
       return null;
     } else if (loadType instanceof EnergyLoadTypeModel) {
-      let temp = loadType as EnergyLoadTypeModel;
+      const temp = loadType as EnergyLoadTypeModel;
       return EnergyLoadType[temp.type];
     } else if (loadType instanceof TorpedoLoadTypeModel) {
-      let temp = loadType as TorpedoLoadTypeModel;
+      const temp = loadType as TorpedoLoadTypeModel;
       return TorpedoLoadType[temp.type];
     } else if (loadType instanceof CaptureTypeModel) {
-      let temp = loadType as CaptureTypeModel;
+      const temp = loadType as CaptureTypeModel;
       return CaptureType[temp.type];
     } else if (loadType instanceof MineTypeModel) {
-      let temp = loadType as MineTypeModel;
+      const temp = loadType as MineTypeModel;
       return MineType[temp.type];
     } else {
       return null;
@@ -1408,17 +1408,17 @@ class Marshaller {
   }
 
   encode(json: any) {
-    let text = JSON.stringify(json);
-    let encoded = pako.deflate(new TextEncoder().encode(text));
-    let result = Base64.fromUint8Array(encoded, true);
+    const text = JSON.stringify(json);
+    const encoded = pako.deflate(new TextEncoder().encode(text));
+    const result = Base64.fromUint8Array(encoded, true);
     return result;
   }
 
   decode(s: string) {
     if (s) {
       try {
-        let encoded = Base64.toUint8Array(s);
-        let text = new TextDecoder().decode(pako.inflate(encoded));
+        const encoded = Base64.toUint8Array(s);
+        const text = new TextDecoder().decode(pako.inflate(encoded));
         return JSON.parse(text);
       } catch (e) {
         return undefined;
@@ -1429,24 +1429,24 @@ class Marshaller {
   }
 
   decodeAsset(s: string): Asset {
-    let json = this.decode(s);
+    const json = this.decode(s);
     let type = null;
     [AssetType.Character, AssetType.Ship, AssetType.Resource].forEach((a) => {
       if (AssetType[a] === json.type) {
         type = a;
       }
     });
-    let name = json.name;
-    let stats = [null, null, null, null, null];
+    const name = json.name;
+    const stats = [null, null, null, null, null];
     if (json.stats) {
       allAssetStatTypes().forEach((a) => {
-        let statName = AssetStatType[a];
-        let s = json.stats[statName];
+        const statName = AssetStatType[a];
+        const s = json.stats[statName];
         if (s === '-') {
           stats[a] = new AssetStat();
         } else if (s?.length && s?.indexOf('/') >= 0) {
-          let base = parseInt(s.substring(0, s.indexOf('/')));
-          let critical = parseInt(s.substring(s.indexOf('/') + 1));
+          const base = parseInt(s.substring(0, s.indexOf('/')));
+          const critical = parseInt(s.substring(s.indexOf('/') + 1));
 
           stats[a] = new AssetStat(base, critical);
         }
@@ -1476,7 +1476,7 @@ class Marshaller {
   }
 
   decodeStation(json: any): Station {
-    let result = new Station();
+    const result = new Station();
     if (json.version) {
       result.version = json.version;
     }
@@ -1488,7 +1488,7 @@ class Marshaller {
     result.name = json.name;
 
     if (json['missionProfile']) {
-      let profile = MissionProfiles.instance.getStationMissionProfileByName(
+      const profile = MissionProfiles.instance.getStationMissionProfileByName(
         json['missionProfile']['name'],
       );
       if (profile != null) {
@@ -1504,9 +1504,9 @@ class Marshaller {
     }
 
     if (json['frame']) {
-      let frame: any = json['frame'];
+      const frame: any = json['frame'];
       if (frame['type'] === 'Custom') {
-        let step = new CustomStationSpaceframeStep();
+        const step = new CustomStationSpaceframeStep();
         allSystems().forEach(
           (s) => (step.systems[s] = frame.systems[System[s]]),
         );
@@ -1525,8 +1525,8 @@ class Marshaller {
         }
         result.stationFrameStep = step;
       } else {
-        let type = frame['type'];
-        let profile = StationFrameModel.getByIdName(type);
+        const type = frame['type'];
+        const profile = StationFrameModel.getByIdName(type);
         if (profile) {
           result.stationFrameStep = new StandardStationSpaceframeStep(
             profile.id,
@@ -1555,8 +1555,8 @@ class Marshaller {
   }
 
   decodeStarship(s: string) {
-    let json = this.decode(s);
-    let result = new Starship();
+    const json = this.decode(s);
+    const result = new Starship();
     if (json.version) {
       result.version = json.version;
     }
@@ -1567,7 +1567,7 @@ class Marshaller {
       result.stereotype = Stereotype.SimpleStarship;
     }
     if (json.era) {
-      let era = Eras.instance.getEraByName(json.era);
+      const era = Eras.instance.getEraByName(json.era);
       if (era != null) {
         result.era = era;
       }
@@ -1587,7 +1587,7 @@ class Marshaller {
     });
     if (json.spaceframe) {
       if (json.spaceframe.custom) {
-        let frame = SpaceframeModel.createCustomSpaceframe(
+        const frame = SpaceframeModel.createCustomSpaceframe(
           result.type,
           json.spaceframe.custom.serviceYear,
         );
@@ -1608,7 +1608,7 @@ class Marshaller {
 
         if (json.spaceframe.custom.talents) {
           json.spaceframe.custom.talents.forEach((t) => {
-            let model = new SelectedTalent(t);
+            const model = new SelectedTalent(t);
             if (model) {
               frame.talents.push(model);
             }
@@ -1627,7 +1627,7 @@ class Marshaller {
         );
         if (json.spaceframe.talents) {
           json.spaceframe.talents.forEach((t) => {
-            let talent = this.hydrateTalent(t, result.version);
+            const talent = this.hydrateTalent(t, result.version);
             if (talent != null) {
               result.spaceframeStep.talents.push(talent);
             }
@@ -1656,7 +1656,7 @@ class Marshaller {
       }
 
       if (json.missionProfile.talent) {
-        let talent = this.hydrateTalent(
+        const talent = this.hydrateTalent(
           json.missionProfile.talent,
           result.version,
         );
@@ -1677,7 +1677,7 @@ class Marshaller {
       }
     }
     if (json.serviceRecord) {
-      let types = allServiceRecords().filter(
+      const types = allServiceRecords().filter(
         (t) => ServiceRecord[t] === json.serviceRecord.type,
       );
       if (types.length === 1) {
@@ -1747,10 +1747,10 @@ class Marshaller {
 
     if (json.talentDetails) {
       json.talentDetails.forEach((detail) => {
-        let w = detail.weapon;
-        let weapon = this.decodeWeapon(w, result.version);
+        const w = detail.weapon;
+        const weapon = this.decodeWeapon(w, result.version);
 
-        let talent = result.additionalTalents.filter(
+        const talent = result.additionalTalents.filter(
           (t) => t.name === TALENT_NAME_EXPANDED_MUNITIONS && t.weapon == null,
         );
         if (talent?.length) {
@@ -1771,8 +1771,8 @@ class Marshaller {
       if (UsageCategory[c] === json['usageCategory']) usageCategory = c;
     });
 
-    let name = json['name'];
-    let baseDice = json['baseDice'];
+    const name = json['name'];
+    const baseDice = json['baseDice'];
 
     let weaponType = null;
     [
@@ -1832,7 +1832,7 @@ class Marshaller {
   }
 
   decodeCreature(json: any) {
-    let result = new Creature();
+    const result = new Creature();
     result.stereotype = Stereotype.Creature;
     if (json.name?.length) {
       result.name = json.name;
@@ -1843,7 +1843,7 @@ class Marshaller {
     }
 
     if (json.era) {
-      let era = Eras.instance.getEraByName(json.era);
+      const era = Eras.instance.getEraByName(json.era);
       if (era != null) {
         result.era = era;
       }
@@ -1878,7 +1878,7 @@ class Marshaller {
 
     if (json.locomotion) {
       result.locomotion = json.locomotion.map((l) => {
-        let type = LocomotionTypeHelper.instance.getTypeByIdName(l.type);
+        const type = LocomotionTypeHelper.instance.getTypeByIdName(l.type);
         let count = undefined;
         if (l.count != null) {
           count = l.count;
@@ -1889,7 +1889,7 @@ class Marshaller {
 
     if (json.talents) {
       json.talents.forEach((t) => {
-        let talent = this.hydrateTalent(t, result.version);
+        const talent = this.hydrateTalent(t, result.version);
         if (talent != null) {
           result.additionalTalents.push(talent);
         }
@@ -1922,7 +1922,7 @@ class Marshaller {
   }
 
   decodeCharacter(json: any) {
-    let result = new Character();
+    const result = new Character();
     if (json['stereotype'] === 'npc') {
       result.stereotype = Stereotype.Npc;
     } else if (json['stereotype'] === 'supportingCharacter') {
@@ -1930,19 +1930,19 @@ class Marshaller {
     } else if (json['stereotype'] === 'soloCharacter') {
       result.stereotype = Stereotype.SoloCharacter;
     }
-    let type = CharacterTypeModel.getCharacterTypeByTypeName(json.type);
+    const type = CharacterTypeModel.getCharacterTypeByTypeName(json.type);
     if (type) {
       result.type = type.type;
     }
     if (json.era) {
-      let era = Eras.instance.getEraByName(json.era);
+      const era = Eras.instance.getEraByName(json.era);
       if (era != null) {
         result.era = era;
       }
     }
     result.name = json.name;
     result.additionalTraits = json.traits ? json.traits.join(', ') : '';
-    let rank = json.rank;
+    const rank = json.rank;
     if (rank) {
       if (typeof rank === 'string') {
         result._rank = new CharacterRank(rank as string);
@@ -1981,25 +1981,25 @@ class Marshaller {
     }
 
     if (json.role != null) {
-      let role = json.role;
+      const role = json.role;
       if (typeof role === 'string') {
-        let roleType = RolesHelper.instance.getRoleByName(role);
+        const roleType = RolesHelper.instance.getRoleByName(role);
         if (roleType != null) {
           result.role = roleType;
         } else {
           result.jobAssignment = role;
         }
       } else {
-        let roleId = role['id'];
+        const roleId = role['id'];
         if (roleId != null) {
-          let r = RolesHelper.instance.getRoleByTypeName(roleId, result.type);
+          const r = RolesHelper.instance.getRoleByTypeName(roleId, result.type);
           if (r != null) {
             result.role = r;
           }
         }
         if (role['secondaryId'] != null) {
-          let secondaryId = role['secondaryId'];
-          let r = RolesHelper.instance.getRoleByTypeName(
+          const secondaryId = role['secondaryId'];
+          const r = RolesHelper.instance.getRoleByTypeName(
             secondaryId,
             result.type,
           );
@@ -2017,7 +2017,7 @@ class Marshaller {
         if (typeof e === 'number') {
           return new CareerEventStep(e);
         } else {
-          let step = new CareerEventStep(e['id']);
+          const step = new CareerEventStep(e['id']);
           if (e['attribute']) {
             step.attribute = AttributesHelper.getAttributeByName(
               e['attribute'],
@@ -2049,7 +2049,7 @@ class Marshaller {
       result.pastime = [...json.pastime];
     }
     if (json.age) {
-      let age = AgeHelper.getAge(json.age);
+      const age = AgeHelper.getAge(json.age);
       if (age) {
         result.age = age;
       }
@@ -2057,9 +2057,9 @@ class Marshaller {
     if (json.species != null) {
       if (typeof json.species === 'string') {
         // backward compatibility
-        let speciesCode = SpeciesHelper.getSpeciesTypeByName(json.species);
+        const speciesCode = SpeciesHelper.getSpeciesTypeByName(json.species);
 
-        let species = SpeciesHelper.getSpeciesByType(speciesCode);
+        const species = SpeciesHelper.getSpeciesByType(speciesCode);
         if (species != null) {
           result.speciesStep = new SpeciesStep(speciesCode);
 
@@ -2069,7 +2069,7 @@ class Marshaller {
           }
 
           if (json.mixedSpecies != null) {
-            let speciesCode = SpeciesHelper.getSpeciesTypeByName(
+            const speciesCode = SpeciesHelper.getSpeciesTypeByName(
               json.mixedSpecies,
             );
             if (speciesCode != null) {
@@ -2077,7 +2077,7 @@ class Marshaller {
             }
           }
           if (json.originalSpecies != null) {
-            let speciesCode = SpeciesHelper.getSpeciesTypeByName(
+            const speciesCode = SpeciesHelper.getSpeciesTypeByName(
               json.originalSpecies,
             );
             if (speciesCode != null) {
@@ -2086,9 +2086,9 @@ class Marshaller {
           }
         }
       } else {
-        let speciesBlock = json.species;
+        const speciesBlock = json.species;
         if (speciesBlock.primary != null) {
-          let speciesCode = SpeciesHelper.getSpeciesTypeByName(
+          const speciesCode = SpeciesHelper.getSpeciesTypeByName(
             speciesBlock.primary,
           );
 
@@ -2098,7 +2098,7 @@ class Marshaller {
               result.speciesStep.customSpeciesName = speciesBlock.customName;
             }
           } else {
-            let species = SpeciesHelper.getSpeciesByType(speciesCode);
+            const species = SpeciesHelper.getSpeciesByType(speciesCode);
 
             if (species != null) {
               result.speciesStep = new SpeciesStep(speciesCode);
@@ -2120,7 +2120,7 @@ class Marshaller {
           }
 
           if (speciesBlock.mixed != null) {
-            let speciesCode = SpeciesHelper.getSpeciesTypeByName(
+            const speciesCode = SpeciesHelper.getSpeciesTypeByName(
               speciesBlock.mixed,
             );
             if (speciesCode != null) {
@@ -2128,7 +2128,7 @@ class Marshaller {
             }
           }
           if (speciesBlock.original != null) {
-            let speciesCode = SpeciesHelper.getSpeciesTypeByName(
+            const speciesCode = SpeciesHelper.getSpeciesTypeByName(
               speciesBlock.original,
             );
             if (speciesCode != null) {
@@ -2169,7 +2169,7 @@ class Marshaller {
                   .filter((i) => i != null);
             }
             if (speciesBlock.abilityOptions.choice != null) {
-              let choices = Object.keys(SpeciesAbilityChoice)
+              const choices = Object.keys(SpeciesAbilityChoice)
                 .filter((item) => {
                   return !isNaN(Number(item));
                 })
@@ -2187,9 +2187,9 @@ class Marshaller {
       }
     }
     if (json.career) {
-      let temp = json.career;
+      const temp = json.career;
       if (typeof temp === 'string') {
-        let career = CareersHelper.instance.getCareerByTypeName(
+        const career = CareersHelper.instance.getCareerByTypeName(
           temp,
           result.type,
           result.version,
@@ -2200,9 +2200,9 @@ class Marshaller {
           result.careerStep = new CareerStep(career?.id);
         }
       } else {
-        let length = temp.length;
+        const length = temp.length;
         if (length != null) {
-          let career = CareersHelper.instance.getCareerByTypeName(
+          const career = CareersHelper.instance.getCareerByTypeName(
             length,
             result.type,
             result.version,
@@ -2228,8 +2228,8 @@ class Marshaller {
       }
     }
     if (json.training != null) {
-      let trackAsString = json.training.track;
-      let tracks = getAllTracks().filter((t) => Track[t] === trackAsString);
+      const trackAsString = json.training.track;
+      const tracks = getAllTracks().filter((t) => Track[t] === trackAsString);
 
       result.educationStep = new EducationStep(
         tracks.length ? tracks[0] : undefined,
@@ -2270,13 +2270,13 @@ class Marshaller {
         result.educationStep.value = json.training.value;
       }
       if (json.training.talent != null) {
-        let talent = this.hydrateTalent(json.training.talent, result.version);
+        const talent = this.hydrateTalent(json.training.talent, result.version);
         if (talent != null) {
           result.educationStep.talent = talent;
         }
       }
     } else {
-      let rank =
+      const rank =
         result._rank == null
           ? null
           : RanksHelper.instance().getRankByName(result._rank?.name);
@@ -2288,7 +2288,7 @@ class Marshaller {
       }
     }
     if (json.focuses) {
-      let focuses = [...json.focuses];
+      const focuses = [...json.focuses];
       if (result.stereotype === Stereotype.MainCharacter) {
         result.legacyMode = true;
         result._focuses = focuses;
@@ -2306,7 +2306,7 @@ class Marshaller {
     }
     if (json.attributes) {
       AttributesHelper.getAllAttributes().forEach((a) => {
-        let value = json.attributes[Attribute[a]];
+        const value = json.attributes[Attribute[a]];
         if (value != null) {
           result._attributes[a] = value;
         }
@@ -2333,7 +2333,7 @@ class Marshaller {
       }
     }
     if (json.environment) {
-      let environment = EnvironmentsHelper.getEnvironmentByTypeName(
+      const environment = EnvironmentsHelper.getEnvironmentByTypeName(
         json.environment.id,
         result.type,
         result.version,
@@ -2375,11 +2375,11 @@ class Marshaller {
     }
 
     if (json.upbringing) {
-      let upbringing = UpbringingsHelper.getUpbringingByTypeName(
+      const upbringing = UpbringingsHelper.getUpbringingByTypeName(
         json.upbringing.id,
         result.type,
       );
-      let step = new UpbringingStep(upbringing, json.upbringing.accepted);
+      const step = new UpbringingStep(upbringing, json.upbringing.accepted);
       if (json.upbringing.focus) {
         step.focus = json.upbringing.focus;
       }
@@ -2427,7 +2427,7 @@ class Marshaller {
 
     if (json.talents) {
       json.talents.forEach((t) => {
-        let talent = this.hydrateTalent(t, result.version);
+        const talent = this.hydrateTalent(t, result.version);
         if (talent != null) {
           result.addTalent(talent);
         }
@@ -2536,7 +2536,7 @@ class Marshaller {
 
     // backward compatibility
     if (json.implants) {
-      let talent = result.getTalentByName(TALENT_NAME_BORG_IMPLANTS);
+      const talent = result.getTalentByName(TALENT_NAME_BORG_IMPLANTS);
       talent.implants = json.implants
         .map((i) => BorgImplants.instance.getImplantByTypeName(i)?.type)
         .filter((i) => i != null);
@@ -2571,7 +2571,7 @@ class Marshaller {
       return Object.values(json)
         .map((j) => {
           if (j['type'] === 'advancement') {
-            let improvement = new StarshipAdvancementStep();
+            const improvement = new StarshipAdvancementStep();
             allStarshipAdvancementChoices().forEach((c) => {
               if (StarshipAdvancementChoice[c] === j['choice']) {
                 improvement.choice = c;
@@ -2620,7 +2620,7 @@ class Marshaller {
         .map((j) => {
           if (j['type'] === 'supporting') {
             // backward compatibility
-            let improvement = new CharacterAdvancementStep();
+            const improvement = new CharacterAdvancementStep();
             if (j['value'] != null) {
               improvement.value = j['value'];
               improvement.choice = CharacterAdvancementChoice.Value;
@@ -2642,7 +2642,7 @@ class Marshaller {
             }
             return improvement;
           } else if (j['type'] === 'advancement') {
-            let improvement = new CharacterAdvancementStep();
+            const improvement = new CharacterAdvancementStep();
             allCharacterAdvancementChoices().forEach((c) => {
               if (CharacterAdvancementChoice[c] === j['choice']) {
                 improvement.choice = c;
@@ -2785,9 +2785,9 @@ class Marshaller {
     ) {
       talentName = 'Dedicated Personnel';
     }
-    let talent = TalentsHelper.getTalent(talentName);
+    const talent = TalentsHelper.getTalent(talentName);
     if (talent) {
-      let selectedTalent = new SelectedTalent(talent.name);
+      const selectedTalent = new SelectedTalent(talent.name);
 
       if (t.name === 'Augmented Ability (Control)') {
         selectedTalent.attribute = Attribute.Control;

--- a/WebTools/src/helpers/missionPods.ts
+++ b/WebTools/src/helpers/missionPods.ts
@@ -332,7 +332,7 @@ export class MissionPodHelper {
   getMissionPodByName(name: string, version: number) {
     let result = undefined;
     const list = version === 1 ? this._missionPods : this._missionPods2e;
-    for (let id in list) {
+    for (const id in list) {
       if (MissionPod[id] === name) {
         result = list[id];
         break;
@@ -342,12 +342,12 @@ export class MissionPodHelper {
   }
 
   getMissionPods(starship: Starship) {
-    let missionPods: MissionPodModel[] = [];
+    const missionPods: MissionPodModel[] = [];
 
     const list =
       starship.version === 1 ? this._missionPods : this._missionPods2e;
-    for (var pod in list) {
-      let p = list[pod];
+    for (const pod in list) {
+      const p = list[pod];
       if (p.isPrerequisitesFulfilled(starship)) {
         missionPods.push(p);
       }

--- a/WebTools/src/helpers/missionProfiles.ts
+++ b/WebTools/src/helpers/missionProfiles.ts
@@ -91,7 +91,7 @@ export class MissionProfileModel {
       ? 'MissionProfile.klingon.'
       : 'MissionProfile.default.';
     const key = makeKey(prefix, MissionProfile[this.id]);
-    let result = i18next.t(key);
+    const result = i18next.t(key);
     return result === key ? this.name : result;
   }
 
@@ -100,7 +100,7 @@ export class MissionProfileModel {
       ? 'MissionProfile.klingon.'
       : 'MissionProfile.default.';
     const key = makeKey(prefix, MissionProfile[this.id], '.description');
-    let result = i18next.t(key);
+    const result = i18next.t(key);
     return result === key ? '' : result;
   }
 }
@@ -953,7 +953,7 @@ class MissionProfiles {
   };
 
   getMissionProfiles(starship: Starship) {
-    let profiles: MissionProfileModel[] = [];
+    const profiles: MissionProfileModel[] = [];
     let list = this._profiles2e;
     if (starship.version === 1) {
       list = isKlingonWarrior1e(starship.type, starship.version)
@@ -977,7 +977,7 @@ class MissionProfiles {
           this._profiles2e[MissionProfile.ScientificAndSurvey],
       };
     }
-    for (let profile of Object.values(list)) {
+    for (const profile of Object.values(list)) {
       if (profile && profile.isPrerequisitesFulfilled(starship)) {
         profiles.push(profile);
       }
@@ -991,7 +991,7 @@ class MissionProfiles {
   }
 
   getStationMissionProfiles() {
-    let profiles = [...Object.values(this._stationProfiles)];
+    const profiles = [...Object.values(this._stationProfiles)];
     profiles.sort((p1, p2) => {
       return p1.localizedName.localeCompare(p2.localizedName);
     });
@@ -1005,7 +1005,7 @@ class MissionProfiles {
     if ('PolicalOperationsStation' === name) {
       name = MissionProfile[MissionProfile.PoliticalOperationsStation];
     }
-    let profiles = [...Object.values(this._stationProfiles)].filter(
+    const profiles = [...Object.values(this._stationProfiles)].filter(
       (p) => MissionProfile[p.id] === name,
     );
 
@@ -1032,7 +1032,7 @@ class MissionProfiles {
       list = this._klingonProfiles2e;
     }
     let result = null;
-    for (let id in list) {
+    for (const id in list) {
       if (profile === MissionProfile[id]) {
         result = list[id];
         break;

--- a/WebTools/src/helpers/pointAllocator.ts
+++ b/WebTools/src/helpers/pointAllocator.ts
@@ -1,8 +1,8 @@
 export default class PointAllocator {
   static allocatePointsEvenly(points: number) {
-    let base = points < 0 ? Math.ceil(points / 6) : Math.floor(points / 6);
-    let remainder = points - base * 6;
-    let result = [base, base, base, base, base, base];
+    const base = points < 0 ? Math.ceil(points / 6) : Math.floor(points / 6);
+    const remainder = points - base * 6;
+    const result = [base, base, base, base, base, base];
     for (let i = 0; i < Math.min(Math.abs(remainder), 6); i++) {
       result[i] += points < 0 ? -1 : 1;
     }
@@ -10,7 +10,7 @@ export default class PointAllocator {
   }
 
   static allocatePointsRandomly(points: number) {
-    let result = [0, 0, 0, 0, 0, 0];
+    const result = [0, 0, 0, 0, 0, 0];
     for (let i = 0; i < points; i++) {
       let done = false;
       while (!done) {

--- a/WebTools/src/helpers/prerequisite.ts
+++ b/WebTools/src/helpers/prerequisite.ts
@@ -56,7 +56,7 @@ export class RolePrerequisite implements IConstructPrerequisite {
         character.role === this.role || character.secondaryRole === this.role
       );
     } else if (character.stereotype === Stereotype.MainCharacter) {
-      let roles = character.talents
+      const roles = character.talents
         .map((t) => t.talentModel.prerequisites)
         .flat()
         .filter((p) => p instanceof RolePrerequisite)
@@ -165,7 +165,7 @@ export class AnyOfPrerequisite
     if (this.prerequisites.length === 0) {
       return true;
     } else {
-      var result = false;
+      let result = false;
       this.prerequisites.forEach((req) => {
         result = result || req.isPrerequisiteFulfilled(character);
       });

--- a/WebTools/src/helpers/propulsionSystem.ts
+++ b/WebTools/src/helpers/propulsionSystem.ts
@@ -16,7 +16,10 @@ export class PropulsionSystemModel {
   }
 
   get localizedName() {
-    let key = makeKey('PropulsionSystemType.', PropulsionSystemType[this.type]);
+    const key = makeKey(
+      'PropulsionSystemType.',
+      PropulsionSystemType[this.type],
+    );
     return i18next.t(key);
   }
   static readonly types = [
@@ -29,12 +32,12 @@ export class PropulsionSystemModel {
   ];
 
   static getByType(type: PropulsionSystemType) {
-    let result = this.types.filter((t) => t.type === type);
+    const result = this.types.filter((t) => t.type === type);
     return result.length ? result[0] : undefined;
   }
 
   static getByTypeName(type: string) {
-    let result = this.types.filter(
+    const result = this.types.filter(
       (t) => PropulsionSystemType[t.type] === type,
     );
     return result.length ? result[0] : undefined;

--- a/WebTools/src/helpers/ranks.ts
+++ b/WebTools/src/helpers/ranks.ts
@@ -276,14 +276,14 @@ export class RankModel {
   }
 
   get localizedName() {
-    let key = makeKey('Rank.', Rank[this.id], '.name');
-    let result = i18next.t(key);
+    const key = makeKey('Rank.', Rank[this.id], '.name');
+    const result = i18next.t(key);
     return key === result ? this.name : result;
   }
 
   get localizedAbbreviation() {
-    let key = makeKey('Rank.', Rank[this.id], '.abbrev');
-    let result = i18next.t(key);
+    const key = makeKey('Rank.', Rank[this.id], '.abbrev');
+    const result = i18next.t(key);
     return key === result ? this.abbreviation : result;
   }
 }
@@ -1527,7 +1527,7 @@ export class RanksHelper {
   }
 
   getSortedRanks(character: Character, ignorePrerequisites?: boolean) {
-    let result = this.getRanks(character, ignorePrerequisites);
+    const result = this.getRanks(character, ignorePrerequisites);
 
     result.sort((r1, r2) => {
       return r2.levelValue - r1.levelValue;
@@ -1537,7 +1537,7 @@ export class RanksHelper {
   }
 
   getRank(rank: Rank) {
-    let ranks = this._ranks.filter((r) => r.id === rank);
+    const ranks = this._ranks.filter((r) => r.id === rank);
     return ranks?.length ? ranks[0] : null;
   }
 
@@ -1586,11 +1586,11 @@ export class RanksHelper {
 
 export const getNameAndShortRankOf = (character: Character) => {
   if (character.rank) {
-    let rank =
+    const rank =
       character.rank.id != null
         ? RanksHelper.instance().getRank(character.rank.id)
         : RanksHelper.instance().getRankByName(character.rank?.name);
-    let abbreviation =
+    const abbreviation =
       rank && rank.localizedAbbreviation ? rank.localizedAbbreviation : '';
     return abbreviation + ' ' + character.name;
   } else {

--- a/WebTools/src/helpers/roles.ts
+++ b/WebTools/src/helpers/roles.ts
@@ -200,7 +200,7 @@ export class RoleModel {
   }
 
   get isKlingon() {
-    let prerequisites = this.prerequisites.filter(
+    const prerequisites = this.prerequisites.filter(
       (p) => p instanceof KlingonCharacterPrerequisite,
     );
     return prerequisites.length > 0;
@@ -900,10 +900,10 @@ export class RolesHelper {
   ];
 
   getRoles(character: Character) {
-    var departments = this.determineHighestDiscipline(character);
-    var roles: RoleModel[] = [];
-    var list = this._roles;
-    for (var r of list) {
+    const departments = this.determineHighestDiscipline(character);
+    const roles: RoleModel[] = [];
+    const list = this._roles;
+    for (const r of list) {
       if (r.isPrerequisitesFilled(character)) {
         if (
           character.hasTalent('Multi-Discipline') &&
@@ -915,7 +915,7 @@ export class RolesHelper {
       }
     }
 
-    let temp = roles.sort((a, b) => {
+    const temp = roles.sort((a, b) => {
       if (a.department == null && b.department == null) {
         return a.id - b.id;
       } else if (
@@ -949,8 +949,8 @@ export class RolesHelper {
   }
 
   getRoleModelByName(role: string, type: CharacterType) {
-    var list = this._roles;
-    for (var r of list) {
+    const list = this._roles;
+    for (const r of list) {
       if (r.name === role) {
         return r;
       }
@@ -960,13 +960,13 @@ export class RolesHelper {
   }
 
   getRole(role: Role, characterType: CharacterType) {
-    let roles = this._roles.filter((r) => r.id === role);
+    const roles = this._roles.filter((r) => r.id === role);
     if (roles.length === 0) {
       return undefined;
     } else if (roles.length === 1) {
       return roles[0];
     } else {
-      let typeRoles = roles.filter(
+      const typeRoles = roles.filter(
         (r) =>
           (r.isKlingonRole() && isKlingonWarriorType(characterType)) ||
           (!r.isKlingonRole() && !isKlingonWarriorType(characterType)),
@@ -992,8 +992,8 @@ export class RolesHelper {
   }
 
   getRoleByName(role: string): Role {
-    var list = this._roles;
-    for (var r of list) {
+    const list = this._roles;
+    for (const r of list) {
       if (r.name === role) {
         return r.id;
       }
@@ -1003,8 +1003,8 @@ export class RolesHelper {
   }
 
   getRoleByTypeName(role: string) {
-    var list = this._roles;
-    for (var r of list) {
+    const list = this._roles;
+    for (const r of list) {
       if (Role[r.id] === role) {
         return r.id;
       }
@@ -1014,7 +1014,7 @@ export class RolesHelper {
   }
 
   private determineHighestDiscipline(character: Character) {
-    let departments = character.departments;
+    const departments = character.departments;
     let maxDepartment = [];
     let maxDepartmentValue = 0;
     DepartmentsHelper.instance.getDepartments().forEach((s) => {

--- a/WebTools/src/helpers/sources.ts
+++ b/WebTools/src/helpers/sources.ts
@@ -91,8 +91,8 @@ class SourceViewModel {
   }
 
   get localizedName() {
-    let key = makeKey('Source.book.', Source[this.id]);
-    let result = i18n.t(key);
+    const key = makeKey('Source.book.', Source[this.id]);
+    const result = i18n.t(key);
     return result === key ? this.name : result;
   }
 }
@@ -294,9 +294,9 @@ class Sources {
   };
 
   getSources() {
-    let sources: SourceViewModel[] = [];
-    for (let source in this._sources) {
-      let src = this._sources[source];
+    const sources: SourceViewModel[] = [];
+    for (const source in this._sources) {
+      const src = this._sources[source];
       sources.push(src);
     }
     return sources;

--- a/WebTools/src/helpers/spaceframeModel.ts
+++ b/WebTools/src/helpers/spaceframeModel.ts
@@ -117,7 +117,7 @@ export class SpaceframeModel implements IServiceYearProvider {
     if (serviceYear != null) {
       return this.talents.filter((t) => {
         let result = true;
-        let model = t instanceof SelectedTalent ? t.talentModel : t;
+        const model = t instanceof SelectedTalent ? t.talentModel : t;
         model.prerequisites.forEach((p) => {
           if (p instanceof MaxServiceYearPrerequisite) {
             result =
@@ -184,9 +184,9 @@ export class SpaceframeModel implements IServiceYearProvider {
   }
 
   get localizedName() {
-    let key = this.key;
+    const key = this.key;
     if (key != null) {
-      let local = i18next.t(key);
+      const local = i18next.t(key);
       return local === key ? this.name : local;
     } else {
       return this.name;
@@ -197,7 +197,7 @@ export class SpaceframeModel implements IServiceYearProvider {
     let key = this.key;
     if (key != null) {
       key += '.description';
-      let local = i18next.t(key);
+      const local = i18next.t(key);
       return local === key ? undefined : local;
     } else {
       return undefined;
@@ -237,8 +237,8 @@ export class SpaceframeModel implements IServiceYearProvider {
     soloStats?: SoloSpaceframeStats,
     errata: boolean = false,
   ) {
-    let sourcePrerequisite = new SourcePrerequisite(...source);
-    let prerequisites: IConstructPrerequisite[] = [
+    const sourcePrerequisite = new SourcePrerequisite(...source);
+    const prerequisites: IConstructPrerequisite[] = [
       sourcePrerequisite,
       new StarshipTypePrerequisite(type),
       new ServiceYearPrerequisite(serviceYear),

--- a/WebTools/src/helpers/spaceframeOutlineHelper.ts
+++ b/WebTools/src/helpers/spaceframeOutlineHelper.ts
@@ -692,7 +692,7 @@ class SpaceframeOutlineHelper {
   }
 
   getOutline(starship: Starship): string | Outline {
-    let spaceframe = starship.spaceframeModel;
+    const spaceframe = starship.spaceframeModel;
     if (
       starship.spaceframeStep?.appearance != null ||
       starship.simpleStats?.appearance != null

--- a/WebTools/src/helpers/spaceframeVariant.ts
+++ b/WebTools/src/helpers/spaceframeVariant.ts
@@ -59,7 +59,7 @@ export class SpaceframeVariantModel {
   }
 
   static variantCodeByName(name: string): SpaceframeVariant | undefined {
-    let result = this.ALL.filter((v) => SpaceframeVariant[v.id] === name);
+    const result = this.ALL.filter((v) => SpaceframeVariant[v.id] === name);
     return result?.length ? result[0].id : undefined;
   }
 

--- a/WebTools/src/helpers/spaceframes.ts
+++ b/WebTools/src/helpers/spaceframes.ts
@@ -3246,9 +3246,9 @@ export class SpaceframeHelper {
   };
 
   getSpaceframes(starship: Starship, ignoreMaxServiceYear: boolean = false) {
-    let frames: SpaceframeModel[] = [];
-    for (var frame in this._frames) {
-      let f = this._frames[frame];
+    const frames: SpaceframeModel[] = [];
+    for (const frame in this._frames) {
+      const f = this._frames[frame];
       if (
         f.serviceYear <= starship.serviceYear &&
         (f.maxServiceYear >= starship.serviceYear || ignoreMaxServiceYear)
@@ -3273,7 +3273,7 @@ export class SpaceframeHelper {
 
   getSpaceframeByName(name: string) {
     let result = undefined;
-    for (let id in this._frames) {
+    for (const id in this._frames) {
       if (Spaceframe[id] === name) {
         result = this._frames[id];
         break;

--- a/WebTools/src/helpers/species.ts
+++ b/WebTools/src/helpers/species.ts
@@ -4199,18 +4199,18 @@ class _Species {
   };
 
   getAllSpecies() {
-    let result = [];
-    for (let archetype in this._species) {
-      let spec = this._species[archetype];
+    const result = [];
+    for (const archetype in this._species) {
+      const spec = this._species[archetype];
       result.push(spec);
     }
     return result;
   }
 
   getSpecies(characterType: CharacterType) {
-    let species: SpeciesModel[] = [];
-    for (let archetype in this._species) {
-      let spec = this._species[archetype];
+    const species: SpeciesModel[] = [];
+    for (const archetype in this._species) {
+      const spec = this._species[archetype];
 
       const hasEra =
         spec.eras.indexOf(store.getState().context.era) > -1 ||
@@ -4233,14 +4233,14 @@ class _Species {
     character: Character,
   ) {
     if (isKlingonWarriorType(type)) {
-      var species: SpeciesModel[] = [];
+      const species: SpeciesModel[] = [];
 
-      var klingonSpecies =
+      const klingonSpecies =
         store.getState().context.era === Era.NextGeneration
           ? [Species.Klingon]
           : [Species.Klingon, Species.KlingonQuchHa, Species.KlingonQuchHa_2E];
-      for (let archetype of klingonSpecies) {
-        let spec = this._species[archetype];
+      for (const archetype of klingonSpecies) {
+        const spec = this._species[archetype];
         const hasSource = hasAnySource(spec.sources);
 
         if (hasSource && !this.ignoreSpecies(archetype)) {
@@ -4256,16 +4256,16 @@ class _Species {
       Character.isSpeciesListLimited(character) &&
       character.typeDetails != null
     ) {
-      let alliedMilitary = (character.typeDetails as AlliedMilitaryDetails)
+      const alliedMilitary = (character.typeDetails as AlliedMilitaryDetails)
         .alliedMilitary;
-      let species = alliedMilitary.species
+      const species = alliedMilitary.species
         .map((s) => this._species[s])
         .filter((s) => hasAnySource(s.sources) && !this.ignoreSpecies(s.id));
       return species.sort((a, b) => {
         return a.localizedName.localeCompare(b.localizedName);
       });
     } else {
-      let candidates = this.getSpecies(character.type);
+      const candidates = this.getSpecies(character.type);
       return excludeSpeciesBasedOnOtherSpecies
         ? candidates.filter((s) => s.isMixedSpeciesAllowed)
         : candidates;
@@ -4273,13 +4273,13 @@ class _Species {
   }
 
   getSpeciesByType(species: Species): SpeciesModel {
-    let model = this._species[species];
+    const model = this._species[species];
     return model;
   }
 
   getSpeciesByName(name: string) {
-    for (var sp in this._species) {
-      var spec = this._species[sp];
+    for (const sp in this._species) {
+      const spec = this._species[sp];
 
       if (spec.name === name) {
         return spec.id;
@@ -4290,9 +4290,9 @@ class _Species {
 
   getSpeciesTypeByName(name: string): Species {
     let result = undefined;
-    for (let species in this._species) {
+    for (const species in this._species) {
       if (name === Species[species]) {
-        let speciesModel = this._species[species];
+        const speciesModel = this._species[species];
         result = speciesModel.id;
         break;
       }
@@ -4316,7 +4316,7 @@ class _Species {
     ) {
       return Species.Klingon;
     } else if (isKlingonWarriorType(characterType)) {
-      let roll = Math.floor(Math.random() * 20) + 1;
+      const roll = Math.floor(Math.random() * 20) + 1;
       // it doesn't appear that there are any real rules for this.
       if (hasSource(Source.SpeciesSourcebook)) {
         return roll <= 5 ? Species.KlingonQuchHa_2E : Species.Klingon;
@@ -4324,7 +4324,7 @@ class _Species {
         return roll <= 5 ? Species.KlingonQuchHa : Species.Klingon;
       }
     } else {
-      let roll = Math.floor(Math.random() * 20) + 1;
+      const roll = Math.floor(Math.random() * 20) + 1;
       let species = Species.Human;
 
       switch (store.getState().context.era) {
@@ -4513,8 +4513,8 @@ class _Species {
   }
 
   generateFromAlphaQuadrantTable(): Species {
-    var roll = Math.floor(Math.random() * 20) + 1;
-    var species = Species.Human;
+    const roll = Math.floor(Math.random() * 20) + 1;
+    let species = Species.Human;
 
     switch (store.getState().context.era) {
       case Era.Enterprise: {
@@ -4635,8 +4635,8 @@ class _Species {
   }
 
   generateFromBetaQuadrantTable(): Species {
-    var roll = Math.floor(Math.random() * 20) + 1;
-    var species = Species.Human;
+    const roll = Math.floor(Math.random() * 20) + 1;
+    let species = Species.Human;
 
     switch (store.getState().context.era) {
       case Era.Enterprise: {
@@ -4755,20 +4755,20 @@ class _Species {
   }
 
   generateRandomSpeciesForQuadrant(source: Source): Species | null {
-    let quadrantSpecies = this.getSpecies(CharacterType.Starfleet).filter(
+    const quadrantSpecies = this.getSpecies(CharacterType.Starfleet).filter(
       (s) => s.sources.indexOf(source) >= 0,
     );
     if (quadrantSpecies.length === 0) {
       return null;
     } else {
-      let roll = Math.floor(Math.random() * quadrantSpecies.length);
+      const roll = Math.floor(Math.random() * quadrantSpecies.length);
       return quadrantSpecies[roll].id;
     }
   }
 
   getCaptainsLogSpecies() {
-    let result: SpeciesModel[] = [];
-    for (let id in this._species) {
+    const result: SpeciesModel[] = [];
+    for (const id in this._species) {
       const species = this._species[id];
       if (species.sources.indexOf(Source.CaptainsLog) >= 0) {
         result.push(species);

--- a/WebTools/src/helpers/speciesAbility.ts
+++ b/WebTools/src/helpers/speciesAbility.ts
@@ -28,12 +28,16 @@ export class SpeciesAbility {
   }
 
   get name() {
-    let key = makeKey('SpeciesAbility.', Species[this.species]);
+    const key = makeKey('SpeciesAbility.', Species[this.species]);
     return i18next.t(key);
   }
 
   get description() {
-    let key = makeKey('SpeciesAbility.', Species[this.species], '.description');
+    const key = makeKey(
+      'SpeciesAbility.',
+      Species[this.species],
+      '.description',
+    );
     return i18next.t(key);
   }
 
@@ -56,7 +60,7 @@ export class SpeciesAbility {
   }
 
   public getChoiceName(choice: SpeciesAbilityChoice) {
-    let key = makeKey(
+    const key = makeKey(
       'SpeciesAbility.',
       Species[this.species],
       '.',
@@ -66,7 +70,7 @@ export class SpeciesAbility {
   }
 
   public getChoiceDescription(choice: SpeciesAbilityChoice) {
-    let key = makeKey(
+    const key = makeKey(
       'SpeciesAbility.',
       Species[this.species],
       '.',

--- a/WebTools/src/helpers/speciesModel.ts
+++ b/WebTools/src/helpers/speciesModel.ts
@@ -86,7 +86,7 @@ export class SpeciesModel implements ISpecies {
   }
 
   get isAttributeSelectionRequired() {
-    let definedAttributeCount =
+    const definedAttributeCount =
       this.attributes?.length - this.decrementAttributes?.length;
     if (definedAttributeCount <= 3) {
       return false;

--- a/WebTools/src/helpers/stationFrameModel.ts
+++ b/WebTools/src/helpers/stationFrameModel.ts
@@ -294,13 +294,13 @@ export class StationFrameModel {
 
   public static getById(type: StationFrame) {
     this.initializeType();
-    let frames = StationFrameModel.TYPES.filter((f) => type === f.id);
+    const frames = StationFrameModel.TYPES.filter((f) => type === f.id);
     return frames?.length ? frames[0] : undefined;
   }
 
   public static getByIdName(typeName: string) {
     this.initializeType();
-    let frames = StationFrameModel.TYPES.filter(
+    const frames = StationFrameModel.TYPES.filter(
       (f) => typeName === StationFrame[f.id],
     );
     return frames?.length ? frames[0] : undefined;

--- a/WebTools/src/helpers/systems.ts
+++ b/WebTools/src/helpers/systems.ts
@@ -19,6 +19,6 @@ export function allSystems() {
 }
 
 export function systemByName(name: string) {
-  let result = allSystems().filter((s) => System[s] === name);
+  const result = allSystems().filter((s) => System[s] === name);
   return result?.length ? result[0] : undefined;
 }

--- a/WebTools/src/helpers/talentModel.ts
+++ b/WebTools/src/helpers/talentModel.ts
@@ -49,7 +49,7 @@ export class TalentModel implements ITalent {
     if (category instanceof TalentCategorization) {
       this.category = category;
     } else {
-      let species = Object.keys(Species).filter(
+      const species = Object.keys(Species).filter(
         (item) => !isNaN(Number(item)) && Species[item] === category,
       );
       if (species?.length === 0) {
@@ -95,9 +95,9 @@ export class TalentModel implements ITalent {
 
   get is2eSupported() {
     let result = false;
-    let sources = SourcesHelper.getSources();
+    const sources = SourcesHelper.getSources();
     this.sources.forEach((s) => {
-      let source = sources.filter((src) => src.id === s)[0];
+      const source = sources.filter((src) => src.id === s)[0];
       if (source.version === 2) {
         result = true;
       }
@@ -106,8 +106,8 @@ export class TalentModel implements ITalent {
   }
 
   get is2eDescriptionPresent() {
-    let key = 'Talent.' + this.rootKey + '.description2e';
-    let result = i18next.t(key);
+    const key = 'Talent.' + this.rootKey + '.description2e';
+    const result = i18next.t(key);
     return result !== key;
   }
 
@@ -125,11 +125,11 @@ export class TalentModel implements ITalent {
   }
 
   get localizedDisplayName() {
-    let key = 'Talent.' + this.rootKey;
-    let result = i18next.t(key);
+    const key = 'Talent.' + this.rootKey;
+    const result = i18next.t(key);
 
     if (result === key) {
-      let name = this.localizedName;
+      const name = this.localizedName;
       if (this.category) {
         const suffix = ' (' + this.category + ')';
         if (name.indexOf(suffix) >= 0) {
@@ -146,14 +146,14 @@ export class TalentModel implements ITalent {
   }
 
   get localizedDescription() {
-    let key = 'Talent.' + this.rootKey + '.description';
-    let result = i18next.t(key);
+    const key = 'Talent.' + this.rootKey + '.description';
+    const result = i18next.t(key);
     return result === key ? this.description : result;
   }
 
   get localizedDescription2e() {
-    let key = 'Talent.' + this.rootKey + '.description2e';
-    let result = i18next.t(key);
+    const key = 'Talent.' + this.rootKey + '.description2e';
+    const result = i18next.t(key);
     return result === key ? this.localizedDescription : result;
   }
 
@@ -162,8 +162,8 @@ export class TalentModel implements ITalent {
   }
 
   get localizedName() {
-    let key = 'Talent.' + this.rootKey;
-    let result = i18next.t(key);
+    const key = 'Talent.' + this.rootKey;
+    const result = i18next.t(key);
     return result === key ? this.name : result;
   }
 
@@ -180,21 +180,21 @@ export class TalentModel implements ITalent {
   }
 
   localizedNameForSource(source: Source): string {
-    let result = this.localizedDisplayName;
-    let alias = this.aliases.filter((a) => a.source === source);
+    const result = this.localizedDisplayName;
+    const alias = this.aliases.filter((a) => a.source === source);
     return alias?.length ? alias[0].localizedName : result;
   }
 
   get localizedSoloDescription(): string {
     // for Starship talents, this is the short, abbreviated description of the talent
-    let key = 'Talent.' + this.rootKey + '.soloDescription';
-    let result = i18next.t(key);
+    const key = 'Talent.' + this.rootKey + '.soloDescription';
+    const result = i18next.t(key);
     return result === key ? '' : result;
   }
 
   private sourcesFromPrerequsite(prerequisite: ICompositePrerequisite) {
-    let result = [];
-    let subList = prerequisite.prerequisites;
+    const result = [];
+    const subList = prerequisite.prerequisites;
     subList.forEach((p) => {
       if (p instanceof SourcePrerequisite) {
         Array.prototype.push.apply(
@@ -296,7 +296,7 @@ export class TalentModel implements ITalent {
 
   nameForSource(source: Source) {
     let result = this.name;
-    for (let a of this.aliases) {
+    for (const a of this.aliases) {
       if (a.source === source) {
         result = a.name;
         break;
@@ -328,7 +328,7 @@ export class TalentModel implements ITalent {
   get requirement() {
     let prerequisites = undefined;
     this.prerequisites.forEach((p) => {
-      let desc = p.describe();
+      const desc = p.describe();
       if (desc) {
         if (prerequisites == null) {
           prerequisites = desc;

--- a/WebTools/src/helpers/talents.ts
+++ b/WebTools/src/helpers/talents.ts
@@ -237,8 +237,8 @@ class RandomNpcPrerequisite implements IConstructPrerequisite {
 
 class ScientistPrerequisite implements IConstructPrerequisite {
   isPrerequisiteFulfilled(c: Character | Starship | Creature | Station) {
-    let science = c.departments[Department.Science];
-    let temp = c.departments.filter((d) => d > science);
+    const science = c.departments[Department.Science];
+    const temp = c.departments.filter((d) => d > science);
     return temp.length === 0;
   }
 
@@ -249,8 +249,8 @@ class ScientistPrerequisite implements IConstructPrerequisite {
 
 class SecurityPrerequisite implements IConstructPrerequisite {
   isPrerequisiteFulfilled(c: Character | Starship | Creature | Station) {
-    let security = c.departments[Department.Security];
-    let temp = c.departments.filter((d) => d > security);
+    const security = c.departments[Department.Security];
+    const temp = c.departments.filter((d) => d > security);
     return temp.length === 0;
   }
 
@@ -261,8 +261,8 @@ class SecurityPrerequisite implements IConstructPrerequisite {
 
 class CommandPrerequisite implements IConstructPrerequisite {
   isPrerequisiteFulfilled(c: Character | Starship | Creature | Station) {
-    let command = c.departments[Department.Command];
-    let temp = c.departments.filter((d) => d > command);
+    const command = c.departments[Department.Command];
+    const temp = c.departments.filter((d) => d > command);
     return temp.length === 0;
   }
 
@@ -392,7 +392,7 @@ class FocusPrerequisite implements IConstructPrerequisite {
     if (!(c instanceof Character)) {
       return false;
     } else {
-      let localizedFocuses = this.focuses.map((f) => localizedFocus(f));
+      const localizedFocuses = this.focuses.map((f) => localizedFocus(f));
       return (
         c.focuses.filter(
           (f) => this.focuses.includes(f) || localizedFocuses.includes(f),
@@ -532,13 +532,13 @@ export class CenturyPrerequisite implements IConstructPrerequisite {
   }
 
   isPrerequisiteFulfilled(s: Character | Starship | Creature | Station) {
-    let year = centuryToYear(this.century);
+    const year = centuryToYear(this.century);
     if (!(s instanceof Starship)) {
       return false;
     } else if (this.toCentury == null) {
       return s != null && s.serviceYear != null && s.serviceYear >= year;
     } else {
-      let toYear = centuryToYear(this.toCentury + 1) + 1;
+      const toYear = centuryToYear(this.toCentury + 1) + 1;
       return (
         s != null &&
         s.serviceYear != null &&
@@ -562,7 +562,9 @@ export class CenturyPrerequisite implements IConstructPrerequisite {
   }
 
   addSuffix(century: number) {
-    let lastDigit = century.toString().substring(century.toString().length - 1);
+    const lastDigit = century
+      .toString()
+      .substring(century.toString().length - 1);
     if (lastDigit === '1') {
       return this.century + 'st';
     } else if (lastDigit === '2') {
@@ -9404,7 +9406,7 @@ export class Talents {
   customTalent = new TalentModel(TALENT_NAME_CUSTOM_TALENT, '', []);
 
   getTalents(): TalentModel[] {
-    let result = [];
+    const result = [];
     this._talents.forEach((t) => result.push(t));
     this._starshipTalents.forEach((t) => result.push(t));
     return result;
@@ -9419,7 +9421,7 @@ export class Talents {
 
     if (talent == null) {
       for (let i = 0; i < this._talents.length; i++) {
-        let t = this._talents[i];
+        const t = this._talents[i];
         if (t.matches(name)) {
           talent = t;
           break;
@@ -9429,7 +9431,7 @@ export class Talents {
 
     if (talent == null) {
       for (let i = 0; i < this._starshipTalents.length; i++) {
-        let t = this._starshipTalents[i];
+        const t = this._starshipTalents[i];
         if (t.matches(name)) {
           talent = t;
           break;
@@ -9439,7 +9441,7 @@ export class Talents {
 
     if (talent == null) {
       for (let i = 0; i < this._specialRules.length; i++) {
-        let t = this._specialRules[i];
+        const t = this._specialRules[i];
         if (t.matches(name)) {
           talent = t;
           break;
@@ -9448,7 +9450,7 @@ export class Talents {
     }
 
     if (talent == null && name.indexOf(' [') >= 0) {
-      let tempName = name.substring(0, name.indexOf(' ['));
+      const tempName = name.substring(0, name.indexOf(' ['));
       talent = this.getTalent(tempName);
     }
 
@@ -9489,12 +9491,12 @@ export class Talents {
     ) {
       return [this.getTalent('Morphogenic Matrix')];
     } else {
-      let result = this._talents.filter((t) =>
+      const result = this._talents.filter((t) =>
         t.isPrerequisiteFulfilled(character),
       );
 
       if (character.stereotype === Stereotype.Npc) {
-        let rules = this._specialRules.filter(
+        const rules = this._specialRules.filter(
           (t) =>
             t.isPrerequisiteFulfilled(character) &&
             !character.hasTalent(t.name),
@@ -9515,7 +9517,7 @@ export class Talents {
   ) {
     const talents: TalentModel[] = [];
     for (let i = 0; i < this._starshipTalents.length; i++) {
-      let talent = this._starshipTalents[i];
+      const talent = this._starshipTalents[i];
       let include = talent.isStarshipTalent;
       if (starship instanceof Station) {
         include = include || talent.isStarbaseTalent;
@@ -9544,7 +9546,7 @@ export class Talents {
   }
 
   getAllAvailableTalentsForNpc(character: Character): TalentModel[] {
-    let result = this._talents.filter((t) =>
+    const result = this._talents.filter((t) =>
       t.isPrerequisiteFulfilled(character),
     );
     result.push(
@@ -9558,7 +9560,7 @@ export class Talents {
     if (character.careerStep?.career === Career.Young) {
       return [this.getTalent(TALENT_NAME_UNTAPPED_POTENTIAL)];
     } else if (character.careerStep?.career === Career.Veteran) {
-      let result = [
+      const result = [
         this.getTalent('Veteran'),
         this.getTalent('Wrote the Book'),
         this.getTalent('Life Lessons'),

--- a/WebTools/src/helpers/tracks.ts
+++ b/WebTools/src/helpers/tracks.ts
@@ -121,20 +121,20 @@ export class TrackModel {
   }
 
   get localizedName() {
-    let key = makeKey(this.prefix, Track[this.id]);
-    let result = i18next.t(key);
+    const key = makeKey(this.prefix, Track[this.id]);
+    const result = i18next.t(key);
     return result === key ? this.name : result;
   }
 
   get localizedName2e() {
-    let key = makeKey(this.prefix, Track[this.id], '.2e');
-    let result = i18next.t(key);
+    const key = makeKey(this.prefix, Track[this.id], '.2e');
+    const result = i18next.t(key);
     return result === key ? this.localizedName : result;
   }
 
   get localizedDescription() {
-    let key = makeKey(this.prefix, Track[this.id], '.description');
-    let result = i18next.t(key);
+    const key = makeKey(this.prefix, Track[this.id], '.description');
+    const result = i18next.t(key);
     return result === key ? this.description : result;
   }
 }
@@ -1100,9 +1100,9 @@ export class TracksHelper {
   }
 
   getTracks(type: CharacterType, version: number) {
-    var tracks: TrackModel[] = [];
-    var list = this.chooseList(type, version);
-    for (let model of list) {
+    const tracks: TrackModel[] = [];
+    const list = this.chooseList(type, version);
+    for (const model of list) {
       if (hasAnySource(model.sources)) {
         if (model.id === Track.EnlistedSecurityTraining) {
           continue;
@@ -1136,7 +1136,7 @@ export class TracksHelper {
       this._ambassardorTracks,
       this._civilianTracks,
     ];
-    let result = tracks
+    const result = tracks
       .map((list) => list.filter((t) => t.id === track))
       .filter((list) => list.length > 0)
       .map((list) => list[0]);
@@ -1144,12 +1144,12 @@ export class TracksHelper {
   }
 
   getTrack(track: Track, type: CharacterType, version: number): TrackModel {
-    let list =
+    const list =
       type === CharacterType.Starfleet && version > 1
         ? this._version2Tracks
         : this.chooseList(type, version);
     let result = null;
-    for (let t of list) {
+    for (const t of list) {
       if (t.id === track) {
         result = t;
         break;
@@ -1199,16 +1199,16 @@ export class TracksHelper {
 
   generateTrack(characterType: CharacterType, version: number): Track {
     if (characterType === CharacterType.Starfleet && version === 1) {
-      let tracks = [Track.Command, Track.Operations, Track.Sciences];
-      let roll = Math.floor(Math.random() * tracks.length);
+      const tracks = [Track.Command, Track.Operations, Track.Sciences];
+      const roll = Math.floor(Math.random() * tracks.length);
       return tracks[roll];
     } else if (characterType === CharacterType.Starfleet) {
-      let list = this._version2Tracks;
-      let roll = Math.floor(Math.random() * list.length);
+      const list = this._version2Tracks;
+      const roll = Math.floor(Math.random() * list.length);
       return list[roll].id;
     } else {
-      let list = this.chooseList(characterType, version);
-      let roll = Math.floor(Math.random() * list.length);
+      const list = this.chooseList(characterType, version);
+      const roll = Math.floor(Math.random() * list.length);
       return list[roll].id;
     }
   }

--- a/WebTools/src/helpers/upbringings.ts
+++ b/WebTools/src/helpers/upbringings.ts
@@ -74,24 +74,24 @@ export class EarlyOutlookModel {
   }
 
   get localizedName() {
-    let key = makeKey(this.keyPrefix, EarlyOutlook[this.id], '.name');
-    let result = i18next.t(key);
+    const key = makeKey(this.keyPrefix, EarlyOutlook[this.id], '.name');
+    const result = i18next.t(key);
     return result === key ? this.name : result;
   }
 
   get localizedDescription() {
-    let key = makeKey(this.keyPrefix, EarlyOutlook[this.id], '.description');
-    let result = i18next.t(key);
+    const key = makeKey(this.keyPrefix, EarlyOutlook[this.id], '.description');
+    const result = i18next.t(key);
     return result === key ? this.description : result;
   }
 
   get localizedFocusDescription() {
-    let key = makeKey(
+    const key = makeKey(
       this.keyPrefix,
       EarlyOutlook[this.id],
       '.focusDescription',
     );
-    let result = i18next.t(key);
+    const result = i18next.t(key);
     return result === key ? this.focusDescription : result;
   }
 }
@@ -701,12 +701,12 @@ class Upbringings {
   }
 
   getCastes() {
-    let list = this.getEarlyOutlooksList(CharacterType.KlingonWarrior, false);
+    const list = this.getEarlyOutlooksList(CharacterType.KlingonWarrior, false);
     return this.toList(list);
   }
 
   getCaste(caste: EarlyOutlook) {
-    var list = this.getEarlyOutlooksList(
+    const list = this.getEarlyOutlooksList(
       CharacterType.KlingonWarrior,
       false,
     ).filter((o) => o.id === caste);
@@ -714,7 +714,7 @@ class Upbringings {
   }
 
   getAspirations() {
-    let list = this.getEarlyOutlooksList(CharacterType.Starfleet, true);
+    const list = this.getEarlyOutlooksList(CharacterType.Starfleet, true);
     return this.toList(list);
   }
 
@@ -757,9 +757,10 @@ class Upbringings {
     );
   }
   getAspiration(aspiration: EarlyOutlook) {
-    var list = this.getEarlyOutlooksList(CharacterType.Starfleet, true).filter(
-      (o) => o.id === aspiration,
-    );
+    const list = this.getEarlyOutlooksList(
+      CharacterType.Starfleet,
+      true,
+    ).filter((o) => o.id === aspiration);
     return list ? list[0] : undefined;
   }
 
@@ -770,30 +771,31 @@ class Upbringings {
   }
 
   getUpbringings() {
-    var list = this.getEarlyOutlooksList(CharacterType.Starfleet, false);
+    const list = this.getEarlyOutlooksList(CharacterType.Starfleet, false);
     return this.toList(list);
   }
 
   getUpbringing(upbringing: EarlyOutlook) {
-    var list = this.getEarlyOutlooksList(CharacterType.Starfleet, false).filter(
-      (o) => o.id === upbringing,
-    );
+    const list = this.getEarlyOutlooksList(
+      CharacterType.Starfleet,
+      false,
+    ).filter((o) => o.id === upbringing);
     return list ? list[0] : undefined;
   }
 
   getAllUpbringings(characterType: CharacterType, alternate: boolean = false) {
-    var list = this.getEarlyOutlooksList(characterType, alternate);
+    const list = this.getEarlyOutlooksList(characterType, alternate);
     return this.toList(list);
   }
 
   generateUpbringing(characterType: CharacterType, alternate: boolean) {
-    let list = this.getEarlyOutlooksList(characterType, alternate);
-    var roll = Math.floor(Math.random() * list.length);
+    const list = this.getEarlyOutlooksList(characterType, alternate);
+    const roll = Math.floor(Math.random() * list.length);
     return list[roll];
   }
 
   getUpbringingByTypeName(typeName: string, type: CharacterType) {
-    let mapping = {
+    const mapping = {
       MilitaryOrExploration: EarlyOutlook[EarlyOutlook.WarriorCaste],
       BusinessOrTrade: EarlyOutlook[EarlyOutlook.MerchantCaste],
       AgricultureOrRural: EarlyOutlook[EarlyOutlook.AgriculturalCaste],
@@ -803,7 +805,7 @@ class Upbringings {
     };
 
     if (isKlingonWarriorType(type)) {
-      let compat = mapping[typeName];
+      const compat = mapping[typeName];
       if (compat) {
         typeName = compat;
       }

--- a/WebTools/src/helpers/weapons.ts
+++ b/WebTools/src/helpers/weapons.ts
@@ -78,7 +78,7 @@ export class WeaponQuality {
         { rank: this.rank },
       );
     } else {
-      let key = makeKey('Weapon.quality.', Quality[this.quality], '.name');
+      const key = makeKey('Weapon.quality.', Quality[this.quality], '.name');
       return i18next.t(key, { rank: '' }) === key
         ? Quality[this.quality]
         : i18next.t(key, { rank: '' });
@@ -381,7 +381,7 @@ export class EnergyLoadTypeModel {
   }
 
   static getEnergyLoadTypeModelByType(type: EnergyLoadType, version: number) {
-    let result = this.allTypes(version).filter((e) => e.type === type)[0];
+    const result = this.allTypes(version).filter((e) => e.type === type)[0];
     return result;
   }
 }
@@ -715,14 +715,14 @@ export class TorpedoLoadTypeModel {
   }
 
   get effectAndQualities() {
-    let result = [];
+    const result = [];
     this._weaponEffects.forEach((e) => result.push(e));
     this._weaponQualities.forEach((q) => result.push(q));
     return result;
   }
 
   static getTorpedoLoadTypeModelByType(type: TorpedoLoadType, version: number) {
-    let result = this.allTypes(version).filter((e) => e.type === type)[0];
+    const result = this.allTypes(version).filter((e) => e.type === type)[0];
     return result;
   }
 }
@@ -1010,18 +1010,18 @@ export class MineTypeModel {
   }
 
   get effectAndQualities(): WeaponQuality[] {
-    let result = [];
+    const result = [];
     result.push(...this._weaponEffects);
     result.push(...this._weaponQualities);
     return result;
   }
 
   get effectAndQualitiesAsString(): string {
-    let result: string[] = [];
+    const result: string[] = [];
     if (this.effect) {
       result.push(this.effect);
     }
-    let qualities = this.qualities;
+    const qualities = this.qualities;
     if (qualities) {
       result.push(qualities);
     }
@@ -1029,17 +1029,19 @@ export class MineTypeModel {
   }
 
   get effect() {
-    let result = this._weaponEffects.map((q) => q.localizedDescription);
+    const result = this._weaponEffects.map((q) => q.localizedDescription);
     return result.join(', ');
   }
 
   get qualities() {
-    let result = this._weaponQualities.map((q) => q.localizedDescription);
+    const result = this._weaponQualities.map((q) => q.localizedDescription);
     return result.join(', ');
   }
 
   static getMineTypeById(type: MineType, version: number) {
-    let types = MineTypeModel.allTypes(version).filter((t) => t.type === type);
+    const types = MineTypeModel.allTypes(version).filter(
+      (t) => t.type === type,
+    );
     return types?.length ? types[0] : null;
   }
 }
@@ -1141,7 +1143,7 @@ export class Weapon {
   }
 
   copy() {
-    let result = new Weapon(
+    const result = new Weapon(
       this.usageCategory,
       this._name,
       this.baseDice,
@@ -1192,7 +1194,7 @@ export class Weapon {
     if (this.usageCategory === UsageCategory.Character) {
       return this.effects.concat(this.qualities);
     } else if (this.loadType instanceof EnergyLoadTypeModel) {
-      let quality = [
+      const quality = [
         ...(this.loadType as EnergyLoadTypeModel).effectsAndQualities,
       ];
       if (this.deliveryType?.additionalQuality != null) {
@@ -1279,13 +1281,13 @@ export class Weapon {
         this.loadType != null &&
         this.loadType instanceof TorpedoLoadTypeModel
       ) {
-        let torpedoLoadType = this.loadType as TorpedoLoadTypeModel;
+        const torpedoLoadType = this.loadType as TorpedoLoadTypeModel;
         result = [...torpedoLoadType._weaponQualities];
       } else if (
         this.loadType != null &&
         this.loadType instanceof MineTypeModel
       ) {
-        let mineType = this.loadType as MineTypeModel;
+        const mineType = this.loadType as MineTypeModel;
         result = [...mineType._weaponQualities];
       }
 
@@ -1307,13 +1309,13 @@ export class Weapon {
         this.loadType != null &&
         this.loadType instanceof TorpedoLoadTypeModel
       ) {
-        let torpedoLoadType = this.loadType as TorpedoLoadTypeModel;
+        const torpedoLoadType = this.loadType as TorpedoLoadTypeModel;
         result = [...torpedoLoadType._weaponEffects];
       } else if (
         this.loadType != null &&
         this.loadType instanceof MineTypeModel
       ) {
-        let mineType = this.loadType as MineTypeModel;
+        const mineType = this.loadType as MineTypeModel;
         result = [...mineType._weaponEffects];
       }
 
@@ -1325,13 +1327,13 @@ export class Weapon {
     }
   }
   get injuryTypeEffectsAndQualities() {
-    let result = [];
+    const result = [];
     if (this.injuryType != null) {
       result.push(
         i18next.t(makeKey('InjuryType.', InjuryType[this.injuryType])),
       );
     }
-    let temp = this.effectsAndQualitiesAsString;
+    const temp = this.effectsAndQualitiesAsString;
     if (temp.length) {
       result.push(temp);
     }
@@ -1342,7 +1344,7 @@ export class Weapon {
     if (this.usageCategory === UsageCategory.Character) {
       return [...this.weaponQualities];
     } else {
-      let result = [];
+      const result = [];
       if (
         this.loadType != null &&
         this.loadType instanceof EnergyLoadTypeModel
@@ -1354,13 +1356,13 @@ export class Weapon {
         this.loadType != null &&
         this.loadType instanceof TorpedoLoadTypeModel
       ) {
-        let torpedoLoadType = this.loadType as TorpedoLoadTypeModel;
+        const torpedoLoadType = this.loadType as TorpedoLoadTypeModel;
         result.push(...torpedoLoadType.effectAndQualities);
       } else if (
         this.loadType != null &&
         this.loadType instanceof MineTypeModel
       ) {
-        let torpedoLoadType = this.loadType as MineTypeModel;
+        const torpedoLoadType = this.loadType as MineTypeModel;
         result.push(...torpedoLoadType.effectAndQualities);
       }
 
@@ -1392,7 +1394,7 @@ export class Weapon {
     hands: number = 1,
     personalWeaponType?: PersonalWeaponType,
   ) {
-    let result = new Weapon(UsageCategory.Character, name, dice, type);
+    const result = new Weapon(UsageCategory.Character, name, dice, type);
     result._qualities = qualities;
     result._effects = effects;
     result.hands = hands;
@@ -1686,8 +1688,8 @@ class StarshipWeaponList {
   }
 
   getWeaponByName(name: string, version: number) {
-    let list = version === 1 ? this.list : this.list2e;
-    let filteredList = list.filter((w) => w.name === name);
+    const list = version === 1 ? this.list : this.list2e;
+    const filteredList = list.filter((w) => w.name === name);
     return filteredList?.length ? filteredList[0] : undefined;
   }
 }

--- a/WebTools/src/i18n/config.ts
+++ b/WebTools/src/i18n/config.ts
@@ -62,19 +62,19 @@ const languageDetector = new LanguageDetector();
 languageDetector.addDetector(staDetector);
 
 export const getNavigatorLanguage = () => {
-  let found = staDetector
+  const found = staDetector
     .lookup({})
     ?.filter((l) => supportedLanguagesCodes.includes(l));
   return found?.length ? found[0] : 'en';
 };
 
 export const isEnglishDefault = () => {
-  let language = getNavigatorLanguage();
+  const language = getNavigatorLanguage();
   return language.indexOf('en') === 0;
 };
 
 export const getCurrentLanguageCode = () => {
-  let previousLanguage = window.localStorage.getItem(localStorageKey);
+  const previousLanguage = window.localStorage.getItem(localStorageKey);
   if (previousLanguage == null) {
     return getNavigatorLanguage();
   } else if (
@@ -101,7 +101,7 @@ export const clearLanguageOverride = () => {
 };
 
 export const isLanguageOverridePresent = () => {
-  let value = window.localStorage.getItem(localStorageKey);
+  const value = window.localStorage.getItem(localStorageKey);
   return value === 'en';
 };
 

--- a/WebTools/src/index.tsx
+++ b/WebTools/src/index.tsx
@@ -148,7 +148,7 @@ const StationTalentsPage = React.lazy(
     ),
 );
 
-let root = createRoot(document.getElementById('mainBody'));
+const root = createRoot(document.getElementById('mainBody'));
 root.render(
   <HelmetProvider>
     <Provider store={store}>

--- a/WebTools/src/mapping/export/pdfExporter.ts
+++ b/WebTools/src/mapping/export/pdfExporter.ts
@@ -39,7 +39,7 @@ class TextBlock {
       this.text = [text];
     } else {
       this.text = [];
-      let parts = text.split(' ');
+      const parts = text.split(' ');
       let currentText = '';
       parts.forEach((p) => {
         if (
@@ -73,7 +73,7 @@ class TextBlock {
   ) {
     this.text.forEach((t) => {
       if (alignment === TextAlignment.Center) {
-        let width = this.font.widthOfTextAtSize(t, this.fontSize);
+        const width = this.font.widthOfTextAtSize(t, this.fontSize);
         page.drawText(t, {
           x: column - width / 2,
           y: page.getHeight() - currentLine,
@@ -82,7 +82,7 @@ class TextBlock {
           color: this.color,
         });
       } else if (alignment === TextAlignment.Right) {
-        let width = this.font.widthOfTextAtSize(t, this.fontSize);
+        const width = this.font.widthOfTextAtSize(t, this.fontSize);
         page.drawText(t, {
           x: column - width,
           y: page.getHeight() - currentLine,
@@ -208,7 +208,7 @@ export class PdfExporter {
       sector,
     );
 
-    let systems = sector.systems;
+    const systems = sector.systems;
     for (let i = 0; i < systems.length; i++) {
       await this.populateSystemPage(
         pdf,
@@ -224,7 +224,7 @@ export class PdfExporter {
   }
 
   async createStarSystemPdf(system: StarSystem) {
-    let pdf = await PDFDocument.create();
+    const pdf = await PDFDocument.create();
     pdf.registerFontkit(fontkit);
     const lcarsFontBytes = await fetch('/static/font/lcars_font.TTF').then(
       (res) => res.arrayBuffer(),
@@ -289,7 +289,7 @@ export class PdfExporter {
       font,
     );
 
-    let lineHeight = font.heightAtSize(12, { descender: true });
+    const lineHeight = font.heightAtSize(12, { descender: true });
     let currentLine = 60 + lineHeight;
 
     this.addLabelAndValue(
@@ -310,7 +310,7 @@ export class PdfExporter {
     this.renderPlanetsLower(page, font, system);
 
     currentLine = 215;
-    let blockLine = currentLine;
+    const blockLine = currentLine;
 
     if (system.star) {
       this.addPillHeader(
@@ -355,7 +355,7 @@ export class PdfExporter {
         PdfExporter.COLUMN_ONE,
         currentLine,
       );
-      let offset = light.widthOfTextAtSize(
+      const offset = light.widthOfTextAtSize(
         system.star.massInKgs.toFixed(4) + ' x 10',
         10.0,
       );
@@ -451,7 +451,7 @@ export class PdfExporter {
         PdfExporter.COLUMN_TWO,
         currentLine,
       );
-      let offset = light.widthOfTextAtSize(
+      const offset = light.widthOfTextAtSize(
         system.companionStar.massInKgs.toFixed(4) + ' x 10',
         10.0,
       );
@@ -491,34 +491,34 @@ export class PdfExporter {
     currentLine += 20;
 
     if (system.worlds?.length) {
-      let innerWorlds = system.worldsAndSatelliteWorlds.filter(
+      const innerWorlds = system.worldsAndSatelliteWorlds.filter(
         (w) => w.orbitalRadius < system.gardenZoneInnerRadius,
       );
-      let ecosphereWorlds = system.worldsAndSatelliteWorlds.filter(
+      const ecosphereWorlds = system.worldsAndSatelliteWorlds.filter(
         (w) =>
           w.orbitalRadius >= system.gardenZoneInnerRadius &&
           w.orbitalRadius < system.gardenZoneOuterRadius,
       );
-      let outerWorlds = system.worldsAndSatelliteWorlds.filter(
+      const outerWorlds = system.worldsAndSatelliteWorlds.filter(
         (w) => w.orbitalRadius >= system.gardenZoneOuterRadius,
       );
 
-      let titles = [
+      const titles = [
         i18next.t('StarSystem.common.innerZone'),
         i18next.t('StarSystem.common.ecosphere'),
         i18next.t('StarSystem.common.outerZone'),
       ];
-      let worldLists = [innerWorlds, ecosphereWorlds, outerWorlds];
+      const worldLists = [innerWorlds, ecosphereWorlds, outerWorlds];
 
       for (let i = 0; i < titles.length; i++) {
-        let worlds = worldLists[i];
-        let title = titles[i];
+        const worlds = worldLists[i];
+        const title = titles[i];
         let titleWritten = false;
 
         for (let j = 0; j < worlds.length; j++) {
-          let attributes = worlds[j].attributeList;
+          const attributes = worlds[j].attributeList;
           if (attributes.length) {
-            let block = new AttributeTwoColumnBlock(
+            const block = new AttributeTwoColumnBlock(
               attributes.map(
                 (a) =>
                   new AttributeDataValue(
@@ -612,16 +612,16 @@ export class PdfExporter {
       PdfExporter.LCARS_BLACK,
     ).writeOnPage(page, 533, 114);
 
-    let r = Math.max(
+    const r = Math.max(
       2,
       Math.sqrt(system.star?.spectralClass?.radius?.midpoint * 60),
     );
-    let starColor = rgb(
+    const starColor = rgb(
       system.star.spectralClass.colour.red / 255.0,
       system.star.spectralClass.colour.green / 255.0,
       system.star.spectralClass.colour.blue / 255.0,
     );
-    let borderColor = system.star.spectralClass.colour.isApproximatelyWhite
+    const borderColor = system.star.spectralClass.colour.isApproximatelyWhite
       ? PdfExporter.LCARS_BLACK
       : PdfExporter.LCARS_WHITE;
     page.drawCircle({
@@ -670,16 +670,16 @@ export class PdfExporter {
     }
 
     if (system.companionStar && system.companionType === CompanionType.Close) {
-      let r2 = Math.max(
+      const r2 = Math.max(
         2,
         Math.sqrt(system.companionStar?.spectralClass?.radius?.midpoint * 60),
       );
-      let starColor2 = rgb(
+      const starColor2 = rgb(
         system.companionStar.spectralClass.colour.red / 255.0,
         system.companionStar.spectralClass.colour.green / 255.0,
         system.companionStar.spectralClass.colour.blue / 255.0,
       );
-      let borderColor2 = system.companionStar.spectralClass.colour
+      const borderColor2 = system.companionStar.spectralClass.colour
         .isApproximatelyWhite
         ? PdfExporter.LCARS_BLACK
         : PdfExporter.LCARS_WHITE;
@@ -731,7 +731,7 @@ export class PdfExporter {
       }
     }
 
-    let orbits = this.findAllOrbits(system);
+    const orbits = this.findAllOrbits(system);
     let maxWorldDiameter = 50000;
     system.worlds
       ?.filter((w) => w.diameter != null)
@@ -744,23 +744,23 @@ export class PdfExporter {
       .forEach(
         (w) => (smallWorldDiameter = Math.min(w.diameter, smallWorldDiameter)),
       );
-    let factor =
+    const factor =
       10 / Math.sqrt(maxWorldDiameter / 1000 - smallWorldDiameter / 1000);
 
     system.worlds?.forEach((w, i) => {
-      let r = Math.max(
+      const r = Math.max(
         1,
         w.diameter == null
           ? 10
           : Math.sqrt(w.diameter / 1500 - smallWorldDiameter / 1500) * factor,
       );
-      let orbitalX = this.calculateOrbitX(w.orbitalRadius, orbits);
-      let prevOrbitalX =
+      const orbitalX = this.calculateOrbitX(w.orbitalRadius, orbits);
+      const prevOrbitalX =
         i === 0
           ? PdfExporter.COLUMN_ONE
           : this.calculateOrbitX(system.worlds[i - 1].orbitalRadius, orbits) +
             1;
-      let auWidth = orbitalX - 1 - prevOrbitalX;
+      const auWidth = orbitalX - 1 - prevOrbitalX;
 
       if (auWidth > 0) {
         page.drawSvgPath(
@@ -774,7 +774,7 @@ export class PdfExporter {
             borderWidth: 0,
           },
         );
-        let label = new TextBlock(
+        const label = new TextBlock(
           w.orbitalRadius.toFixed(2) + ' AU',
           8,
           font,
@@ -787,8 +787,8 @@ export class PdfExporter {
 
       if (w.worldClass.id === WorldClass.AsteroidBelt) {
         if (w.worldDetails instanceof AsteroidBeltDetails) {
-          let details = w.worldDetails as AsteroidBeltDetails;
-          let innermostRadius = w.orbitalRadius - details.depth / 2;
+          const details = w.worldDetails as AsteroidBeltDetails;
+          const innermostRadius = w.orbitalRadius - details.depth / 2;
           page.drawCircle({
             x: this.calculateOrbitX(innermostRadius, orbits),
             y: page.getHeight() - 130.5,
@@ -796,7 +796,7 @@ export class PdfExporter {
             color: PdfExporter.LCARS_PURPLE,
           });
 
-          let innerMidRadius = w.orbitalRadius - details.depth / 4;
+          const innerMidRadius = w.orbitalRadius - details.depth / 4;
           page.drawCircle({
             x: this.calculateOrbitX(innerMidRadius, orbits),
             y: page.getHeight() - 134.5,
@@ -804,7 +804,7 @@ export class PdfExporter {
             color: PdfExporter.LCARS_PURPLE,
           });
 
-          let outermostRadius = w.orbitalRadius + details.depth / 2;
+          const outermostRadius = w.orbitalRadius + details.depth / 2;
           page.drawCircle({
             x: this.calculateOrbitX(outermostRadius, orbits),
             y: page.getHeight() - 133.5,
@@ -812,7 +812,7 @@ export class PdfExporter {
             color: PdfExporter.LCARS_PURPLE,
           });
 
-          let outerMidRadius = w.orbitalRadius + details.depth / 4;
+          const outerMidRadius = w.orbitalRadius + details.depth / 4;
           page.drawCircle({
             x: this.calculateOrbitX(outerMidRadius, orbits),
             y: page.getHeight() - 130.5,
@@ -873,7 +873,7 @@ export class PdfExporter {
     });
 
     if (system.worlds?.length) {
-      let x =
+      const x =
         this.calculateOrbitX(
           system.worlds[system.worlds.length - 1].orbitalRadius,
           orbits,
@@ -897,8 +897,8 @@ export class PdfExporter {
       system.gardenZoneInnerRadius &&
       system.gardenZoneOuterRadius
     ) {
-      let innerX = this.calculateOrbitX(system.gardenZoneInnerRadius, orbits);
-      let outerX = this.calculateOrbitX(system.gardenZoneOuterRadius, orbits);
+      const innerX = this.calculateOrbitX(system.gardenZoneInnerRadius, orbits);
+      const outerX = this.calculateOrbitX(system.gardenZoneOuterRadius, orbits);
       page.drawSvgPath(
         'M 167.999,180.000 V 168 H' + (innerX - 1).toFixed(2) + ' V 180 z',
         {
@@ -906,7 +906,7 @@ export class PdfExporter {
           borderWidth: 0,
         },
       );
-      let innerText = new TextBlock(
+      const innerText = new TextBlock(
         'INNER ZONE',
         6,
         font,
@@ -927,7 +927,7 @@ export class PdfExporter {
           borderWidth: 0,
         },
       );
-      let ecoText = new TextBlock(
+      const ecoText = new TextBlock(
         'ECOSPHERE',
         6,
         font,
@@ -949,7 +949,7 @@ export class PdfExporter {
           borderWidth: 0,
         },
       );
-      let outerText = new TextBlock(
+      const outerText = new TextBlock(
         'OUTER ZONE',
         6,
         font,
@@ -972,7 +972,7 @@ export class PdfExporter {
       system.worlds?.length &&
       system.worlds[0].worldClass.id === WorldClass.AsteroidBelt
     ) {
-      let belt = system.worlds[0];
+      const belt = system.worlds[0];
       if (belt.worldDetails instanceof AsteroidBeltDetails) {
         orbits.push(
           belt.orbitalRadius -
@@ -985,7 +985,7 @@ export class PdfExporter {
       system.worlds[system.worlds.length - 1].worldClass.id ===
         WorldClass.AsteroidBelt
     ) {
-      let belt = system.worlds[system.worlds.length - 1];
+      const belt = system.worlds[system.worlds.length - 1];
       if (belt.worldDetails instanceof AsteroidBeltDetails) {
         orbits.push(
           belt.orbitalRadius +
@@ -1011,9 +1011,9 @@ export class PdfExporter {
 
   calculateOrbitX(orbitInAus: number, orbits: number[]) {
     if (orbits?.length) {
-      let firstOrbitInAus = orbits[0];
-      let firstOrbit = Math.log1p(firstOrbitInAus);
-      let lastOrbit = Math.log1p(orbits[orbits.length - 1]);
+      const firstOrbitInAus = orbits[0];
+      const firstOrbit = Math.log1p(firstOrbitInAus);
+      const lastOrbit = Math.log1p(orbits[orbits.length - 1]);
 
       return (
         PdfExporter.COLUMN_ONE +
@@ -1034,10 +1034,10 @@ export class PdfExporter {
     start: number,
     end: number,
   ) {
-    let lineHeight = 18;
-    let textWidth = font.widthOfTextAtSize(headerText.toUpperCase(), 18);
-    let r = lineHeight / 2;
-    let offset = r * 1.2;
+    const lineHeight = 18;
+    const textWidth = font.widthOfTextAtSize(headerText.toUpperCase(), 18);
+    const r = lineHeight / 2;
+    const offset = r * 1.2;
 
     page.drawCircle({
       x: start + r,
@@ -1106,7 +1106,7 @@ export class PdfExporter {
 
   async addLcarsHeaderToPage(page: PDFPage, text: string, font: PDFFont) {
     text = text.toLocaleUpperCase();
-    let width = font.widthOfTextAtSize(text, 18.0);
+    const width = font.widthOfTextAtSize(text, 18.0);
     page.drawRectangle({
       x: 564 - (width + 8),
       y: page.getHeight() - 45,
@@ -1144,11 +1144,11 @@ export class PdfExporter {
       color: PdfExporter.LCARS_PURPLE,
     });
 
-    let systems = sector.sortedSystems;
+    const systems = sector.sortedSystems;
     systems.forEach((s) => {
-      let z = (s.sectorCoordinates.z / 20) * 0.6 + 0.4;
-      let baseColour = s.star.spectralClass.colour;
-      let colour = baseColour.blend(new SimpleColor(255, 255, 255), 1 - z);
+      const z = (s.sectorCoordinates.z / 20) * 0.6 + 0.4;
+      const baseColour = s.star.spectralClass.colour;
+      const colour = baseColour.blend(new SimpleColor(255, 255, 255), 1 - z);
       let borderColour = colour;
       if (colour.isApproximatelyWhite) {
         borderColour = SimpleColor.from('#666666').blend(
@@ -1160,10 +1160,13 @@ export class PdfExporter {
       let r = Math.max(1, Math.sqrt(s.star.spectralClass.radius.midpoint * 35));
 
       if (s.isBinary) {
-        let r1 = r * 0.75;
+        const r1 = r * 0.75;
 
-        let baseColour2 = s.companionStar.spectralClass.colour;
-        let colour2 = baseColour2.blend(new SimpleColor(255, 255, 255), 1 - z);
+        const baseColour2 = s.companionStar.spectralClass.colour;
+        const colour2 = baseColour2.blend(
+          new SimpleColor(255, 255, 255),
+          1 - z,
+        );
         let borderColour2 = colour2;
         if (colour2.isApproximatelyWhite) {
           borderColour2 = SimpleColor.from('#666666').blend(
@@ -1250,7 +1253,7 @@ export class PdfExporter {
         borderWidth: 0.75,
       });
 
-      let sectorText = s.friendlyName
+      const sectorText = s.friendlyName
         ? s.friendlyName.toLocaleUpperCase()
         : s.id;
       page.drawText(sectorText, {

--- a/WebTools/src/mapping/page/starSystemDetailsPage.tsx
+++ b/WebTools/src/mapping/page/starSystemDetailsPage.tsx
@@ -31,11 +31,11 @@ const StarSystemDetailsPage: React.FC<IStarSystemDetailsPageProperties> = ({
   const navigate = useNavigate();
 
   const renderWorlds = (title: string, from: number, to?: number) => {
-    let worlds = starSystem.worldsAndSatelliteWorlds.filter(
+    const worlds = starSystem.worldsAndSatelliteWorlds.filter(
       (w) => w.orbitalRadius >= from && (to == null || w.orbitalRadius < to),
     );
     if (worlds.length > 0) {
-      let list = worlds.map((w, i) => (
+      const list = worlds.map((w, i) => (
         <WorldView world={w} system={starSystem} key={'world-' + w.orbitId} />
       ));
       return (
@@ -57,7 +57,7 @@ const StarSystemDetailsPage: React.FC<IStarSystemDetailsPageProperties> = ({
       async ({ PdfExporter }) => {
         setLoadingExport(false);
 
-        let pdfDoc = await new PdfExporter().createStarSystemPdf(starSystem);
+        const pdfDoc = await new PdfExporter().createStarSystemPdf(starSystem);
 
         const pdfBytes = await pdfDoc.save();
         download(

--- a/WebTools/src/mapping/page/systemGenerationPage.tsx
+++ b/WebTools/src/mapping/page/systemGenerationPage.tsx
@@ -28,7 +28,7 @@ const SystemGenerationPage = () => {
 
   const renderSectorTypeSection = () => {
     if (region === SpaceRegion.ShackletonExpanse) {
-      let options = SpecialSectorTypeModel.allSpecialSectorTypes().map(
+      const options = SpecialSectorTypeModel.allSpecialSectorTypes().map(
         (s) => new DropDownElement(s.id, s.name),
       );
       return (

--- a/WebTools/src/mapping/table/atmosphereTable.ts
+++ b/WebTools/src/mapping/table/atmosphereTable.ts
@@ -44,7 +44,7 @@ export class AtmosphereDetails {
   }
 
   get attributeList(): WorldAttribute[] {
-    let result = [];
+    const result = [];
     result.push(
       new WorldAttribute(
         i18next.t('World.attribute.atmosphereType'),
@@ -129,7 +129,9 @@ const atmosphereTableClassE = () => {
 };
 
 const atmosphereTableClassK = () => {
-  let result = new AtmosphereDetails(AtmosphereType.StandardOxygenNitrogenMix);
+  const result = new AtmosphereDetails(
+    AtmosphereType.StandardOxygenNitrogenMix,
+  );
   result.density =
     D20.roll() <= 10
       ? AtmosphericDensityType.VeryThin
@@ -138,7 +140,7 @@ const atmosphereTableClassK = () => {
 };
 
 const atmosphereTableClassL = () => {
-  let result = new AtmosphereDetails(AtmosphereType.OxygenArgonMix);
+  const result = new AtmosphereDetails(AtmosphereType.OxygenArgonMix);
   result.density =
     D20.roll() <= 10
       ? AtmosphericDensityType.VeryThin
@@ -147,7 +149,9 @@ const atmosphereTableClassL = () => {
 };
 
 const atmosphereTableClassM = () => {
-  let result = new AtmosphereDetails(AtmosphereType.StandardOxygenNitrogenMix);
+  const result = new AtmosphereDetails(
+    AtmosphereType.StandardOxygenNitrogenMix,
+  );
 
   switch (D20.roll()) {
     case 1:
@@ -220,8 +224,8 @@ const atmosphericContaminantTable = () => {
     case 19:
       return [AtmosphericContaminantType.IrritantPollens];
     case 20:
-      let result = atmosphericContaminantTable();
-      let more = atmosphericContaminantTable();
+      const result = atmosphericContaminantTable();
+      const more = atmosphericContaminantTable();
       more.forEach((c) => {
         if (result.indexOf(c) < 0) {
           if (

--- a/WebTools/src/mapping/table/civilizationTables.ts
+++ b/WebTools/src/mapping/table/civilizationTables.ts
@@ -29,7 +29,7 @@ export enum ReligionType {
 }
 
 export const governmentTypeTable: TableRoll<GovernmentType> = () => {
-  let roll = D20.roll();
+  const roll = D20.roll();
   switch (roll) {
     case 1:
     case 2:
@@ -63,7 +63,7 @@ export const governmentTypeTable: TableRoll<GovernmentType> = () => {
 };
 
 export const polityTypeTable: TableRoll<PolityType> = () => {
-  let roll = D20.roll();
+  const roll = D20.roll();
   switch (roll) {
     case 1:
     case 2:

--- a/WebTools/src/mapping/table/luminosityTable.ts
+++ b/WebTools/src/mapping/table/luminosityTable.ts
@@ -199,16 +199,16 @@ class LuminosityTableImpl {
         l.spectralClass === star.spectralClass.id,
     );
 
-    let exactMatch = this.selectOption(options, star.subClass);
+    const exactMatch = this.selectOption(options, star.subClass);
     if (exactMatch != null) {
       return addNoiseToValue(exactMatch.luminosity);
     } else {
       let o9 = this.selectOption(options, 9);
       if (o9 == null) {
-        let o5 = this.selectOption(options, 5);
-        let o0 = this.selectOption(options, 0);
+        const o5 = this.selectOption(options, 5);
+        const o0 = this.selectOption(options, 0);
 
-        let delta = o0.luminosity - o5.luminosity;
+        const delta = o0.luminosity - o5.luminosity;
 
         let o9Value = o5.luminosity - 0.67 * delta;
         if (o9Value <= 0) {
@@ -227,14 +227,14 @@ class LuminosityTableImpl {
       if (star.subClass === 9) {
         return addNoiseToValue(o9.luminosity);
       } else {
-        let result = this.interpolateSelection(options, star.subClass);
+        const result = this.interpolateSelection(options, star.subClass);
         return addNoiseToValue(result);
       }
     }
   }
 
   selectOption(options: LuminosityCrossReference[], value: number) {
-    let match = options.filter((l) => l.subSpectralClass === value);
+    const match = options.filter((l) => l.subSpectralClass === value);
     if (match.length === 1) {
       return match[0];
     } else {
@@ -245,7 +245,7 @@ class LuminosityTableImpl {
   interpolateSelection(options: LuminosityCrossReference[], subClass: number) {
     let lower = options[0];
     for (let i = 0; i < options.length; i++) {
-      let o = options[i];
+      const o = options[i];
       if (o.subSpectralClass < subClass) {
         lower = o;
       } else {
@@ -254,7 +254,7 @@ class LuminosityTableImpl {
     }
     let upper = options[options.length - 1];
     for (let i = options.length - 1; i >= 0; i--) {
-      let o = options[i];
+      const o = options[i];
       if (o.subSpectralClass > subClass) {
         upper = o;
       } else {
@@ -262,7 +262,7 @@ class LuminosityTableImpl {
       }
     }
 
-    let ratio =
+    const ratio =
       1 -
       (subClass - lower.subSpectralClass) /
         (upper.subSpectralClass - lower.subSpectralClass);

--- a/WebTools/src/mapping/table/noise.ts
+++ b/WebTools/src/mapping/table/noise.ts
@@ -1,9 +1,9 @@
 import { D20 } from '../../common/die';
 
 export const addNoiseToValue = (value: number, magnitude: number = 1) => {
-  let roll1 = (D20.roll() - 10) * 0.001;
-  let roll2 = (D20.roll() - 10) * (D20.roll() === 20 ? 0.05 : 0.01);
+  const roll1 = (D20.roll() - 10) * 0.001;
+  const roll2 = (D20.roll() - 10) * (D20.roll() === 20 ? 0.05 : 0.01);
 
-  let variance = roll1 + roll2;
+  const variance = roll1 + roll2;
   return value + variance * value * magnitude;
 };

--- a/WebTools/src/mapping/table/notableSpacialPhenomenaTable.ts
+++ b/WebTools/src/mapping/table/notableSpacialPhenomenaTable.ts
@@ -10,7 +10,7 @@ export const notableSpatialPhenomenaTable = (
   spectralClass: SpectralClass,
   sector?: SpecialSectors,
 ) => {
-  let roll = D20.roll();
+  const roll = D20.roll();
   let result = [];
   if (sector === null) {
     switch (spectralClass) {

--- a/WebTools/src/mapping/table/notableSystemTable.ts
+++ b/WebTools/src/mapping/table/notableSystemTable.ts
@@ -5,7 +5,7 @@ import { TableRoll } from '../../common/tableRoll';
 // This table has really changed since the original version in
 // the Shackleton Expanse book
 export const notableSystemTable: TableRoll<number> = () => {
-  let roll = D20.roll();
+  const roll = D20.roll();
 
   switch (roll) {
     case 1:

--- a/WebTools/src/mapping/table/orbit.ts
+++ b/WebTools/src/mapping/table/orbit.ts
@@ -12,7 +12,7 @@ export class Orbit {
   public slot: number;
 
   static createStandardOrbit(index: number, radius: number, slot: number) {
-    let result = new Orbit();
+    const result = new Orbit();
     result.index = index;
     result.radius = radius;
     result.slot = radius;
@@ -29,7 +29,7 @@ export class Orbits {
   }
 
   static createOrbits(numberOfWorlds: number, system: StarSystem) {
-    let orbits = new Orbits();
+    const orbits = new Orbits();
     let initialOrbit = this.determineInitialOrbit(system);
     if (
       initialOrbit < LuminosityTable.tenabilityRadius(system.luminosityValue)
@@ -46,7 +46,7 @@ export class Orbits {
     );
 
     if (orbits.primaryWorldOrbit > 1) {
-      let idealBode =
+      const idealBode =
         (system.gardenZoneIdealRadius - initialOrbit) /
         Math.pow(BLAGG_CONSTANT, orbits.primaryWorldOrbit - 1);
       if (idealBode < 0.001 || system.gardenZoneIdealRadius < 0.05) {
@@ -56,7 +56,7 @@ export class Orbits {
           orbits.primaryWorldOrbit = 1;
           initialOrbit = system.gardenZoneIdealRadius;
 
-          let orderOfMagnitude = Math.max(
+          const orderOfMagnitude = Math.max(
             0,
             Math.floor(Math.log(system.gardenZoneIdealRadius) / Math.log(10)),
           );
@@ -67,7 +67,7 @@ export class Orbits {
       }
     } else {
       initialOrbit = system.gardenZoneIdealRadius;
-      let orderOfMagnitude = Math.max(
+      const orderOfMagnitude = Math.max(
         0,
         Math.round(Math.log(system.gardenZoneIdealRadius) / Math.log(10)),
       );
@@ -109,7 +109,7 @@ export class Orbits {
       system.companionStar != null &&
       system.companionType === CompanionType.Distant
     ) {
-      let orbitalRadius = this.determineRadius(
+      const orbitalRadius = this.determineRadius(
         bodeIndex + 2,
         initialOrbit,
         bodeConstant,

--- a/WebTools/src/mapping/table/sector.ts
+++ b/WebTools/src/mapping/table/sector.ts
@@ -25,12 +25,12 @@ export class Sector {
   }
 
   get plainText() {
-    let systems = this.systems.map((s) => s.plainText).join('\n\n');
+    const systems = this.systems.map((s) => s.plainText).join('\n\n');
     return 'Sector: ' + this.name + '\n\n' + systems;
   }
 
   get sortedSystems() {
-    let result = [...this.systems];
+    const result = [...this.systems];
     result.sort((a, b) => {
       if (a.sectorCoordinates.z !== b.sectorCoordinates.z) {
         return a.sectorCoordinates.z - b.sectorCoordinates.z;

--- a/WebTools/src/mapping/table/star.ts
+++ b/WebTools/src/mapping/table/star.ts
@@ -32,7 +32,7 @@ export class SpecialSectorTypeModel {
   }
 }
 
-let sectorsTypes = [
+const sectorsTypes = [
   new SpecialSectorTypeModel(SpecialSectors.PinwheelSector, 'Pinwheel Sector'),
   new SpecialSectorTypeModel(
     SpecialSectors.EnduranceDivide,
@@ -63,13 +63,13 @@ export class SpaceRegionModel {
   }
 
   get localizedName() {
-    let key = makeKey('SpaceRegion.', SpaceRegion[this.id]);
-    let localName = i18next.t(key);
+    const key = makeKey('SpaceRegion.', SpaceRegion[this.id]);
+    const localName = i18next.t(key);
     return localName === key ? this.name : localName;
   }
 }
 
-let regions = [
+const regions = [
   new SpaceRegionModel(SpaceRegion.AlphaQuadrant, 'Alpha Quadrant', 'AL'),
   new SpaceRegionModel(SpaceRegion.BetaQuadrant, 'Beta Quadrant', 'BE'),
   new SpaceRegionModel(SpaceRegion.GammaQuadrant, 'Gamma Quadrant', 'GA'),
@@ -161,13 +161,13 @@ export class Star {
     ) {
       return this.spectralClass.description;
     } else {
-      let designation =
+      const designation =
         this.spectralClass.description +
         this.subClass +
         (this.luminosityClass != null
           ? LuminosityClass[this.luminosityClass.id]
           : '');
-      let description =
+      const description =
         this.spectralClass.colourDescription +
         (this.luminosityClass != null
           ? ' / ' + this.luminosityClass.description

--- a/WebTools/src/mapping/table/starSystem.ts
+++ b/WebTools/src/mapping/table/starSystem.ts
@@ -59,7 +59,7 @@ export class StarSystem {
   }
 
   clone() {
-    let result = new StarSystem(this.star);
+    const result = new StarSystem(this.star);
     result.id = this.id;
     result.sectorCoordinates = this.sectorCoordinates;
     result.worlds = this.worlds;
@@ -96,7 +96,7 @@ export class StarSystem {
   }
 
   get plainText() {
-    let worlds = this.worlds.map((w) => w.plainText).join('\n\n');
+    const worlds = this.worlds.map((w) => w.plainText).join('\n\n');
 
     return (
       'Star System: ' +
@@ -116,11 +116,11 @@ export class StarSystem {
   }
 
   get worldsAndSatelliteWorlds() {
-    let result = [];
+    const result = [];
     this.worlds.forEach((w) => {
       result.push(w);
       if (w.worldDetails != null && w.worldDetails instanceof GasGiantDetails) {
-        let details = w.worldDetails as GasGiantDetails;
+        const details = w.worldDetails as GasGiantDetails;
         details.ecosphereWorlds.forEach((e) => result.push(e));
       }
     });

--- a/WebTools/src/mapping/table/systemGenerator.ts
+++ b/WebTools/src/mapping/table/systemGenerator.ts
@@ -640,7 +640,7 @@ class SystemGeneration {
   };
 
   private orbitalEccentricity = () => {
-    let roll = D20.roll();
+    const roll = D20.roll();
     switch (roll) {
       case 1:
       case 2:
@@ -761,17 +761,17 @@ class SystemGeneration {
   ];
 
   generateSector(region: SpaceRegionModel, sectorType?: SpecialSectors) {
-    let count = notableSystemTable();
-    let sector = new Sector(region.prefix);
+    const count = notableSystemTable();
+    const sector = new Sector(region.prefix);
     for (let i = 0; i < count; i++) {
-      let system = this.generateStarSystem(region, sectorType);
+      const system = this.generateStarSystem(region, sectorType);
       if (system) {
         sector.systems.push(system);
       }
     }
 
-    let maxId = 250;
-    let interval = Math.round(maxId / sector.systems.length);
+    const maxId = 250;
+    const interval = Math.round(maxId / sector.systems.length);
 
     let start = 1;
     sector.systems.forEach((s) => {
@@ -824,14 +824,14 @@ class SystemGeneration {
     }
 
     if (star != null) {
-      let starSystem = new StarSystem(star);
+      const starSystem = new StarSystem(star);
       starSystem.phenomenon = phenomenon;
       starSystem.sectorCoordinates = this.generateCoordinates();
 
       if (D6.rollFace().isEffect) {
         let tries = 10;
         while (tries-- > 0) {
-          let companion = this.generateStar();
+          const companion = this.generateStar();
           if (companion != null && companion instanceof Star) {
             if ((companion as Star).mass <= star.mass) {
               starSystem.companionStar = companion;
@@ -855,7 +855,7 @@ class SystemGeneration {
   }
 
   generateStar() {
-    let spectralClass = this.rollSpectralClass();
+    const spectralClass = this.rollSpectralClass();
     if (spectralClass != null) {
       return this.generateStarDetails(spectralClass);
     } else {
@@ -864,7 +864,7 @@ class SystemGeneration {
   }
 
   generateStarDetails(spectralClass: SpectralClassModel) {
-    let subClass = this.rollSubSpectralClass();
+    const subClass = this.rollSubSpectralClass();
     let mass = null;
     let luminosity = null;
     while (mass == null) {
@@ -874,9 +874,9 @@ class SystemGeneration {
           : undefined;
       mass = this.determineMass(spectralClass, luminosity);
     }
-    let star = new Star(spectralClass, subClass, luminosity, mass);
+    const star = new Star(spectralClass, subClass, luminosity, mass);
     if (!star.spectralClass.isDwarf) {
-      let luminosityValue = LuminosityTable.generateLuminosity(star);
+      const luminosityValue = LuminosityTable.generateLuminosity(star);
       star.luminosityValue = luminosityValue;
     }
 
@@ -888,25 +888,25 @@ class SystemGeneration {
     luminosityClass: LuminosityClassModel,
   ) {
     for (let i = 0; i < this.stellarMassTable.length; i++) {
-      let mass = this.stellarMassTable[i];
+      const mass = this.stellarMassTable[i];
       if (
         mass.spectralClass === spectralClass.id &&
         ((luminosityClass == null && mass.luminosityClass == null) ||
           (luminosityClass != null &&
             luminosityClass.id === mass.luminosityClass))
       ) {
-        let baseMass = mass.mass;
+        const baseMass = mass.mass;
 
-        let roll = (D20.roll() - 10) / 10;
+        const roll = (D20.roll() - 10) / 10;
         if (roll < 0) {
           let delta = Math.min(baseMass / 2, 10);
           if (i > 0) {
-            let previous = this.stellarMassTable[i - 1];
+            const previous = this.stellarMassTable[i - 1];
             if (previous.spectralClass === spectralClass.id) {
               delta = previous.mass - baseMass;
             }
           }
-          let result = baseMass - (roll * delta) / 2;
+          const result = baseMass - (roll * delta) / 2;
           if (result < 0) {
             console.log('Weird! ' + roll + ' ' + baseMass + ' ' + delta);
           }
@@ -914,7 +914,7 @@ class SystemGeneration {
         } else {
           let delta = Math.min(baseMass / 2, 0.1);
           if (i < this.stellarMassTable.length - 1) {
-            let next = this.stellarMassTable[i + 1];
+            const next = this.stellarMassTable[i + 1];
             if (next.spectralClass === spectralClass.id) {
               delta = baseMass - next.mass;
             }
@@ -927,14 +927,14 @@ class SystemGeneration {
   }
 
   generateCoordinates() {
-    let x = D20.roll() - D20.roll() / 20.0;
-    let y = D20.roll() - D20.roll() / 20.0;
-    let z = D20.roll() - D20.roll() / 20.0;
+    const x = D20.roll() - D20.roll() / 20.0;
+    const y = D20.roll() - D20.roll() / 20.0;
+    const z = D20.roll() - D20.roll() / 20.0;
     return new SectorCoordinates(x, y, z);
   }
 
   rollWorldType(table: TableRoll<WorldClass>) {
-    let worldType = table();
+    const worldType = table();
     return worldClasses[worldType];
   }
 
@@ -944,14 +944,14 @@ class SystemGeneration {
         world.worldClass.id === WorldClass.D ||
         world.worldClass.id === WorldClass.Y
       ) {
-        let feature = isolatedColonyFeaturesOfInterest();
+        const feature = isolatedColonyFeaturesOfInterest();
         world.features.push(feature.localizedDescription);
       } else if (world.worldClass.id === WorldClass.L && D20.roll() < 14) {
-        let feature = isolatedColonyFeaturesOfInterest();
+        const feature = isolatedColonyFeaturesOfInterest();
         world.features.push(feature.localizedDescription);
       } else {
         world.features.push(planetaryFeaturesOfInterest().localizedDescription);
-        let feature2 = planetaryFeaturesOfInterest().localizedDescription;
+        const feature2 = planetaryFeaturesOfInterest().localizedDescription;
         if (world.features.indexOf(feature2) < 0) {
           world.features.push(feature2);
         }
@@ -976,10 +976,10 @@ class SystemGeneration {
         (orbit.radius < starSystem.gardenZoneOuterRadius &&
           orbit.radius >= starSystem.gardenZoneInnerRadius))
     ) {
-      let roll = D20.roll() + D20.roll();
-      let type = this.generalPlanetaryType[roll];
+      const roll = D20.roll() + D20.roll();
+      const type = this.generalPlanetaryType[roll];
 
-      let world = this.createBasicWorldAttributes(
+      const world = this.createBasicWorldAttributes(
         type.worldClass,
         orbit,
         romanNumeral,
@@ -1019,9 +1019,9 @@ class SystemGeneration {
         }
       }
 
-      let worldType = this.rollWorldType(table);
+      const worldType = this.rollWorldType(table);
 
-      let world = this.createBasicWorldAttributes(
+      const world = this.createBasicWorldAttributes(
         worldType,
         orbit,
         romanNumeral,
@@ -1041,7 +1041,7 @@ class SystemGeneration {
     romanNumeral: number,
     starSystem: StarSystem,
   ) {
-    let world = new World(
+    const world = new World(
       worldType,
       worldType.id === WorldClass.AsteroidBelt ? undefined : romanNumeral,
     );
@@ -1062,20 +1062,20 @@ class SystemGeneration {
       this.numberOfPlanetsModifiers.forEach((mod) => (roll += mod(starSystem)));
       roll = Math.max(1, Math.min(20, roll));
 
-      let worldCount = this.numberOfPlanetsTable[roll];
-      let orbits = Orbits.createOrbits(worldCount, starSystem);
-      let primaryWorldOrbit = orbits.primaryWorldOrbit;
+      const worldCount = this.numberOfPlanetsTable[roll];
+      const orbits = Orbits.createOrbits(worldCount, starSystem);
+      const primaryWorldOrbit = orbits.primaryWorldOrbit;
 
       let romanNumeralId = 0;
 
       for (let i = 0; i < worldCount; i++) {
-        let orbit = orbits.orbits[i];
+        const orbit = orbits.orbits[i];
         let world = null;
         if (
           i === primaryWorldOrbit - 1 &&
           orbit.radius > starSystem.gardenZoneOuterRadius
         ) {
-          let roll = D20.roll();
+          const roll = D20.roll();
           let worldClass = worldClasses[WorldClass.J];
           if (roll >= 9) {
             worldClass = worldClasses[WorldClass.I];
@@ -1103,7 +1103,7 @@ class SystemGeneration {
           } else {
             romanNumeralId++;
             if (!world.worldClass.isGasGiant) {
-              let moons = numberOfMoonsTable();
+              const moons = numberOfMoonsTable();
               let modifier = 0;
               if (starSystem.star?.spectralClass?.id === SpectralClass.M) {
                 modifier += 1;
@@ -1116,7 +1116,7 @@ class SystemGeneration {
           }
 
           if (world.worldClass.id === WorldClass.AsteroidBelt) {
-            let details = new AsteroidBeltDetails();
+            const details = new AsteroidBeltDetails();
 
             let roll = Math.ceil((D20.roll() + D20.roll()) / 2);
             details.asteroidSize = this.asteroidSizeTable[roll];
@@ -1184,8 +1184,8 @@ class SystemGeneration {
             } else if (orbit.radius >= starSystem.gardenZoneOuterRadius) {
               zoneRoll = Math.min(20, zoneRoll + 5);
             }
-            let zone = this.asteroidBeltZoneDominance(zoneRoll);
-            let { nZone, mZone, cZone } = this.asteroidBeltZoneDepths(
+            const zone = this.asteroidBeltZoneDominance(zoneRoll);
+            const { nZone, mZone, cZone } = this.asteroidBeltZoneDepths(
               zone,
               D20.roll(),
             );
@@ -1227,7 +1227,7 @@ class SystemGeneration {
     }
     this.gasGiantSatellitesTable[forceEcosphere ? 23 : detailsRoll](world);
     this.calculateGasGiantSize(world);
-    let details = world.worldDetails as GasGiantDetails;
+    const details = world.worldDetails as GasGiantDetails;
     if (details.ecosphere) {
       details.ecosphereWorlds = [
         this.createSatelliteWorld(
@@ -1248,7 +1248,7 @@ class SystemGeneration {
     region: SpaceRegionModel,
     isPrimary: boolean,
   ) {
-    let details = gasGiant.worldDetails as GasGiantDetails;
+    const details = gasGiant.worldDetails as GasGiantDetails;
     let moonWorld = this.createBasicWorld(
       isPrimary,
       orbit,
@@ -1278,7 +1278,7 @@ class SystemGeneration {
         this.calculateStandardPlanetSize(moonWorld, starSystem);
         moonWorld.worldDetails = this.deriveStandardWorldDetails(moonWorld);
 
-        let orbitalRadius = (D20.roll() * D20.roll()) / 4 + D20.roll();
+        const orbitalRadius = (D20.roll() * D20.roll()) / 4 + D20.roll();
         moonWorld.satelliteOrbitalRadius = orbitalRadius * gasGiant.diameter;
         moonWorld.period =
           Math.sqrt(
@@ -1301,13 +1301,13 @@ class SystemGeneration {
   }
 
   deriveStandardWorldDetails(world: World) {
-    let result = new StandardWorldDetails();
+    const result = new StandardWorldDetails();
     if (world.orbitalRadius != null) {
-      let period =
+      const period =
         D20.roll() + D20.roll() + 5 + world.mass / world.orbitalRadius;
 
       if (period > 40) {
-        let specialRoll = Math.ceil(D20.roll() / 2);
+        const specialRoll = Math.ceil(D20.roll() / 2);
         switch (specialRoll) {
           case 1:
             result.rotationPeriod = addNoiseToValue(D20.roll() * 3) * 24;
@@ -1366,7 +1366,7 @@ class SystemGeneration {
       );
     }
 
-    let roll = D20.roll();
+    const roll = D20.roll();
     switch (roll) {
       case 1:
       case 2:
@@ -1399,7 +1399,7 @@ class SystemGeneration {
         break;
 
       case 20:
-        let subRoll = Math.ceil(D20.roll() / 5) * 10 + 40;
+        const subRoll = Math.ceil(D20.roll() / 5) * 10 + 40;
         result.axialTilt = Math.min(
           90,
           addNoiseToValue(D20.roll() / 2 + subRoll),
@@ -1429,10 +1429,10 @@ class SystemGeneration {
       maximumDiameter = 120000000;
     }
 
-    let delta = (maximumDiameter - minimumDiameter) / (40 - 1);
-    let roll = D20.roll() + D20.roll();
+    const delta = (maximumDiameter - minimumDiameter) / (40 - 1);
+    const roll = D20.roll() + D20.roll();
 
-    let diameter = (roll - 2) * delta + minimumDiameter;
+    const diameter = (roll - 2) * delta + minimumDiameter;
     world.diameter = addNoiseToValue(diameter);
     world.density = addNoiseToValue(
       ((D20.roll() + D20.roll()) / 2) * 0.01 + 0.1,
@@ -1460,9 +1460,9 @@ class SystemGeneration {
       minimumDiameter = 100;
       maximumDiameter = 10000;
     }
-    let delta = (maximumDiameter - minimumDiameter) / (40 - 1);
-    let roll = D20.roll() + D20.roll();
-    let diameter = (roll - 2) * delta + minimumDiameter;
+    const delta = (maximumDiameter - minimumDiameter) / (40 - 1);
+    const roll = D20.roll() + D20.roll();
+    const diameter = (roll - 2) * delta + minimumDiameter;
     world.diameter = addNoiseToValue(diameter);
 
     let core = D20.roll() > 2 ? WorldCoreType.Molten : WorldCoreType.Heavy;
@@ -1491,7 +1491,7 @@ class SystemGeneration {
       world.diameter < 6400 &&
       starSystem.gardenZoneOuterRadius < world.orbitalRadius
     ) {
-      let temp = D20.roll();
+      const temp = D20.roll();
       if (temp >= 14) {
         core = WorldCoreType.Icy;
       } else if (temp >= 8) {
@@ -1517,14 +1517,14 @@ class SystemGeneration {
   }
 
   rollSpectralClass() {
-    let roll1 = D20.roll();
+    const roll1 = D20.roll();
 
     if (roll1 === 20) {
-      let roll2 = D20.roll();
+      const roll2 = D20.roll();
       if (roll2 === 20) {
         return undefined;
       } else {
-        let spectralClasses = this.specialSpectraTable[roll2];
+        const spectralClasses = this.specialSpectraTable[roll2];
         let spectralClass = spectralClasses[0];
         if (spectralClasses.length > 1) {
           spectralClass =
@@ -1533,13 +1533,13 @@ class SystemGeneration {
         return spectralClass;
       }
     } else {
-      let spectralClass = this.spectralClassTable[roll1];
+      const spectralClass = this.spectralClassTable[roll1];
       return spectralClass;
     }
   }
 
   rollSubSpectralClass() {
-    let roll = D20.roll();
+    const roll = D20.roll();
     if (roll === 20) {
       return 0;
     } else {
@@ -1550,8 +1550,8 @@ class SystemGeneration {
   rollLuminosity(spectralClass: SpectralClassModel) {
     let luminosity = undefined;
     while (true) {
-      let roll = D20.roll();
-      let lumens = this.luminosityClassTable[roll];
+      const roll = D20.roll();
+      const lumens = this.luminosityClassTable[roll];
       luminosity = lumens[0];
       if (lumens.length > 1) {
         luminosity = lumens[Math.floor(Math.random() * lumens.length)];

--- a/WebTools/src/mapping/table/world.ts
+++ b/WebTools/src/mapping/table/world.ts
@@ -109,7 +109,7 @@ export class AsteroidBeltDetails extends WorldDetails {
   }
 
   get attributeList() {
-    let result = [];
+    const result = [];
     if (this.asteroidSize != null) {
       result.push(
         new WorldAttribute(
@@ -170,7 +170,7 @@ export class GasGiantDetails extends WorldDetails {
   ecosphere: boolean;
 
   public static createBasicDistributionOfMoons(gasGiant: World) {
-    let result = new GasGiantDetails();
+    const result = new GasGiantDetails();
     let modifier = 0;
     if (gasGiant?.worldClass?.id === WorldClass.J) {
       modifier = 1;
@@ -191,7 +191,7 @@ export class GasGiantDetails extends WorldDetails {
   }
 
   public static createBasicDistributionOfMoonsWithEcosphere(gasGiant: World) {
-    let result = this.createBasicDistributionOfMoons(gasGiant);
+    const result = this.createBasicDistributionOfMoons(gasGiant);
     if (D20.roll() > 10) {
       result.giantMoons = Math.max(1, result.giantMoons);
     } else {
@@ -202,13 +202,13 @@ export class GasGiantDetails extends WorldDetails {
   }
 
   public static createFaintRing(gasGiant: World) {
-    let result = this.createBasicDistributionOfMoons(gasGiant);
+    const result = this.createBasicDistributionOfMoons(gasGiant);
     result.ring = RingTypeModel.getType(RingType.Faint);
     return result;
   }
 
   public static createTwiceAsManyWorlds(gasGiant: World) {
-    let result = this.createBasicDistributionOfMoons(gasGiant);
+    const result = this.createBasicDistributionOfMoons(gasGiant);
     result.moonlets += result.moonlets;
     result.smallMoons += result.smallMoons;
     result.mediumMoons += result.mediumMoons;
@@ -218,19 +218,19 @@ export class GasGiantDetails extends WorldDetails {
   }
 
   public static createBrightRing(gasGiant: World) {
-    let result = this.createBasicDistributionOfMoons(gasGiant);
+    const result = this.createBasicDistributionOfMoons(gasGiant);
     result.ring = RingTypeModel.getType(RingType.Spectacular);
     return result;
   }
 
   public static createOortBelt(gasGiant: World) {
-    let result = this.createBasicDistributionOfMoons(gasGiant);
+    const result = this.createBasicDistributionOfMoons(gasGiant);
     result.ring = RingTypeModel.getType(RingType.OortCloud);
     return result;
   }
 
   public static createAsteroidBelt(gasGiant: World) {
-    let result = this.createBasicDistributionOfMoons(gasGiant);
+    const result = this.createBasicDistributionOfMoons(gasGiant);
     result.moonlets = undefined;
     result.smallMoons = undefined;
     result.ring = RingTypeModel.getType(RingType.AsteroidBelt);
@@ -305,7 +305,7 @@ export class GasGiantDetails extends WorldDetails {
   }
 
   get attributeList() {
-    let result = [];
+    const result = [];
     result.push(
       new WorldAttribute(
         i18next.t('World.attribute.satellites'),
@@ -349,7 +349,7 @@ export class StandardWorldDetails extends WorldDetails {
   }
 
   get attributeList() {
-    let result = [];
+    const result = [];
     if (this.tidallyLocked != null) {
       result.push(
         new WorldAttribute(
@@ -493,7 +493,7 @@ export class World {
   }
 
   get attributeList() {
-    let result = [];
+    const result = [];
     if (this.orbitLabel != null) {
       result.push(
         new WorldAttribute(
@@ -643,7 +643,7 @@ export class World {
     }
 
     if (this.features?.length) {
-      let features = this.features
+      const features = this.features
         .map((f) =>
           typeof f === 'string' || f instanceof String
             ? f

--- a/WebTools/src/mapping/view/editableHeader.tsx
+++ b/WebTools/src/mapping/view/editableHeader.tsx
@@ -77,7 +77,7 @@ export class EditableHeader extends React.Component<
   }
 
   toggleEditMode() {
-    let editMode = !this.state.editMode;
+    const editMode = !this.state.editMode;
     if (editMode) {
       this.setState((state) => ({
         ...state,

--- a/WebTools/src/mapping/view/sectorMapView.tsx
+++ b/WebTools/src/mapping/view/sectorMapView.tsx
@@ -11,7 +11,7 @@ interface ISectorMapViewProperties extends IPageProperties {
 
 class SectorMapView extends React.Component<ISectorMapViewProperties, {}> {
   render() {
-    let purple = '#9179B7';
+    const purple = '#9179B7';
 
     return this.props.sector ? (
       <div className="sectorMap">
@@ -44,19 +44,19 @@ class SectorMapView extends React.Component<ISectorMapViewProperties, {}> {
   }
 
   renderStarSystems() {
-    let systems = this.props.sector.sortedSystems;
+    const systems = this.props.sector.sortedSystems;
     return systems.map((s, i) => {
-      let z = (s.sectorCoordinates.z / 20) * 0.75 + 0.25;
-      let baseColour = s.star.spectralClass.colour;
-      let colour = baseColour.blend(new SimpleColor(0, 0, 0), 1 - z);
+      const z = (s.sectorCoordinates.z / 20) * 0.75 + 0.25;
+      const baseColour = s.star.spectralClass.colour;
+      const colour = baseColour.blend(new SimpleColor(0, 0, 0), 1 - z);
 
       let r = Math.max(1, Math.sqrt(s.star.spectralClass.radius.midpoint * 50));
 
       if (s.isBinary) {
-        let r1 = r * 0.75;
+        const r1 = r * 0.75;
 
-        let baseColour2 = s.companionStar.spectralClass.colour;
-        let colour2 = baseColour2.blend(new SimpleColor(0, 0, 0), 1 - z);
+        const baseColour2 = s.companionStar.spectralClass.colour;
+        const colour2 = baseColour2.blend(new SimpleColor(0, 0, 0), 1 - z);
 
         let r2 = Math.max(
           1,

--- a/WebTools/src/mapping/view/starView.tsx
+++ b/WebTools/src/mapping/view/starView.tsx
@@ -79,7 +79,7 @@ class StarView extends React.Component<IStarViewProperties, {}> {
   }
 
   renderMassInKg() {
-    let mass = (1.98847 * this.props.star.mass).toFixed(4);
+    const mass = (1.98847 * this.props.star.mass).toFixed(4);
     return (
       <span>
         {mass} x 10<sup>30</sup>

--- a/WebTools/src/mapping/view/systemMapLowerView.tsx
+++ b/WebTools/src/mapping/view/systemMapLowerView.tsx
@@ -10,7 +10,7 @@ class SystemMapLowerView extends SystemMapView {
     const { system } = this.props;
     const purple = '#906F9A';
 
-    let r = Math.max(
+    const r = Math.max(
       2,
       Math.sqrt(system.star?.spectralClass?.radius?.midpoint * 200),
     );
@@ -21,7 +21,7 @@ class SystemMapLowerView extends SystemMapView {
 
     if (system.companionStar) {
       if (system.companionType === CompanionType.Close) {
-        let r2 = Math.max(
+        const r2 = Math.max(
           2,
           Math.sqrt(
             system.companionStar?.spectralClass?.radius?.midpoint * 200,
@@ -139,7 +139,7 @@ class SystemMapLowerView extends SystemMapView {
       }
     }
 
-    let orbits = this.findAllOrbits();
+    const orbits = this.findAllOrbits();
 
     let maxWorldDiameter = 50000;
     system.worlds
@@ -153,17 +153,17 @@ class SystemMapLowerView extends SystemMapView {
       .forEach(
         (w) => (smallWorldDiameter = Math.min(w.diameter, smallWorldDiameter)),
       );
-    let factor =
+    const factor =
       18 / Math.sqrt(maxWorldDiameter / 1000 - smallWorldDiameter / 1000);
 
-    let worldGradients = system.worlds?.map((w, i) => {
-      let r = Math.max(
+    const worldGradients = system.worlds?.map((w, i) => {
+      const r = Math.max(
         2,
         w.diameter == null
           ? 10
           : Math.sqrt(w.diameter / 1000 - smallWorldDiameter / 1000) * factor,
       );
-      let orbitalX = this.calculateOrbitX(w.orbitalRadius, orbits);
+      const orbitalX = this.calculateOrbitX(w.orbitalRadius, orbits);
 
       return (
         <radialGradient
@@ -180,24 +180,24 @@ class SystemMapLowerView extends SystemMapView {
       );
     });
 
-    let worlds = system.worlds?.map((w, i) => {
-      let r = Math.max(
+    const worlds = system.worlds?.map((w, i) => {
+      const r = Math.max(
         2,
         w.diameter == null
           ? 10
           : Math.sqrt(w.diameter / 1000 - smallWorldDiameter / 1000) * factor,
       );
-      let orbitalX = this.calculateOrbitX(w.orbitalRadius, orbits);
-      let prevOrbitalX =
+      const orbitalX = this.calculateOrbitX(w.orbitalRadius, orbits);
+      const prevOrbitalX =
         i === 0
           ? 0
           : this.calculateOrbitX(system.worlds[i - 1].orbitalRadius, orbits) +
             2;
-      let auWidth = orbitalX - 2 - prevOrbitalX;
+      const auWidth = orbitalX - 2 - prevOrbitalX;
 
       let axis = null;
       if (w.worldDetails instanceof StandardWorldDetails) {
-        let details = w.worldDetails as StandardWorldDetails;
+        const details = w.worldDetails as StandardWorldDetails;
         axis = (
           <path
             d={
@@ -232,13 +232,13 @@ class SystemMapLowerView extends SystemMapView {
       }
 
       if (w.worldClass.id === WorldClass.AsteroidBelt) {
-        let details = w.worldDetails as AsteroidBeltDetails;
+        const details = w.worldDetails as AsteroidBeltDetails;
 
-        let beltWidth = details.depth;
-        let beltStart = w.orbitalRadius - beltWidth * 0.5;
-        let beltStartMidway = w.orbitalRadius - beltWidth * 0.25;
-        let beltEnd = w.orbitalRadius + beltWidth * 0.5;
-        let beltEndMidway = w.orbitalRadius + beltWidth * 0.25;
+        const beltWidth = details.depth;
+        const beltStart = w.orbitalRadius - beltWidth * 0.5;
+        const beltStartMidway = w.orbitalRadius - beltWidth * 0.25;
+        const beltEnd = w.orbitalRadius + beltWidth * 0.5;
+        const beltEndMidway = w.orbitalRadius + beltWidth * 0.25;
 
         return (
           <g key={'world-' + i}>
@@ -515,12 +515,12 @@ class SystemMapLowerView extends SystemMapView {
   renderTrackers(orbits: number[], offset: number) {
     const { system } = this.props;
     if (orbits?.length && system?.worlds?.length) {
-      let inner = this.calculateOrbitX(system.gardenZoneInnerRadius, orbits);
-      let outer = this.calculateOrbitX(system.gardenZoneOuterRadius, orbits);
+      const inner = this.calculateOrbitX(system.gardenZoneInnerRadius, orbits);
+      const outer = this.calculateOrbitX(system.gardenZoneOuterRadius, orbits);
 
-      let ecoWidth = outer - 2 - (inner + 2);
+      const ecoWidth = outer - 2 - (inner + 2);
 
-      let lastAuMarker = system.worlds
+      const lastAuMarker = system.worlds
         ? this.calculateOrbitX(
             system.worlds[system.worlds.length - 1].orbitalRadius,
             orbits,

--- a/WebTools/src/mapping/view/systemMapUpperView.tsx
+++ b/WebTools/src/mapping/view/systemMapUpperView.tsx
@@ -11,7 +11,7 @@ class SystemMapUpperView extends SystemMapView {
     const { system } = this.props;
     const purple = '#906F9A';
 
-    let r = Math.max(
+    const r = Math.max(
       2,
       Math.sqrt(system.star?.spectralClass?.radius?.midpoint * 200),
     );
@@ -19,11 +19,11 @@ class SystemMapUpperView extends SystemMapView {
     let star2 = null;
     let companionGradient = null;
 
-    let orbits = this.findAllOrbits();
+    const orbits = this.findAllOrbits();
 
     if (system.companionStar) {
       if (system.companionType === CompanionType.Close) {
-        let r2 = Math.max(
+        const r2 = Math.max(
           2,
           Math.sqrt(
             system.companionStar?.spectralClass?.radius?.midpoint * 200,
@@ -157,13 +157,13 @@ class SystemMapUpperView extends SystemMapView {
       .forEach(
         (w) => (smallWorldDiameter = Math.min(w.diameter, smallWorldDiameter)),
       );
-    let factor =
+    const factor =
       18 / Math.sqrt(maxWorldDiameter / 1000 - smallWorldDiameter / 1000);
 
-    let verticalLines = system.worlds?.map((w, i) => {
-      let x = this.calculateOrbitX(w.orbitalRadius, orbits);
-      let y1 = this.calculateThirtyDegreeY(x);
-      let y2 = 620;
+    const verticalLines = system.worlds?.map((w, i) => {
+      const x = this.calculateOrbitX(w.orbitalRadius, orbits);
+      const y1 = this.calculateThirtyDegreeY(x);
+      const y2 = 620;
       return (
         <path
           d={
@@ -182,17 +182,17 @@ class SystemMapUpperView extends SystemMapView {
       );
     });
 
-    let worldGradients = system.worlds
+    const worldGradients = system.worlds
       ?.filter((w) => w.worldClass.id !== WorldClass.AsteroidBelt)
       .map((w, i) => {
-        let r = Math.max(
+        const r = Math.max(
           2,
           w.diameter == null
             ? 10
             : Math.sqrt(w.diameter / 1000 - smallWorldDiameter / 1000) * factor,
         );
-        let orbitalX = this.calculateOrbitX(w.orbitalRadius, orbits);
-        let y = this.calculateThirtyDegreeY(orbitalX);
+        const orbitalX = this.calculateOrbitX(w.orbitalRadius, orbits);
+        const y = this.calculateThirtyDegreeY(orbitalX);
 
         return (
           <radialGradient
@@ -209,37 +209,37 @@ class SystemMapUpperView extends SystemMapView {
         );
       });
 
-    let orbitalArcs = system.worlds?.map((w, i) => {
-      let x = this.calculateOrbitX(w.orbitalRadius, orbits);
-      let y = this.calculateThirtyDegreeY(x);
+    const orbitalArcs = system.worlds?.map((w, i) => {
+      const x = this.calculateOrbitX(w.orbitalRadius, orbits);
+      const y = this.calculateThirtyDegreeY(x);
 
-      let radiusY = this.calculateArcRadiusY(x - 35, y - 35);
-      let radiusX = radiusY * 5;
+      const radiusY = this.calculateArcRadiusY(x - 35, y - 35);
+      const radiusX = radiusY * 5;
 
       if (w.worldClass.id === WorldClass.AsteroidBelt) {
-        let details = w.worldDetails as AsteroidBeltDetails;
+        const details = w.worldDetails as AsteroidBeltDetails;
 
-        let beltWidth = details.depth;
-        let beltStartX = this.calculateOrbitX(
+        const beltWidth = details.depth;
+        const beltStartX = this.calculateOrbitX(
           w.orbitalRadius - beltWidth * 0.5,
           orbits,
         );
-        let beltEndX = this.calculateOrbitX(
+        const beltEndX = this.calculateOrbitX(
           w.orbitalRadius + beltWidth * 0.5,
           orbits,
         );
 
-        let allX = [beltStartX, beltEndX];
+        const allX = [beltStartX, beltEndX];
         if (beltEndX - beltStartX > 5) {
           for (let i = beltStartX + 2; i < beltEndX; i += 2) {
             allX.push(i);
           }
         }
 
-        let arcs = allX.map((x1, index) => {
-          let y1 = this.calculateThirtyDegreeY(x1);
-          let radiusY1 = this.calculateArcRadiusY(x1 - 35, y1 - 35);
-          let radiusX1 = radiusY1 * 5;
+        const arcs = allX.map((x1, index) => {
+          const y1 = this.calculateThirtyDegreeY(x1);
+          const radiusY1 = this.calculateArcRadiusY(x1 - 35, y1 - 35);
+          const radiusX1 = radiusY1 * 5;
 
           return (
             <path
@@ -283,12 +283,12 @@ class SystemMapUpperView extends SystemMapView {
       }
     });
 
-    let worldsCircles = system.worlds
+    const worldsCircles = system.worlds
       ?.filter((w) => w.worldClass.id !== WorldClass.AsteroidBelt)
       .map((w, i) => {
-        let x = this.calculateOrbitX(w.orbitalRadius, orbits);
-        let y = this.calculateThirtyDegreeY(x);
-        let r = Math.max(
+        const x = this.calculateOrbitX(w.orbitalRadius, orbits);
+        const y = this.calculateThirtyDegreeY(x);
+        const r = Math.max(
           2,
           w.diameter == null
             ? 10
@@ -451,8 +451,8 @@ class SystemMapUpperView extends SystemMapView {
   }
 
   createRandomDashPattern() {
-    let dashCount = Math.round(Math.random() * 10) + 5;
-    let dashNumbers = [];
+    const dashCount = Math.round(Math.random() * 10) + 5;
+    const dashNumbers = [];
     for (let i = 0; i < dashCount; i++) {
       dashNumbers.push(2);
       dashNumbers.push(Math.round(Math.random() * 19) * 3);
@@ -461,17 +461,17 @@ class SystemMapUpperView extends SystemMapView {
   }
 
   calculateArcY(x: number, radiusX: number, radiusY: number) {
-    let ySquared = radiusY * radiusY * (1 - (x * x) / (radiusX * radiusX));
+    const ySquared = radiusY * radiusY * (1 - (x * x) / (radiusX * radiusX));
     return Math.sqrt(ySquared);
   }
 
   calculateArcX(y: number, radiusX: number, radiusY: number) {
-    let xSquared = radiusX * radiusX * (1 - (y * y) / (radiusY * radiusY));
+    const xSquared = radiusX * radiusX * (1 - (y * y) / (radiusY * radiusY));
     return Math.sqrt(xSquared);
   }
 
   createArcPath(radiusX: number, radiusY: number) {
-    let y = Math.abs(this.calculateArcY(7 - 35, radiusX, radiusY));
+    const y = Math.abs(this.calculateArcY(7 - 35, radiusX, radiusY));
     let y2 = 9;
     let x2 = Math.abs(this.calculateArcX(y2 - 35, radiusX, radiusY)) + 35;
 

--- a/WebTools/src/mapping/view/systemMapView.tsx
+++ b/WebTools/src/mapping/view/systemMapView.tsx
@@ -15,13 +15,13 @@ export class SystemMapView extends React.Component<
   static DISPLAY_WIDTH = 970 - SystemMapView.START_X;
 
   findAllOrbits() {
-    let { system } = this.props;
+    const { system } = this.props;
     let orbits = system.worlds?.map((w) => w.orbitalRadius) ?? [];
     if (
       system.worlds?.length &&
       system.worlds[0].worldClass.id === WorldClass.AsteroidBelt
     ) {
-      let belt = system.worlds[0];
+      const belt = system.worlds[0];
       if (belt.worldDetails instanceof AsteroidBeltDetails) {
         orbits.push(
           belt.orbitalRadius -
@@ -34,7 +34,7 @@ export class SystemMapView extends React.Component<
       system.worlds[system.worlds.length - 1].worldClass.id ===
         WorldClass.AsteroidBelt
     ) {
-      let belt = system.worlds[system.worlds.length - 1];
+      const belt = system.worlds[system.worlds.length - 1];
       if (belt.worldDetails instanceof AsteroidBeltDetails) {
         orbits.push(
           belt.orbitalRadius +
@@ -60,9 +60,9 @@ export class SystemMapView extends React.Component<
 
   calculateOrbitX(orbitInAus: number, orbits: number[]) {
     if (orbits?.length) {
-      let firstOrbitInAus = orbits[0];
-      let firstOrbit = Math.log1p(firstOrbitInAus);
-      let lastOrbit = Math.log1p(orbits[orbits.length - 1]);
+      const firstOrbitInAus = orbits[0];
+      const firstOrbit = Math.log1p(firstOrbitInAus);
+      const lastOrbit = Math.log1p(orbits[orbits.length - 1]);
 
       return (
         SystemMapView.START_X +

--- a/WebTools/src/mapping/view/worldView.tsx
+++ b/WebTools/src/mapping/view/worldView.tsx
@@ -195,8 +195,8 @@ interface IWorldViewProperties extends IPageProperties {
 
 class WorldView extends React.Component<IWorldViewProperties, {}> {
   render() {
-    let { world } = this.props;
-    let attributes = world.attributeList;
+    const { world } = this.props;
+    const attributes = world.attributeList;
     return (
       <div>
         <WorldViewThumbnail world={world} system={this.props.system} />

--- a/WebTools/src/modify/page/characterAdvancementTypeView.tsx
+++ b/WebTools/src/modify/page/characterAdvancementTypeView.tsx
@@ -113,7 +113,7 @@ export const CharacterAdvancementTypeView: React.FC<
   useEffect(() => setChoice(undefined), [type]);
 
   const randomValue = () => {
-    let value = randomUniqueValue(
+    const value = randomUniqueValue(
       character?.values ?? [],
       character?.speciesStep?.species,
     );
@@ -121,7 +121,7 @@ export const CharacterAdvancementTypeView: React.FC<
   };
 
   const dropDownChoices = () => {
-    let result = [];
+    const result = [];
     if (character?.rank != null) {
       result.push(new DropDownElement('', ''));
     }
@@ -329,7 +329,7 @@ export const CharacterAdvancementTypeView: React.FC<
   };
 
   const isAttributeIncrementable = (a: Attribute, c: Character) => {
-    let value = c.attributes[a];
+    const value = c.attributes[a];
     if (
       a === removeAttributeSelection &&
       type === CharacterAdvancementType.Adjustment
@@ -352,7 +352,7 @@ export const CharacterAdvancementTypeView: React.FC<
   };
 
   const isDepartmentIncrementable = (d: Department, c: Character) => {
-    let value = c.departments[d];
+    const value = c.departments[d];
     if (
       d === removeDepartmentSelection &&
       type === CharacterAdvancementType.Adjustment
@@ -376,7 +376,7 @@ export const CharacterAdvancementTypeView: React.FC<
         <div className="col-12 col-md-6">
           <WarriorsSpiritSelectionView
             onSelection={(selection) => {
-              let temp = talentSelection.copy();
+              const temp = talentSelection.copy();
               temp.selection = selection as SpecialWeapon;
               setTalentSelection(temp);
             }}
@@ -389,7 +389,7 @@ export const CharacterAdvancementTypeView: React.FC<
         <div className="col-12 col-md-6">
           <VisitEveryStarSelectionView
             onSelection={(selection) => {
-              let temp = talentSelection.copy();
+              const temp = talentSelection.copy();
               temp.focuses = selection == null ? [] : (selection as string[]);
               setTalentSelection(temp);
             }}
@@ -406,7 +406,7 @@ export const CharacterAdvancementTypeView: React.FC<
               id="customName"
               value={talentSelection.customTalentName}
               onChange={(n) => {
-                let temp = talentSelection?.copy();
+                const temp = talentSelection?.copy();
                 if (temp) {
                   temp.customTalentName = n;
                 }
@@ -420,8 +420,8 @@ export const CharacterAdvancementTypeView: React.FC<
               value={talentSelection.customTalentDescription}
               placeholder={t('Common.text.description')}
               onChange={(e) => {
-                let description = e.target.value;
-                let temp = talentSelection?.copy();
+                const description = e.target.value;
+                const temp = talentSelection?.copy();
                 if (temp) {
                   temp.customTalentDescription = description;
                 }
@@ -436,7 +436,7 @@ export const CharacterAdvancementTypeView: React.FC<
         <div className="col-12 col-md-6">
           <ExpandedProgramSelectionView
             onSelection={(selection) => {
-              let temp = talentSelection.copy();
+              const temp = talentSelection.copy();
               temp.focuses = selection == null ? [] : (selection as string[]);
               setTalentSelection(temp);
             }}
@@ -449,7 +449,7 @@ export const CharacterAdvancementTypeView: React.FC<
         <div className="col-12 col-md-6">
           <BorgImplantsSelectionView
             onSelection={(selection) => {
-              let temp = talentSelection.copy();
+              const temp = talentSelection.copy();
               temp.implants = selection;
               setTalentSelection(temp);
             }}
@@ -462,7 +462,7 @@ export const CharacterAdvancementTypeView: React.FC<
         <div className="col-12 col-md-6">
           <AugmentedAbilitySelectionView
             onAttributeSelection={(a) => {
-              let temp = talentSelection.copy();
+              const temp = talentSelection.copy();
               temp.attribute = a;
               setTalentSelection(temp);
             }}
@@ -475,7 +475,7 @@ export const CharacterAdvancementTypeView: React.FC<
         <div className="col-12 col-md-6">
           <CollaborationDepartmentSelectionView
             onDepartmentSelection={(d) => {
-              let temp = talentSelection.copy();
+              const temp = talentSelection.copy();
               temp.department = d;
               setTalentSelection(temp);
             }}
@@ -492,7 +492,7 @@ export const CharacterAdvancementTypeView: React.FC<
             character={character}
             isChecked={(d) => talentSelection.department === d}
             onSelectDepartment={(d) => {
-              let temp = talentSelection?.copy();
+              const temp = talentSelection?.copy();
               if (temp) {
                 temp.department = d;
               }
@@ -504,7 +504,7 @@ export const CharacterAdvancementTypeView: React.FC<
               } else if (d === talentSelection.department) {
                 return true;
               } else {
-                let departments = character.talents
+                const departments = character.talents
                   .filter(
                     (t) =>
                       t.talent === TALENT_NAME_IM_A_DOCTOR_NOT_A &&
@@ -524,7 +524,7 @@ export const CharacterAdvancementTypeView: React.FC<
         <div className="col-12 col-md-6">
           <BoldOrCautiousDepartmentSelectionView
             onDepartmentSelection={(d) => {
-              let temp = talentSelection.copy();
+              const temp = talentSelection.copy();
               temp.department = d;
               setTalentSelection(temp);
             }}
@@ -538,7 +538,7 @@ export const CharacterAdvancementTypeView: React.FC<
         <div className="col-12 col-md-6">
           <DefensiveTrainingAttackTypeSelectionView
             onSelection={(t) => {
-              let temp = talentSelection.copy();
+              const temp = talentSelection.copy();
               temp.selection = t as AttackType;
               setTalentSelection(temp);
             }}
@@ -551,12 +551,12 @@ export const CharacterAdvancementTypeView: React.FC<
         <div className="col-12 col-md-6">
           <WisdomOfYearsSelectionView
             onFocusSelection={(selection) => {
-              let temp = talentSelection.copy();
+              const temp = talentSelection.copy();
               temp.focuses = selection == null ? [] : [selection];
               setTalentSelection(temp);
             }}
             onValueSelection={(value) => {
-              let temp = talentSelection.copy();
+              const temp = talentSelection.copy();
               temp.value = value;
               setTalentSelection(temp);
             }}

--- a/WebTools/src/modify/page/characterLogEntryView.tsx
+++ b/WebTools/src/modify/page/characterLogEntryView.tsx
@@ -30,7 +30,7 @@ export const CharacterLogEntryView: React.FC<
 > = ({ character, onNextStep, onPreviousStep, saveLogEntry }) => {
   const initializeLogValueEntries = () => {
     return character.values.map((v) => {
-      let result = new SelectedLogValueEntry(new LogValueEntry(v));
+      const result = new SelectedLogValueEntry(new LogValueEntry(v));
       result.selected = false;
       return result;
     });
@@ -46,7 +46,7 @@ export const CharacterLogEntryView: React.FC<
   const [directives, setDirectives] = useState<string[]>(['', '', '']);
 
   const createLogEntryAndNext = () => {
-    let valuesUsed = values.filter((v) => v.selected).map((v) => v.logEntry);
+    const valuesUsed = values.filter((v) => v.selected).map((v) => v.logEntry);
     if (title.length === 0) {
       Dialog.show('Please select a title');
     } else if (details.length === 0) {
@@ -58,7 +58,7 @@ export const CharacterLogEntryView: React.FC<
     ) {
       Dialog.show('Please provide a new value for any challenged values.');
     } else {
-      let entry = new LogEntry((character.logEntries?.length ?? 0) + 1);
+      const entry = new LogEntry((character.logEntries?.length ?? 0) + 1);
       entry.adventureTitle = title;
       entry.missionDescription = details;
       entry.notes = notes;
@@ -70,8 +70,8 @@ export const CharacterLogEntryView: React.FC<
   };
 
   const modifyValue = (index: number, value?: LogValueEntry) => {
-    let temp = [...values];
-    let entry = new SelectedLogValueEntry(
+    const temp = [...values];
+    const entry = new SelectedLogValueEntry(
       value === undefined ? values[index].logEntry : value,
     );
     entry.selected = value !== undefined;
@@ -81,7 +81,7 @@ export const CharacterLogEntryView: React.FC<
   };
 
   const modifyDirective = (directive: string, index: number) => {
-    let temp = [...directives];
+    const temp = [...directives];
     temp[index] = directive;
     let last = 0;
 

--- a/WebTools/src/modify/page/generalEditView.tsx
+++ b/WebTools/src/modify/page/generalEditView.tsx
@@ -103,7 +103,7 @@ export const GeneralEditView: React.FC<IGeneralEditViewProperties> = ({
   };
 
   const prepareForOnNextStep = () => {
-    let errorMessage = character.talentAssemblies
+    const errorMessage = character.talentAssemblies
       .map((t) => determineSelectedTalentExtraErrors(t.talent))
       .filter((m) => m?.length)[0];
     if (
@@ -167,7 +167,7 @@ export const GeneralEditView: React.FC<IGeneralEditViewProperties> = ({
   };
 
   const randomName = (species: SpeciesModel) => {
-    let { name, pronouns } = NameGenerator.instance.createName(species);
+    const { name, pronouns } = NameGenerator.instance.createName(species);
     store.dispatch(setCharacterName(name));
     store.dispatch(setCharacterPronouns(pronouns));
   };
@@ -196,7 +196,7 @@ export const GeneralEditView: React.FC<IGeneralEditViewProperties> = ({
   };
 
   const renderSpeciesTab = () => {
-    let attributes = AttributesHelper.getAllAttributes()
+    const attributes = AttributesHelper.getAllAttributes()
       .filter(
         (a) =>
           character.speciesStep.attributes.includes(a) ||
@@ -224,7 +224,7 @@ export const GeneralEditView: React.FC<IGeneralEditViewProperties> = ({
         );
       });
 
-    let speciesAbilityTalents = character.speciesStep?.ability
+    const speciesAbilityTalents = character.speciesStep?.ability
       ?.isTalentSelectionSupported
       ? character.speciesStep.ability.talentNames.map(
           (t) => new RankedTalent(TalentsHelper.getTalent(t)),

--- a/WebTools/src/modify/page/logEntryValueView.tsx
+++ b/WebTools/src/modify/page/logEntryValueView.tsx
@@ -30,12 +30,12 @@ export const LogEntryValueView: React.FC<ILogEntryValueProperties> = ({
   };
 
   const modifyValueUseType = (type: ValueUseType) => {
-    let entry = new LogValueEntry(value.value, type, value.newValue);
+    const entry = new LogValueEntry(value.value, type, value.newValue);
     onChange(entry);
   };
 
   const modifyNewValue = (newValue: string) => {
-    let entry = new LogValueEntry(value.value, value.useType, newValue);
+    const entry = new LogValueEntry(value.value, value.useType, newValue);
     onChange(entry);
   };
 

--- a/WebTools/src/modify/page/modifyMainCharacterPage.tsx
+++ b/WebTools/src/modify/page/modifyMainCharacterPage.tsx
@@ -48,7 +48,7 @@ const ModifyMainCharacterPage: React.FC<ICharacterProperties> = ({
   character,
 }) => {
   const dropDownItems = () => {
-    let result = [];
+    const result = [];
     if (character.version === 1) {
       //            result.push(new DropDownElement(ModificationType.VersionUpgrade, t('ModificationType.name.versionUpgrade')))
     }
@@ -115,7 +115,7 @@ const ModifyMainCharacterPage: React.FC<ICharacterProperties> = ({
   const navigate = useNavigate();
 
   const milestoneTypesDropDownItems = () => {
-    let result = [];
+    const result = [];
     result.push(
       new DropDownElement(
         CharacterAdvancementType.Adjustment,
@@ -144,7 +144,7 @@ const ModifyMainCharacterPage: React.FC<ICharacterProperties> = ({
   };
 
   const nextStep = () => {
-    let step = getSteps(modificationType)[carouselIndex];
+    const step = getSteps(modificationType)[carouselIndex];
     if (carouselIndex === 0) {
       setCarouselIndex(carouselIndex + 1);
     } else if (step === Step.SelectLog) {
@@ -242,8 +242,8 @@ const ModifyMainCharacterPage: React.FC<ICharacterProperties> = ({
 
   const viewCharacter = () => {
     setTimeout(() => {
-      let c = store.getState().character.currentCharacter;
-      let hash = store.getState().character.replacementHash;
+      const c = store.getState().character.currentCharacter;
+      const hash = store.getState().character.replacementHash;
       store.dispatch(saveCharacterToLocalStorage(c, hash));
       const value = marshaller.encodeMainCharacter(c);
       navigate('/view?s=' + value);
@@ -303,7 +303,7 @@ const ModifyMainCharacterPage: React.FC<ICharacterProperties> = ({
   };
 
   const createSelectLog = () => {
-    let logs = character.logEntries
+    const logs = character.logEntries
       ?.filter((l) => l.valuesUsed?.length)
       ?.map((l) => (
         <LogEntrySelectionView
@@ -354,7 +354,7 @@ const ModifyMainCharacterPage: React.FC<ICharacterProperties> = ({
   };
 
   const createSelectLogCallback = () => {
-    let ids = character.improvements
+    const ids = character.improvements
       ?.filter((i) => i instanceof CharacterAdvancementStep)
       ?.map((i) => i as CharacterAdvancementStep)
       ?.filter((i) => i.log != null)
@@ -365,7 +365,7 @@ const ModifyMainCharacterPage: React.FC<ICharacterProperties> = ({
       )
       ?.map((i) => i.log);
 
-    let logs = character.logEntries?.filter(
+    const logs = character.logEntries?.filter(
       (l) => l.valuesUsed?.length && ids.includes(l.id),
     );
 
@@ -470,7 +470,7 @@ const ModifyMainCharacterPage: React.FC<ICharacterProperties> = ({
   };
 
   const showStep = (step: number) => {
-    let steps = getSteps(modificationType);
+    const steps = getSteps(modificationType);
     switch (steps[step]) {
       case Step.Initial:
         return createCharacterAdvancementTypeView();

--- a/WebTools/src/modify/page/modifyStarshipPage.tsx
+++ b/WebTools/src/modify/page/modifyStarshipPage.tsx
@@ -68,7 +68,7 @@ const ModifyStarshipPage: React.FC<IStarshipProperties> = ({ starship }) => {
   }, [starship, navigate]);
 
   const milestoneTypesDropDownItems = () => {
-    let result = [];
+    const result = [];
     result.push(
       new DropDownElement(
         CharacterAdvancementType.Milestone,
@@ -177,7 +177,7 @@ const ModifyStarshipPage: React.FC<IStarshipProperties> = ({ starship }) => {
   };
 
   const dropDownAdvancementChoices = () => {
-    let result = [];
+    const result = [];
     result.push(new DropDownElement('', ''));
     result.push(
       new DropDownElement(
@@ -202,8 +202,8 @@ const ModifyStarshipPage: React.FC<IStarshipProperties> = ({ starship }) => {
 
   const viewStarship = () => {
     setTimeout(() => {
-      let c = store.getState().starship.starship;
-      let hash = store.getState().starship.hash;
+      const c = store.getState().starship.starship;
+      const hash = store.getState().starship.hash;
       store.dispatch(saveStarshipToLocalStorage(c, hash));
       const value = marshaller.encodeStarship(c);
       navigate('/view?s=' + value);

--- a/WebTools/src/modify/page/promotionView.tsx
+++ b/WebTools/src/modify/page/promotionView.tsx
@@ -32,7 +32,7 @@ export const PromotionView: React.FC<IPromotionViewProperties> = ({
   const [rankName, setRankName] = useState<string | undefined>(undefined);
 
   const getRanks = () => {
-    let result = [new DropDownElement('', '')];
+    const result = [new DropDownElement('', '')];
     if (type === ModificationType.Demotion) {
       result.push(
         ...RanksHelper.instance()
@@ -78,11 +78,11 @@ export const PromotionView: React.FC<IPromotionViewProperties> = ({
                 setRank(undefined);
                 setRankName(undefined);
               } else {
-                let allRanks = RanksHelper.instance().getRanksByType(
+                const allRanks = RanksHelper.instance().getRanksByType(
                   character.type,
                   character.version,
                 );
-                let rank = allRanks.filter((r) => r.id === id)[0];
+                const rank = allRanks.filter((r) => r.id === id)[0];
                 setRank(rank.id);
                 setRankName(rank.name);
               }

--- a/WebTools/src/modify/page/swapMissionPodPage.tsx
+++ b/WebTools/src/modify/page/swapMissionPodPage.tsx
@@ -29,8 +29,8 @@ const SwapMissionPodPage: React.FC<IStarshipProperties> = ({ starship }) => {
 
   const viewStarship = () => {
     setTimeout(() => {
-      let c = store.getState().starship.starship;
-      let hash = store.getState().starship.hash;
+      const c = store.getState().starship.starship;
+      const hash = store.getState().starship.hash;
       store.dispatch(saveStarshipToLocalStorage(c, hash));
       const value = marshaller.encodeStarship(c);
       navigate('/view?s=' + value);

--- a/WebTools/src/npc/model/npcCharacterType.ts
+++ b/WebTools/src/npc/model/npcCharacterType.ts
@@ -124,7 +124,7 @@ export class NpcCharacterTypes {
   }
 
   getType(type: NpcCharacterType) {
-    let types = this.types.filter((t) => t.type === type);
+    const types = this.types.filter((t) => t.type === type);
     return types.length === 1 ? types[0] : null;
   }
 }

--- a/WebTools/src/npc/model/npcGenerator.ts
+++ b/WebTools/src/npc/model/npcGenerator.ts
@@ -662,12 +662,12 @@ export class NpcGenerator {
     era: Era,
     includeDescription: boolean,
   ) {
-    let character = Character.createNpcCharacter(
+    const character = Character.createNpcCharacter(
       era,
       hasSource(Source.Core2ndEdition) ? 2 : 1,
     );
     if (specialization == null) {
-      let specializations =
+      const specializations =
         Specializations.instance.getSpecializations(characterType);
       specialization =
         specializations[Math.floor(Math.random() * specializations.length)];
@@ -677,7 +677,7 @@ export class NpcGenerator {
     character.jobAssignment = specialization.localizedName;
     character.speciesStep = new SpeciesStep(species.id);
     if (species.id === Species.CyberneticallyEnhanced) {
-      let originalSpecies = SpeciesHelper.generateSpecies(
+      const originalSpecies = SpeciesHelper.generateSpecies(
         CharacterType.Starfleet,
       );
       character.speciesStep.originalSpecies = originalSpecies;
@@ -694,8 +694,8 @@ export class NpcGenerator {
       character.speciesStep.attributes = [];
     }
     while (character.speciesStep.attributes.length < 3) {
-      let all = AttributesHelper.getAllAttributes();
-      let attribute = all[Math.floor(all.length * Math.random())];
+      const all = AttributesHelper.getAllAttributes();
+      const attribute = all[Math.floor(all.length * Math.random())];
       if (!character.speciesStep.attributes.includes(attribute)) {
         character.speciesStep.attributes.push(attribute);
       }
@@ -723,7 +723,7 @@ export class NpcGenerator {
       gender = 'Female';
     }
 
-    let { name, pronouns, nameOrigin } = NameGenerator.instance.createName(
+    const { name, pronouns, nameOrigin } = NameGenerator.instance.createName(
       nameSpecies,
       gender,
     );
@@ -734,8 +734,8 @@ export class NpcGenerator {
     character.npcGenerationStep.specialization = specialization.id;
     NpcGenerator.assignAttributes(npcType, character, species, specialization);
 
-    let disciplines = DepartmentsHelper.instance.getDepartments();
-    let disciplinePoints = NpcTypes.departmentPoints(npcType);
+    const disciplines = DepartmentsHelper.instance.getDepartments();
+    const disciplinePoints = NpcTypes.departmentPoints(npcType);
 
     for (let i = 0; i < disciplinePoints.length; i++) {
       let a = disciplines[Math.floor(Math.random() * disciplines.length)];
@@ -746,7 +746,7 @@ export class NpcGenerator {
       disciplines.splice(disciplines.indexOf(a), 1);
     }
 
-    let aspects = [];
+    const aspects = [];
     let careers = [
       Career.Young,
       Career.Young,
@@ -834,10 +834,12 @@ export class NpcGenerator {
     nameOrigin: string,
     aspects: string[],
   ) {
-    let species = SpeciesHelper.getSpeciesByType(character.speciesStep.species);
-    let speciesName = species.name;
+    const species = SpeciesHelper.getSpeciesByType(
+      character.speciesStep.species,
+    );
+    const speciesName = species.name;
 
-    let data = {
+    const data = {
       name: character.name,
       species: speciesName,
       specialization: Specialization[specialization.id],
@@ -849,7 +851,7 @@ export class NpcGenerator {
     };
 
     if (species.id === Species.CyberneticallyEnhanced) {
-      let original = SpeciesHelper.getSpeciesByType(
+      const original = SpeciesHelper.getSpeciesByType(
         character.speciesStep.originalSpecies,
       )?.name;
 
@@ -883,11 +885,11 @@ export class NpcGenerator {
       specialization.primaryFocuses.includes(f),
     );
 
-    let textEncoder = new TextEncoder();
-    let body = textEncoder.encode(JSON.stringify(data));
+    const textEncoder = new TextEncoder();
+    const body = textEncoder.encode(JSON.stringify(data));
 
     try {
-      let response = await fetch('/api/character_description', {
+      const response = await fetch('/api/character_description', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -896,7 +898,7 @@ export class NpcGenerator {
       });
 
       if (response.status === 200) {
-        let responseJson = await response.json();
+        const responseJson = await response.json();
         return responseJson?.description;
       } else {
         return undefined;
@@ -1012,7 +1014,7 @@ export class NpcGenerator {
           );
         } else if (specialization.id === Specialization.Child) {
           character.type = CharacterType.Child;
-          let ages = AgeHelper.getAllChildAges();
+          const ages = AgeHelper.getAllChildAges();
           character.age = ages[Math.floor(Math.random() * ages.length)];
         } else {
           character.type = CharacterType.Civilian;
@@ -1081,11 +1083,11 @@ export class NpcGenerator {
         while (!done) {
           let talentList =
             TalentsHelper.getAllAvailableTalentsForCharacter(character);
-          let specializationSkill = specialization.primaryDiscipline;
-          let roll = D20.roll();
+          const specializationSkill = specialization.primaryDiscipline;
+          const roll = D20.roll();
           if (roll < 7) {
             // go for species talents
-            let talentName = species.talents.map((t) => t.name);
+            const talentName = species.talents.map((t) => t.name);
             talentList = talentList
               .filter(
                 (t) =>
@@ -1132,9 +1134,9 @@ export class NpcGenerator {
           }
 
           if (talentList.length) {
-            let talent =
+            const talent =
               talentList[Math.floor(Math.random() * talentList.length)];
-            let selectedTalent = new SelectedTalent(talent.name);
+            const selectedTalent = new SelectedTalent(talent.name);
             if (talent.name === TALENT_NAME_WARRIORS_SPIRIT) {
               selectedTalent.selection =
                 D20.roll() <= 10
@@ -1160,7 +1162,7 @@ export class NpcGenerator {
               if (specialization.primaryDiscipline != null) {
                 selectedTalent.department = specialization.primaryDiscipline;
               } else {
-                let departments = DepartmentsHelper.instance.getDepartments();
+                const departments = DepartmentsHelper.instance.getDepartments();
                 selectedTalent.department =
                   departments[Math.floor(Math.random() * departments.length)];
               }
@@ -1186,9 +1188,9 @@ export class NpcGenerator {
     species: SpeciesModel,
     specialization: SpecializationModel,
   ) {
-    let attributes = AttributesHelper.getAllAttributes();
-    let attributePoints = NpcTypes.attributePoints(npcType);
-    let chances = [20, 14, 8];
+    const attributes = AttributesHelper.getAllAttributes();
+    const attributePoints = NpcTypes.attributePoints(npcType);
+    const chances = [20, 14, 8];
 
     character.npcGenerationStep.attributes = [0, 0, 0, 0, 0, 0];
     for (let i = 0; i < attributePoints.length; i++) {
@@ -1198,7 +1200,7 @@ export class NpcGenerator {
         i < chances.length &&
         D20.roll() <= chances[i]
       ) {
-        let temp =
+        const temp =
           specialization.primaryAttributes[
             Math.floor(Math.random() * specialization.primaryAttributes.length)
           ];
@@ -1227,8 +1229,8 @@ export class NpcGenerator {
     character: Character,
     specialization: SpecializationModel,
   ) {
-    let count = NpcTypes.numberOfValues(npcType);
-    let valueOptions = [];
+    const count = NpcTypes.numberOfValues(npcType);
+    const valueOptions = [];
     valueOptions.push.apply(valueOptions, specialization.values ?? []);
     valueOptions.push.apply(
       valueOptions,
@@ -1248,12 +1250,14 @@ export class NpcGenerator {
       ] ?? [],
     );
 
-    let species = SpeciesHelper.getSpeciesByType(character.speciesStep.species);
+    const species = SpeciesHelper.getSpeciesByType(
+      character.speciesStep.species,
+    );
     if (species.exampleValues?.length) {
       valueOptions.push(...species.exampleValues);
     }
 
-    let aspects = [];
+    const aspects = [];
     for (let i = 0; i < count; i++) {
       let done = false;
       while (!done) {
@@ -1283,9 +1287,9 @@ export class NpcGenerator {
     character: Character,
     specialization: SpecializationModel,
   ) {
-    let numberOfFocuses = NpcTypes.numberOfFocuses(npcType);
-    let primaryChances = [20, 12, 8, 6, 4, 2];
-    let secondaryChances = [17, 15, 11, 9, 6, 3];
+    const numberOfFocuses = NpcTypes.numberOfFocuses(npcType);
+    const primaryChances = [20, 12, 8, 6, 4, 2];
+    const secondaryChances = [17, 15, 11, 9, 6, 3];
     let specialtyCategory = undefined;
 
     for (let i = 0; i < numberOfFocuses; i++) {
@@ -1314,7 +1318,7 @@ export class NpcGenerator {
         }
 
         if (focuses?.length) {
-          let focus = focuses[Math.floor(Math.random() * focuses.length)];
+          const focus = focuses[Math.floor(Math.random() * focuses.length)];
           if (character.focuses.indexOf(focus) < 0) {
             character.npcGenerationStep.focuses.push(focus);
             done = true;
@@ -1369,10 +1373,10 @@ export class NpcGenerator {
     if (ranks.length > 0) {
       // by using a logarithmic scale, I'm biasing the random values in favour
       // of the ranks at the higher end of the list (which are the more junior ranks)
-      let maxValue = Math.pow(Math.E, ranks.length + 1);
-      let random = Math.log1p(Math.random() * maxValue);
-      let index = Math.min(ranks.length - 1, Math.max(0, Math.floor(random)));
-      let rank = ranks[index];
+      const maxValue = Math.pow(Math.E, ranks.length + 1);
+      const random = Math.log1p(Math.random() * maxValue);
+      const index = Math.min(ranks.length - 1, Math.max(0, Math.floor(random)));
+      const rank = ranks[index];
 
       if (
         specialization.id === Specialization.MedicalDoctor &&

--- a/WebTools/src/npc/model/npcType.ts
+++ b/WebTools/src/npc/model/npcType.ts
@@ -43,11 +43,11 @@ export class NpcTypes {
     } else if (simple) {
       return [10, 10, 9, 9, 9, 9];
     } else {
-      let result = [7, 7, 7, 7, 7, 7];
+      const result = [7, 7, 7, 7, 7, 7];
       for (let i = 0; i < 14; i++) {
         let done = false;
         while (!done) {
-          let attr = Math.floor(Math.random() * 6);
+          const attr = Math.floor(Math.random() * 6);
           if (result[attr] < 12) {
             result[attr] = result[attr] + 1;
             done = true;
@@ -79,11 +79,11 @@ export class NpcTypes {
     } else if (simple) {
       return [3, 3, 3, 3, 2, 2];
     } else {
-      let result = [1, 1, 1, 1, 1, 1];
+      const result = [1, 1, 1, 1, 1, 1];
       for (let i = 0; i < 10; i++) {
         let done = false;
         while (!done) {
-          let disc = Math.floor(Math.random() * 6);
+          const disc = Math.floor(Math.random() * 6);
           if (result[disc] < 5) {
             result[disc] = result[disc] + 1;
             done = true;
@@ -101,7 +101,7 @@ export class NpcTypes {
     } else if (type === NpcType.Notable) {
       return D20.roll() >= 10 ? 2 : 3;
     } else {
-      let distribution = [
+      const distribution = [
         3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6,
       ];
       return distribution[D20.roll() - 1];
@@ -129,7 +129,7 @@ export class NpcTypes {
   }
 
   static getNpcTypeByName(name: string) {
-    let all = [
+    const all = [
       NpcType[NpcType.Minor],
       NpcType[NpcType.Notable],
       NpcType[NpcType.Major],

--- a/WebTools/src/npc/model/specializations.ts
+++ b/WebTools/src/npc/model/specializations.ts
@@ -254,8 +254,8 @@ export class SpecializationModel {
   }
 
   get localizedName() {
-    let key = makeKey('Specialization.', Specialization[this.id]);
-    let result = i18next.t(key);
+    const key = makeKey('Specialization.', Specialization[this.id]);
+    const result = i18next.t(key);
     return key === result ? this.name : result;
   }
 }
@@ -2540,7 +2540,7 @@ export class Specializations {
   }
 
   getSpecialization(specialization: Specialization) {
-    let specializations = this.specializations.filter(
+    const specializations = this.specializations.filter(
       (s) => s.id === specialization,
     );
     return specializations?.length === 1 ? specializations[0] : null;

--- a/WebTools/src/npc/nameGenerator.ts
+++ b/WebTools/src/npc/nameGenerator.ts
@@ -85,7 +85,7 @@ export class NameGenerator {
 
   isSupported(species: ISpecies) {
     let result = false;
-    for (let name of names) {
+    for (const name of names) {
       if (name.species === species.name) {
         result = true;
         break;
@@ -107,9 +107,9 @@ export class NameGenerator {
   ) {
     let result = { name: '', pronouns: '', nameOrigin: undefined };
     let found = false;
-    for (let name of names) {
+    for (const name of names) {
       if (name.species === species.name) {
-        let lastNames = name.names
+        const lastNames = name.names
           .filter((n) => n.type === 'LastName')
           .filter(
             (n) =>
@@ -117,23 +117,23 @@ export class NameGenerator {
           );
         let lastName = null;
         if (lastNames.length > 0) {
-          let r = Math.floor(Math.random() * lastNames.length);
+          const r = Math.floor(Math.random() * lastNames.length);
           lastName = lastNames[r];
         }
-        let firstNames = name.names
+        const firstNames = name.names
           .filter((n) => n.type === 'FirstName')
           .filter((n) => gender == null || gender === n.gender)
           .filter((n) => {
             if (lastName == null) {
               return true;
             } else {
-              let ok =
+              const ok =
                 n.gender === lastName.gender ||
                 n.gender === 'Unisex' ||
                 lastName.gender === 'Unisex';
               if (ok) {
                 let found = n.tags.indexOf('Common') >= 0;
-                for (let tag of lastName.tags) {
+                for (const tag of lastName.tags) {
                   if (n.tags.indexOf(tag) >= 0) {
                     found = true;
                     break;
@@ -147,7 +147,7 @@ export class NameGenerator {
           });
         let firstName = null;
         if (firstNames.length > 0) {
-          let r = Math.floor(Math.random() * firstNames.length);
+          const r = Math.floor(Math.random() * firstNames.length);
           firstName = firstNames[r];
         }
 
@@ -161,7 +161,7 @@ export class NameGenerator {
               ];
           }
         }
-        let pronouns = this.derivePronouns(firstName.gender, gender != null);
+        const pronouns = this.derivePronouns(firstName.gender, gender != null);
 
         let nameOrigin = undefined;
         if (species.id === Species.Human) {
@@ -185,10 +185,10 @@ export class NameGenerator {
     }
 
     if (!found) {
-      let names = species.nameSuggestions;
+      const names = species.nameSuggestions;
 
       let lastName = null;
-      let lastNames = names.filter(
+      const lastNames = names.filter(
         (n) =>
           n.type === 'Family' ||
           n.type === 'Family Name' ||
@@ -196,13 +196,13 @@ export class NameGenerator {
           n.type === 'Clan Names',
       );
       if (lastNames.length > 0) {
-        let parts = lastNames[0].suggestions.split(',');
+        const parts = lastNames[0].suggestions.split(',');
         lastName = parts[Math.floor(Math.random() * parts.length)].trim();
       }
 
       let firstName = null;
       let gender = 'Unisex';
-      let firstNames = names.filter(
+      const firstNames = names.filter(
         (n) =>
           n.type !== 'Family' &&
           n.type !== 'Family Name' &&
@@ -210,14 +210,14 @@ export class NameGenerator {
           n.type !== 'Clan Names',
       );
       if (firstNames.length > 0) {
-        let nameModel =
+        const nameModel =
           firstNames[Math.floor(Math.random() * firstNames.length)];
         gender = nameModel.type;
-        let parts = nameModel.suggestions.split(',');
+        const parts = nameModel.suggestions.split(',');
         firstName = parts[Math.floor(Math.random() * parts.length)].trim();
       }
 
-      let pronouns = this.derivePronouns(gender, gender != null);
+      const pronouns = this.derivePronouns(gender, gender != null);
       result = {
         name: this.combineParts(firstName, lastName, species, pronouns),
         pronouns: pronouns,
@@ -229,10 +229,10 @@ export class NameGenerator {
   }
 
   private determineNameOrigin(firstName: any, lastName: any) {
-    let tags = lastName.tags.filter(
+    const tags = lastName.tags.filter(
       (t) => firstName.tags.includes('Common') || firstName.tags.includes(t),
     );
-    let result = tags.length
+    const result = tags.length
       ? tags[Math.floor(Math.random() * tags.length)]
       : undefined;
     return result === 'Common' ? undefined : result;
@@ -245,7 +245,7 @@ export class NameGenerator {
     pronouns: string,
     names: [] = [],
   ) {
-    let parts = [];
+    const parts = [];
 
     if (species.id === Species.Bajoran) {
       if (lastName) {
@@ -255,7 +255,7 @@ export class NameGenerator {
         parts.push(firstName);
       }
     } else if (species.id === Species.Andorian) {
-      let clanNamePrefix = this.determineAndorianPrefix(pronouns);
+      const clanNamePrefix = this.determineAndorianPrefix(pronouns);
 
       if (firstName) {
         parts.push(firstName);
@@ -269,8 +269,8 @@ export class NameGenerator {
         }
       }
     } else if (species.id === Species.Tellarite && D20.roll() <= 5) {
-      let interstitials = names.filter((n) => n['type'] === 'Interstitial');
-      let interstitial =
+      const interstitials = names.filter((n) => n['type'] === 'Interstitial');
+      const interstitial =
         interstitials[Math.floor(Math.random() * interstitials.length)];
 
       if (firstName) {

--- a/WebTools/src/npc/page/npcConfigurationPage.tsx
+++ b/WebTools/src/npc/page/npcConfigurationPage.tsx
@@ -48,7 +48,7 @@ const NpcConfigurationPage: React.FC<INpcConfigurationPageProperties> = ({
   const [includeDescription, setIncludeDescription] = useState<boolean>(true);
 
   useEffect(() => {
-    let value = window.localStorage.getItem('settings.ai');
+    const value = window.localStorage.getItem('settings.ai');
     setIncludeDescription(value !== 'false');
   }, []);
 
@@ -58,7 +58,7 @@ const NpcConfigurationPage: React.FC<INpcConfigurationPageProperties> = ({
   };
 
   const getSpecializations = () => {
-    let result = [
+    const result = [
       new DropDownElement(
         null,
         t('NpcConfigurationPage.option.anySpecialization'),
@@ -124,7 +124,7 @@ const NpcConfigurationPage: React.FC<INpcConfigurationPageProperties> = ({
       selectedType?.type === NpcCharacterType.RogueRuffianMercenary ||
       selectedType?.type === NpcCharacterType.MinorPolity
     ) {
-      let items = [];
+      const items = [];
       Specializations.instance
         .getSpecializations(selectedType?.type)
         .forEach((s) => {
@@ -132,7 +132,7 @@ const NpcConfigurationPage: React.FC<INpcConfigurationPageProperties> = ({
             selectedSpecialization == null ||
             selectedSpecialization?.id === s.id
           ) {
-            let speciesList = s.species?.length
+            const speciesList = s.species?.length
               ? s.species
               : getStandardFederationSpeciesListAsTypes();
             speciesList.forEach((s) => {
@@ -168,7 +168,7 @@ const NpcConfigurationPage: React.FC<INpcConfigurationPageProperties> = ({
   };
 
   const getSpeciesDropDownList = () => {
-    let result = [
+    const result = [
       new DropDownElement(
         null,
         t('NpcConfigurationPage.option.anyMajorSpecies'),
@@ -214,7 +214,7 @@ const NpcConfigurationPage: React.FC<INpcConfigurationPageProperties> = ({
       selectedType.type === NpcCharacterType.MinorPolity ||
       selectedType.type === NpcCharacterType.RomulanEmpire
     ) {
-      let list = getSpeciesList();
+      const list = getSpeciesList();
       return list[Math.floor(Math.random() * list.length)].id;
     } else {
       return SpeciesHelper.generateSpecies();
@@ -225,7 +225,7 @@ const NpcConfigurationPage: React.FC<INpcConfigurationPageProperties> = ({
     setLoading(true);
     let specialization = selectedSpecialization;
     if (specialization == null) {
-      let specializations = Specializations.instance.getSpecializations(
+      const specializations = Specializations.instance.getSpecializations(
         selectedType.type,
       );
       specialization =
@@ -233,7 +233,7 @@ const NpcConfigurationPage: React.FC<INpcConfigurationPageProperties> = ({
     }
     let species = selectedSpecies;
     if (species == null && specialization.species?.length) {
-      let list = specialization.species
+      const list = specialization.species
         .map((s) => SpeciesHelper.getSpeciesByType(s))
         .filter((s) => s.eras.includes(era));
       species = list[Math.floor(Math.random() * list.length)].id;

--- a/WebTools/src/npc/page/npcFinalPage.tsx
+++ b/WebTools/src/npc/page/npcFinalPage.tsx
@@ -45,7 +45,7 @@ const NpcFinalPage: React.FC<ICharacterProperties> = ({ character }) => {
 
   const showViewPage = () => {
     setTimeout(() => {
-      let c = store.getState().character.currentCharacter;
+      const c = store.getState().character.currentCharacter;
       const value = marshaller.encodeCharacter(c);
       store.dispatch(saveCharacterToLocalStorage(c));
       window.open('/view?s=' + value, '_blank');
@@ -169,7 +169,7 @@ const NpcFinalPage: React.FC<ICharacterProperties> = ({ character }) => {
     });
 
   const randomName = () => {
-    let { name, pronouns } = NameGenerator.instance.createName(species);
+    const { name, pronouns } = NameGenerator.instance.createName(species);
     store.dispatch(setCharacterName(name));
     store.dispatch(setCharacterPronouns(pronouns));
   };

--- a/WebTools/src/npc/page/npcSpecialRulesPage.tsx
+++ b/WebTools/src/npc/page/npcSpecialRulesPage.tsx
@@ -89,7 +89,7 @@ const NpcSpecialRulesPage: React.FC<ICharacterProperties> = ({ character }) => {
       } else {
         let count = 0;
         temp = temp.filter((t) => {
-          let result =
+          const result =
             t.talent !== rankedTalent.name || count + 1 !== rankedTalent.rank;
           if (t.name === rankedTalent.name) {
             count++;
@@ -130,14 +130,14 @@ const NpcSpecialRulesPage: React.FC<ICharacterProperties> = ({ character }) => {
     store.dispatch(setNpcCharacterTalents(temp));
   };
 
-  let talents = character
+  const talents = character
     ? TalentsHelper.getAllAvailableTalentsForNpc(character)
     : [];
 
-  let rankedTalents = [];
+  const rankedTalents = [];
   talents.forEach((t) => {
     if (t.maxRank > 1 || isMultiSelectionTalent(t)) {
-      let count =
+      const count =
         character.npcGenerationStep?.talents?.filter((s) => s.talent === t.name)
           ?.length ?? 0;
       for (let i = 0; i < count + 1; i++) {

--- a/WebTools/src/npc/page/npcStatsPage.tsx
+++ b/WebTools/src/npc/page/npcStatsPage.tsx
@@ -52,7 +52,7 @@ const NpcStatsPage: React.FC<ICharacterProperties> = ({ character }) => {
     if (character.npcGenerationStep?.type === NpcType.Minor) {
       return undefined;
     } else {
-      let department = primaryDepartment();
+      const department = primaryDepartment();
       return (
         <div className="col-12 col-md-6 mt-4">
           <Header level={2} className="my-3">
@@ -111,7 +111,7 @@ const NpcStatsPage: React.FC<ICharacterProperties> = ({ character }) => {
 
   const primaryDepartment = () => {
     let department = undefined;
-    let departments = character.npcGenerationStep?.departments;
+    const departments = character.npcGenerationStep?.departments;
     DepartmentsHelper.instance.getDepartments().forEach((d) => {
       if (department === undefined) {
         department = d;
@@ -126,7 +126,7 @@ const NpcStatsPage: React.FC<ICharacterProperties> = ({ character }) => {
     if (character.npcGenerationStep?.type === NpcType.Minor) {
       return undefined;
     } else {
-      let department = primaryDepartment();
+      const department = primaryDepartment();
 
       return (
         <div className="col-12 col-md-6 mt-4">
@@ -255,7 +255,7 @@ const NpcStatsPage: React.FC<ICharacterProperties> = ({ character }) => {
   };
 
   const getRanks = () => {
-    let ranks = [new DropDownElement('', '')];
+    const ranks = [new DropDownElement('', '')];
     ranks.push(
       ...RanksHelper.instance()
         .getRanksByType(character.type, character.version)
@@ -268,7 +268,7 @@ const NpcStatsPage: React.FC<ICharacterProperties> = ({ character }) => {
     if (rank === '') {
       store.dispatch(setCharacterRank(''));
     } else {
-      let model = RanksHelper.instance().getRank(rank as Rank);
+      const model = RanksHelper.instance().getRank(rank as Rank);
       store.dispatch(
         setCharacterRank(model?.localizedName ?? '', rank as Rank),
       );

--- a/WebTools/src/npc/view/majorNpcAttributeView.tsx
+++ b/WebTools/src/npc/view/majorNpcAttributeView.tsx
@@ -61,7 +61,7 @@ const MajorNpcAttributeView: React.FC<ICharacterProperties> = ({
   };
 
   const setAttribute = (attribute: Attribute, delta: number) => {
-    let attributes = [...character.npcGenerationStep?.attributes];
+    const attributes = [...character.npcGenerationStep?.attributes];
     attributes[attribute] = attributes[attribute] + delta;
     store.dispatch(setNpcCharacterAttributes(attributes));
   };

--- a/WebTools/src/npc/view/majorNpcDepartmentView.tsx
+++ b/WebTools/src/npc/view/majorNpcDepartmentView.tsx
@@ -60,7 +60,7 @@ const MajorNpcDepartmentView: React.FC<ICharacterProperties> = ({
   };
 
   const setDepartment = (department: Department, delta: number) => {
-    let departments = [...character.npcGenerationStep?.departments];
+    const departments = [...character.npcGenerationStep?.departments];
     departments[department] = departments[department] + delta;
     store.dispatch(setNpcCharacterDepartments(departments));
   };

--- a/WebTools/src/npc/view/npcAttributesView.tsx
+++ b/WebTools/src/npc/view/npcAttributesView.tsx
@@ -41,9 +41,9 @@ export const NpcAttributesView: React.FC<ICharacterProperties> = ({
   };
 
   const swapAttributeValues = (from: Attribute, to: Attribute) => {
-    let attributes = [...character.npcGenerationStep?.attributes];
-    let fromValue = attributes[from];
-    let toValue = attributes[to];
+    const attributes = [...character.npcGenerationStep?.attributes];
+    const fromValue = attributes[from];
+    const toValue = attributes[to];
     attributes[from] = toValue;
     attributes[to] = fromValue;
 
@@ -52,7 +52,7 @@ export const NpcAttributesView: React.FC<ICharacterProperties> = ({
   };
 
   const attributes = AttributesHelper.getAllAttributes().map((a, i) => {
-    let val = (character?.npcGenerationStep?.attributes[a] ?? 0) + 7;
+    const val = (character?.npcGenerationStep?.attributes[a] ?? 0) + 7;
     const isChecked = character.speciesStep?.attributes?.includes(a);
 
     return (

--- a/WebTools/src/npc/view/npcDepartmentView.tsx
+++ b/WebTools/src/npc/view/npcDepartmentView.tsx
@@ -45,9 +45,9 @@ const NpcDepartmentView: React.FC<ICharacterProperties> = ({ character }) => {
   };
 
   const swapValues = (from: Department, to: Department) => {
-    let departments = [...character.npcGenerationStep?.departments];
-    let fromValue = departments[from];
-    let toValue = departments[to];
+    const departments = [...character.npcGenerationStep?.departments];
+    const fromValue = departments[from];
+    const toValue = departments[to];
     departments[from] = toValue;
     departments[to] = fromValue;
     store.dispatch(setNpcCharacterDepartments(departments));

--- a/WebTools/src/pages/attributesAndDisciplinesPage.tsx
+++ b/WebTools/src/pages/attributesAndDisciplinesPage.tsx
@@ -43,7 +43,7 @@ const AttributesAndDisciplinesPage: React.FC<ICharacterProperties> = ({
   const { t } = useTranslation();
 
   const randomValue = () => {
-    let value = randomUniqueValue(
+    const value = randomUniqueValue(
       character.values,
       character.speciesStep?.species,
       character.educationStep?.primaryDiscipline,
@@ -127,7 +127,7 @@ const AttributesAndDisciplinesPage: React.FC<ICharacterProperties> = ({
     disciplineCount,
   );
 
-  let talents = filterTalentList();
+  const talents = filterTalentList();
 
   const talentSelection =
     isKlingonWarriorType(character.type) || character.version > 1 ? (
@@ -172,7 +172,7 @@ const AttributesAndDisciplinesPage: React.FC<ICharacterProperties> = ({
     }
   }, [character.finishingStep]);
 
-  let value =
+  const value =
     character.type !== CharacterType.Child &&
     character.type !== CharacterType.Cadet ? (
       <div className="col-lg-6 mt-4">

--- a/WebTools/src/pages/careerEventPage.tsx
+++ b/WebTools/src/pages/careerEventPage.tsx
@@ -39,7 +39,7 @@ const CareerEventPage: React.FC<ICareerEventProperties> = ({
   character,
   context,
 }) => {
-  let existingEvent =
+  const existingEvent =
     context === StepContext.CareerEvent1
       ? character.careerEvents[0]
       : character.careerEvents[1];

--- a/WebTools/src/pages/careerLengthDetailsPage.tsx
+++ b/WebTools/src/pages/careerLengthDetailsPage.tsx
@@ -71,7 +71,7 @@ const CareerLengthDetailsPage: React.FC<ICharacterProperties> = ({
   }, [career.id, career.talent, wroteTheBook]);
 
   const randomValue = () => {
-    let value = randomUniqueValue(
+    const value = randomUniqueValue(
       character.values,
       character.speciesStep?.species,
       character.educationStep?.primaryDiscipline,
@@ -150,7 +150,7 @@ const CareerLengthDetailsPage: React.FC<ICharacterProperties> = ({
 
   const filterTalentList = (): RankedTalent[] => {
     if (career.id === Career.Veteran) {
-      let result = [new RankedTalent(TalentsHelper.getTalent('Veteran'))];
+      const result = [new RankedTalent(TalentsHelper.getTalent('Veteran'))];
 
       if (wroteTheBook != null) {
         result.push(new RankedTalent(wroteTheBook));

--- a/WebTools/src/pages/careerLengthPage.tsx
+++ b/WebTools/src/pages/careerLengthPage.tsx
@@ -106,7 +106,7 @@ const CareerLengthPage: React.FC<ICharacterProperties> = ({ character }) => {
     instructionKey = 'CareerLength.instruction.civilian';
   }
 
-  let message = character.hasTalent(ADVANCED_TEAM_DYNAMICS) ? (
+  const message = character.hasTalent(ADVANCED_TEAM_DYNAMICS) ? (
     <div className="page-text">{t('CareerSelectionPage.exclusionText')}</div>
   ) : undefined;
 

--- a/WebTools/src/pages/characterTypePage.tsx
+++ b/WebTools/src/pages/characterTypePage.tsx
@@ -67,7 +67,7 @@ class CharacterTypePage extends React.Component<
             <input
               value={this.state.otherName}
               onChange={(e) => {
-                let value = e.target.value;
+                const value = e.target.value;
                 this.setState((state) => ({ ...state, otherName: value }));
               }}
             />
@@ -109,7 +109,7 @@ class CharacterTypePage extends React.Component<
             <input
               value={this.state.otherName}
               onChange={(e) => {
-                let value = e.target.value;
+                const value = e.target.value;
                 this.setState((state) => ({ ...state, otherName: value }));
               }}
             />
@@ -176,7 +176,7 @@ class CharacterTypePage extends React.Component<
   }
 
   private selectType(typeAsString: string) {
-    let type = parseInt(typeAsString) as CharacterType;
+    const type = parseInt(typeAsString) as CharacterType;
     this.setState((state) => ({
       ...state,
       type: type,
@@ -184,7 +184,7 @@ class CharacterTypePage extends React.Component<
   }
 
   private selectAlliedMilitaryType(typeAsString: string) {
-    let type = parseInt(typeAsString) as AlliedMilitaryType;
+    const type = parseInt(typeAsString) as AlliedMilitaryType;
     this.setState((state) => ({
       ...state,
       alliedMilitary: type,
@@ -200,7 +200,7 @@ class CharacterTypePage extends React.Component<
 
   private startWorkflow() {
     const { era } = this.props;
-    let character = Character.createMainCharacter(
+    const character = Character.createMainCharacter(
       this.state.type,
       era,
       hasSource(Source.Core2ndEdition) ? 2 : 1,

--- a/WebTools/src/pages/childEducationDetailsPage.tsx
+++ b/WebTools/src/pages/childEducationDetailsPage.tsx
@@ -286,7 +286,7 @@ const ChildEducationDetailsPage: React.FC<ICharacterPageProperties> = ({
   );
 
   const randomValue = () => {
-    let value = randomUniqueValue(
+    const value = randomUniqueValue(
       character.values,
       character.speciesStep?.species,
       character.educationStep?.primaryDiscipline,
@@ -346,7 +346,7 @@ const ChildEducationDetailsPage: React.FC<ICharacterPageProperties> = ({
     }
   };
 
-  let focuses =
+  const focuses =
     character.age.options.numberOfFocuses === 1 ? (
       <div className="col-lg-6 my-3">
         <Header level={2}>{t('Construct.other.focus')}</Header>

--- a/WebTools/src/pages/childEducationPage.tsx
+++ b/WebTools/src/pages/childEducationPage.tsx
@@ -23,7 +23,7 @@ interface ITrackSelectionProperties {
 const AgeSelection: React.FC<ITrackSelectionProperties> = ({ onSelection }) => {
   const { t } = useTranslation();
 
-  let ages = AgeHelper.getAllChildAges().map((a, i) => {
+  const ages = AgeHelper.getAllChildAges().map((a, i) => {
     return (
       <tr
         key={i}

--- a/WebTools/src/pages/customSpeciesDetailsPage.tsx
+++ b/WebTools/src/pages/customSpeciesDetailsPage.tsx
@@ -49,7 +49,7 @@ const CustomSpeciesDetailsPage: React.FC<ICustomSpeciesDetailsProperties> = ({
 
   const renderTalentsSection = () => {
     if (character.stereotype !== Stereotype.SoloCharacter) {
-      let talents: RankedTalent[] = [];
+      const talents: RankedTalent[] = [];
       talents.push(
         ...TalentsHelper.getAllAvailableTalentsForCharacter(character)
           .filter((t) =>

--- a/WebTools/src/pages/earlyOutlookDetailsPage.tsx
+++ b/WebTools/src/pages/earlyOutlookDetailsPage.tsx
@@ -122,7 +122,7 @@ const EarlyOutlookDetailsPage: React.FC<ICharacterProperties> = ({
     </div>
   );
 
-  let talents = getEarlyOutlookTalents(character);
+  const talents = getEarlyOutlookTalents(character);
 
   return (
     <div className="page container ms-0">

--- a/WebTools/src/pages/earlyOutlookPage.tsx
+++ b/WebTools/src/pages/earlyOutlookPage.tsx
@@ -221,7 +221,7 @@ const EarlyOutlookPage: React.FC<ICharacterProperties> = ({ character }) => {
     if (randomUpbringing != null) {
       settingsList = [UpbringingsHelper.getUpbringing(randomUpbringing)];
     }
-    let settingRows = settingsList.map((e, i) => toTableRow(e, i));
+    const settingRows = settingsList.map((e, i) => toTableRow(e, i));
 
     return (
       <>
@@ -281,7 +281,7 @@ const EarlyOutlookPage: React.FC<ICharacterProperties> = ({ character }) => {
     if (randomCaste != null) {
       settingsList = [UpbringingsHelper.getCaste(randomCaste)];
     }
-    let settingRows = settingsList.map((e, i) => toTableRow(e, i));
+    const settingRows = settingsList.map((e, i) => toTableRow(e, i));
 
     return (
       <>
@@ -337,7 +337,7 @@ const EarlyOutlookPage: React.FC<ICharacterProperties> = ({ character }) => {
     if (randomAsperation != null) {
       settingsList = [UpbringingsHelper.getAspiration(randomAsperation)];
     }
-    let settingRows = settingsList.map((e, i) => toTableRow(e, i));
+    const settingRows = settingsList.map((e, i) => toTableRow(e, i));
 
     return (
       <>

--- a/WebTools/src/pages/educationDetailsPage.tsx
+++ b/WebTools/src/pages/educationDetailsPage.tsx
@@ -72,7 +72,7 @@ const EducationDetailsPage: React.FC<ICharacterProperties> = ({
     new EducationSecondaryDisciplineController(character, track);
 
   const randomValue = () => {
-    let value = randomUniqueValue(
+    const value = randomUniqueValue(
       character.values,
       character.speciesStep?.species,
       character.educationStep?.primaryDiscipline,
@@ -83,7 +83,7 @@ const EducationDetailsPage: React.FC<ICharacterProperties> = ({
   const selectRandomFocus = (index: number) => {
     let done = false;
     while (!done) {
-      let focus = localizedFocus(
+      const focus = localizedFocus(
         FocusRandomTableWithHints(
           character.educationStep?.primaryDiscipline,
           track.focuses.focusSuggestions,

--- a/WebTools/src/pages/educationPage.tsx
+++ b/WebTools/src/pages/educationPage.tsx
@@ -33,7 +33,7 @@ const EducationPage: React.FC<ICharacterProperties> = ({ character }) => {
   const { t } = useTranslation();
 
   const rollTrack = () => {
-    let track = TracksHelper.instance.generateTrack(
+    const track = TracksHelper.instance.generateTrack(
       character.type,
       character.version,
     );

--- a/WebTools/src/pages/environmentDetailsPage.tsx
+++ b/WebTools/src/pages/environmentDetailsPage.tsx
@@ -136,7 +136,7 @@ const EnvironmentDetailsPage: React.FC<ICharacterProperties> = ({
   const { t } = useTranslation();
 
   const distinctValues = (attributes: Attribute[]) => {
-    let result = [];
+    const result = [];
     attributes.forEach((a) => {
       if (!result.includes(a)) {
         result.push(a);
@@ -151,11 +151,11 @@ const EnvironmentDetailsPage: React.FC<ICharacterProperties> = ({
   );
   let attributes = environment.attributes;
   if (environment.id === Environment.Homeworld) {
-    let speciesType = character.speciesStep?.species;
+    const speciesType = character.speciesStep?.species;
     if (speciesType === Species.Custom) {
       attributes = AttributesHelper.getAllAttributes();
     } else {
-      let species = SpeciesHelper.getSpeciesByType(
+      const species = SpeciesHelper.getSpeciesByType(
         character.speciesStep?.species,
       );
       attributes = species.attributes;
@@ -164,7 +164,7 @@ const EnvironmentDetailsPage: React.FC<ICharacterProperties> = ({
     environment.id === Environment.AnotherSpeciesWorld &&
     character.environmentStep?.otherSpecies != null
   ) {
-    let species = SpeciesHelper.getSpeciesByType(
+    const species = SpeciesHelper.getSpeciesByType(
       character.environmentStep?.otherSpecies,
     );
     attributes = species?.attributes;
@@ -200,7 +200,7 @@ const EnvironmentDetailsPage: React.FC<ICharacterProperties> = ({
   };
 
   const randomValue = () => {
-    let value = randomUniqueValue(
+    const value = randomUniqueValue(
       character.values,
       character.speciesStep?.species,
       character.environmentStep?.discipline,
@@ -215,7 +215,7 @@ const EnvironmentDetailsPage: React.FC<ICharacterProperties> = ({
     );
   };
 
-  let speciesList = SpeciesHelper.getCaptainsLogSpecies()
+  const speciesList = SpeciesHelper.getCaptainsLogSpecies()
     .filter((s) => s.id !== character.speciesStep?.species)
     .map((s) => new DropDownElement(s.id, s.localizedName));
   speciesList.unshift(new DropDownElement('', t('Common.text.select')));

--- a/WebTools/src/pages/environmentPage.tsx
+++ b/WebTools/src/pages/environmentPage.tsx
@@ -100,7 +100,7 @@ const EnvironmentPage: React.FC<ICharacterProperties> = ({ character }) => {
   };
 
   const chooseRandomEnvironment = () => {
-    let environments = EnvironmentsHelper.getEnvironmentOptions(character);
+    const environments = EnvironmentsHelper.getEnvironmentOptions(character);
 
     return environments[Math.floor(Math.random() * environments.length)].id;
   };
@@ -113,13 +113,13 @@ const EnvironmentPage: React.FC<ICharacterProperties> = ({ character }) => {
       ];
     }
 
-    let settings = environments.filter((e) =>
+    const settings = environments.filter((e) =>
       EnvironmentsHelper.isSetting(e.id),
     );
-    let conditions = environments.filter((e) =>
+    const conditions = environments.filter((e) =>
       EnvironmentsHelper.isCondition(e.id),
     );
-    let homeworlds = environments.filter((e) =>
+    const homeworlds = environments.filter((e) =>
       EnvironmentsHelper.isHomeworld(e.id),
     );
 

--- a/WebTools/src/pages/finishPage.tsx
+++ b/WebTools/src/pages/finishPage.tsx
@@ -45,8 +45,8 @@ const FinishPage: React.FC<IFinishPageProperties> = ({ character }) => {
 
   const currentRole = character.role;
 
-  let roleList = RolesHelper.instance.getRoles(character);
-  let rankList = RanksHelper.instance().getSortedRanks(character, false);
+  const roleList = RolesHelper.instance.getRoles(character);
+  const rankList = RanksHelper.instance().getSortedRanks(character, false);
 
   useEffect(() => {
     if (character.role == null && !character.jobAssignment) {
@@ -58,7 +58,7 @@ const FinishPage: React.FC<IFinishPageProperties> = ({ character }) => {
         setRoleSelectionAllowed(false);
       }
     } else if (!character.isCivilian() && rankList?.length > 0) {
-      let existingRank = rankList.filter((r) => r.id === character.rank?.id);
+      const existingRank = rankList.filter((r) => r.id === character.rank?.id);
       if (character.rank == null || existingRank.length === 0) {
         const rank = rankList[rankList.length - 1];
         if (rank) {
@@ -70,7 +70,7 @@ const FinishPage: React.FC<IFinishPageProperties> = ({ character }) => {
 
   const showViewPage = () => {
     setTimeout(() => {
-      let c = store.getState().character.currentCharacter;
+      const c = store.getState().character.currentCharacter;
       const value = marshaller.encodeMainCharacter(c);
       store.dispatch(saveCharacterToLocalStorage(c));
       window.open('/view?s=' + value, '_blank');
@@ -314,7 +314,7 @@ const FinishPage: React.FC<IFinishPageProperties> = ({ character }) => {
         ({ CharacterSheetRegistry }) => {
           setLoadingExport(false);
           setTimeout(() => {
-            let c = store.getState().character.currentCharacter;
+            const c = store.getState().character.currentCharacter;
             store.dispatch(saveCharacterToLocalStorage(c));
             CharacterSheetDialog.show(
               CharacterSheetRegistry.getCharacterSheets(c),
@@ -355,7 +355,7 @@ const FinishPage: React.FC<IFinishPageProperties> = ({ character }) => {
     if (typeof rank === 'string') {
       store.dispatch(setCharacterRank(rank as string));
     } else {
-      let r = rank as RankModel;
+      const r = rank as RankModel;
       store.dispatch(setCharacterRank(r.name, r.id));
     }
   };
@@ -404,7 +404,7 @@ const FinishPage: React.FC<IFinishPageProperties> = ({ character }) => {
       : species.localizedNameDescription;
 
   const nameSuggestions = species?.nameSuggestions ?? ANY_NAMES;
-  let names = [];
+  const names = [];
 
   nameSuggestions?.forEach((n) => {
     names.push(`${n.type}: ${n.suggestions}`);

--- a/WebTools/src/pages/noviceOrCadetExperiencePage.tsx
+++ b/WebTools/src/pages/noviceOrCadetExperiencePage.tsx
@@ -51,7 +51,7 @@ const NoviceOrCadetExperiencePage: React.FC<ICharacterProperties> = ({
   };
 
   const randomValue = () => {
-    let value = randomUniqueValue(
+    const value = randomUniqueValue(
       character.values,
       character.speciesStep?.species,
       character.educationStep?.primaryDiscipline,
@@ -71,7 +71,7 @@ const NoviceOrCadetExperiencePage: React.FC<ICharacterProperties> = ({
     store.dispatch(addCharacterTalent(talentModel, StepContext.Career));
   }, [talentModel]);
 
-  let instruction =
+  const instruction =
     character.type === CharacterType.Cadet
       ? 'CareerLength.instruction.cadet'
       : 'CareerType.core.young.description';

--- a/WebTools/src/pages/pageFactory.tsx
+++ b/WebTools/src/pages/pageFactory.tsx
@@ -119,9 +119,9 @@ export class PageFactory {
   createPage(page: PageIdentity) {
     let factory = this.factories[page];
 
-    for (let key of Object.keys(this.pageFactories)) {
-      let pageFactory = this.pageFactories[key];
-      let temp = pageFactory.findFactory(page);
+    for (const key of Object.keys(this.pageFactories)) {
+      const pageFactory = this.pageFactories[key];
+      const temp = pageFactory.findFactory(page);
       if (temp != null) {
         factory = temp;
         break;

--- a/WebTools/src/pages/simpleCareerPage.tsx
+++ b/WebTools/src/pages/simpleCareerPage.tsx
@@ -41,7 +41,7 @@ const SimpleCareerPage: React.FC<ISimpleCareerPageProperties> = ({
   };
 
   const randomValue = () => {
-    let value = randomUniqueValue(
+    const value = randomUniqueValue(
       character.values,
       character.speciesStep?.species,
       character.educationStep?.primaryDiscipline,
@@ -57,11 +57,11 @@ const SimpleCareerPage: React.FC<ISimpleCareerPageProperties> = ({
     store.dispatch(addCharacterTalent(talentModel, StepContext.Career));
   }, [talent, talentModel]);
 
-  let instruction =
+  const instruction =
     character.type === CharacterType.Child
       ? 'CareerLength.instruction.child'
       : 'CareerLength.instruction.cadet';
-  let valueText =
+  const valueText =
     character.type === CharacterType.Child
       ? 'Value.childEducation.text'
       : 'Value.careerLength.young.text';

--- a/WebTools/src/pages/sourceSelectionPage.tsx
+++ b/WebTools/src/pages/sourceSelectionPage.tsx
@@ -181,8 +181,8 @@ const SourceSelectionPage: React.FC<ISourceSelectionPageProperties> = ({
 
   const toggleSources = (selectAll: boolean) => {
     if (selectAll) {
-      let version = isSecondEdition() ? 2 : 1;
-      let sources = SourcesHelper.getSources()
+      const version = isSecondEdition() ? 2 : 1;
+      const sources = SourcesHelper.getSources()
         .filter((s) => s.available && (s.version === 1 || version === 2))
         .filter((s) => {
           if (s.id === Source.Core) {

--- a/WebTools/src/pages/speciesDetailsPage.tsx
+++ b/WebTools/src/pages/speciesDetailsPage.tsx
@@ -56,7 +56,9 @@ const SpeciesDetailsPage: React.FC<ISpeciesDetailsProperties> = ({
 }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  let species = SpeciesHelper.getSpeciesByType(character.speciesStep?.species);
+  const species = SpeciesHelper.getSpeciesByType(
+    character.speciesStep?.species,
+  );
   const controller = SpeciesAttributeController.create(character, species);
 
   const selectDesc =
@@ -81,7 +83,7 @@ const SpeciesDetailsPage: React.FC<ISpeciesDetailsProperties> = ({
   };
 
   const renderTraitSection = (species: SpeciesModel) => {
-    let mixed =
+    const mixed =
       character.speciesStep?.mixedSpecies != null
         ? SpeciesHelper.getSpeciesByType(character.speciesStep?.mixedSpecies)
         : null;
@@ -143,7 +145,7 @@ const SpeciesDetailsPage: React.FC<ISpeciesDetailsProperties> = ({
   const renderVersion2TalentsSection = () => {
     let talents = [];
     if (character.speciesStep?.ability == null) {
-      let species = SpeciesHelper.getSpeciesByType(
+      const species = SpeciesHelper.getSpeciesByType(
         character.speciesStep?.species,
       );
       species.talents
@@ -177,7 +179,7 @@ const SpeciesDetailsPage: React.FC<ISpeciesDetailsProperties> = ({
   };
 
   const renderVersion1TalentsSection = () => {
-    let talents: RankedTalent[] = [];
+    const talents: RankedTalent[] = [];
     talents.push(
       ...TalentsHelper.getAllAvailableTalentsForCharacter(character).map(
         (t) => new RankedTalent(t),

--- a/WebTools/src/pages/speciesPage.tsx
+++ b/WebTools/src/pages/speciesPage.tsx
@@ -88,7 +88,7 @@ const SpeciesPage: React.FC<ICharacterProperties> = ({ character }) => {
   };
 
   const selectStandardSpecies = (species: Species) => {
-    let speciesModel = SpeciesHelper.getSpeciesByType(species);
+    const speciesModel = SpeciesHelper.getSpeciesByType(species);
     if (speciesModel.isAttributeSelectionRequired) {
       store.dispatch(setCharacterSpecies(speciesModel.id));
     } else {

--- a/WebTools/src/pages/talentsOverviewPage.tsx
+++ b/WebTools/src/pages/talentsOverviewPage.tsx
@@ -67,8 +67,8 @@ class TalentViewModel {
     );
   }
   matchesAlias(term) {
-    var result = false;
-    for (var i = 0; i < this.aliases.length; i++) {
+    let result = false;
+    for (let i = 0; i < this.aliases.length; i++) {
       const alias = this.aliases[i];
       result = alias.name.toLowerCase().replace('’', "'").indexOf(term) >= 0;
       if (result) {
@@ -81,10 +81,10 @@ class TalentViewModel {
   get version() {
     let first = false;
     let second = this.talent.is2eSupported;
-    let sources = SourcesHelper.getSources();
+    const sources = SourcesHelper.getSources();
 
     this.talent.sources.forEach((s) => {
-      let source = sources.filter((src) => src.id === s)[0];
+      const source = sources.filter((src) => src.id === s)[0];
       if (source.version === 1) {
         first = true;
       } else if (source.version === 2) {
@@ -103,7 +103,7 @@ class TalentViewModel {
   static from(talent: TalentModel) {
     let prerequisites = '';
     talent.prerequisites.forEach((p) => {
-      let desc = p.describe();
+      const desc = p.describe();
       if (desc) {
         if (prerequisites === '') {
           prerequisites = desc;
@@ -123,7 +123,7 @@ class TalentViewModel {
 }
 
 const TalentsOverviewPage = () => {
-  let _allTalents: TalentViewModel[] = [];
+  const _allTalents: TalentViewModel[] = [];
   const [showAdvanced, setShowAdvanced] = useState<boolean>(false);
   const [search, setSearch] = useState('');
   const [version, setVersion] = useState<TalentVersion>(TalentVersion.Both);
@@ -139,7 +139,7 @@ const TalentsOverviewPage = () => {
   const { t } = useTranslation();
 
   const selectTalents = () => {
-    let talents = [];
+    const talents = [];
     for (let i = 0; i < _allTalents.length; i++) {
       const talent = _allTalents[i];
       if (search.length && !talent.matches(search)) {
@@ -268,7 +268,7 @@ const TalentsOverviewPage = () => {
   };
 
   const getSpecies = () => {
-    let speciesList: Species[] = [];
+    const speciesList: Species[] = [];
     _allTalents.forEach((t) => {
       if (t.talent.category.category === TalentCategory.Species) {
         t.talent.category.type.forEach((s) => {
@@ -278,7 +278,7 @@ const TalentsOverviewPage = () => {
         });
       }
     });
-    let dropDowns = speciesList.map(
+    const dropDowns = speciesList.map(
       (s) =>
         new DropDownElement(s, SpeciesHelper.getSpeciesByType(s).localizedName),
     );
@@ -291,13 +291,13 @@ const TalentsOverviewPage = () => {
 
   const loadTalents = () => {
     const talentsList = TalentsHelper.getTalents();
-    for (var i = 0; i < talentsList.length; i++) {
+    for (let i = 0; i < talentsList.length; i++) {
       const talent = talentsList[i];
       const sources = TalentsHelper.getSourceForTalent(talent.name);
 
       let available = sources && sources.length > 0 ? false : true;
       sources.forEach((s) => {
-        let source = SourcesHelper.getSources()[s];
+        const source = SourcesHelper.getSources()[s];
         available = available || source.available;
       });
 
@@ -335,12 +335,12 @@ const TalentsOverviewPage = () => {
       );
     }
 
-    let description =
+    const description =
       hasSource(Source.Core2ndEdition) && version !== TalentVersion.FirstEdition
         ? t.talent.localizedDescription2e
         : t.talent.localizedDescription;
 
-    let lines = description.includes(CHALLENGE_DICE_NOTATION) ? (
+    const lines = description.includes(CHALLENGE_DICE_NOTATION) ? (
       description.split('\n').map((l, i) => {
         return (
           <div className={i === 0 ? '' : 'mt-2'} key={'d-' + i}>

--- a/WebTools/src/pages/toolSelectionPage.tsx
+++ b/WebTools/src/pages/toolSelectionPage.tsx
@@ -58,7 +58,7 @@ const ToolSelectionPage = () => {
 
   const startCharacterCreation = () => {
     if (hasSource(Source.Core2ndEdition)) {
-      let character = Character.createMainCharacter(
+      const character = Character.createMainCharacter(
         CharacterType.Starfleet,
         store.getState().context.era,
         2,
@@ -71,7 +71,7 @@ const ToolSelectionPage = () => {
     ) {
       goToPage(PageIdentity.CharacterType);
     } else {
-      let character = Character.createMainCharacter(
+      const character = Character.createMainCharacter(
         CharacterType.Starfleet,
         store.getState().context.era,
       );

--- a/WebTools/src/safety/model/safetySection.ts
+++ b/WebTools/src/safety/model/safetySection.ts
@@ -26,8 +26,8 @@ export class SafetySection {
 
   get localizedCategories() {
     return this.categories.map((c) => {
-      let key = makeKey('SafetySection.category.', c);
-      let result = i18next.t(key);
+      const key = makeKey('SafetySection.category.', c);
+      const result = i18next.t(key);
       return result === key ? c : result;
     });
   }

--- a/WebTools/src/safety/page/safetyChecklistPage.tsx
+++ b/WebTools/src/safety/page/safetyChecklistPage.tsx
@@ -54,7 +54,7 @@ const SafetySectionView: React.FC<ISafetySectionViewProperties> = ({
         </thead>
         <tbody>
           {section.localizedCategories.map((c, i) => {
-            let category = section.categories[i];
+            const category = section.categories[i];
             return (
               <tr key={'section-category-' + category}>
                 <td>{c}</td>

--- a/WebTools/src/solo/component/d20IconButton.tsx
+++ b/WebTools/src/solo/component/d20IconButton.tsx
@@ -5,9 +5,9 @@ interface ID20IconButton {
 }
 
 const D20IconButton: React.FC<ID20IconButton> = ({ onClick }) => {
-  let defaultPurple = '#de84b7';
-  let highlightColour = '#e59dc5';
-  let [colour, setColour] = useState(defaultPurple);
+  const defaultPurple = '#de84b7';
+  const highlightColour = '#e59dc5';
+  const [colour, setColour] = useState(defaultPurple);
 
   return (
     <button

--- a/WebTools/src/solo/page/soloCareerEventDetailPage.tsx
+++ b/WebTools/src/solo/page/soloCareerEventDetailPage.tsx
@@ -73,7 +73,9 @@ const SoloCareerEventDetailsPage: React.FC<ISoloCareerEventProperties> = ({
   const selectRandomFocus = () => {
     let done = false;
     while (!done) {
-      let focus = localizedFocus(FocusRandomTable(careerEventStep.discipline));
+      const focus = localizedFocus(
+        FocusRandomTable(careerEventStep.discipline),
+      );
       if (character.focuses.indexOf(focus) < 0) {
         done = true;
         store.dispatch(setCharacterFocus(focus, context));

--- a/WebTools/src/solo/page/soloCareerLengthDetailsPage.tsx
+++ b/WebTools/src/solo/page/soloCareerLengthDetailsPage.tsx
@@ -37,7 +37,7 @@ const SoloCareerLengthDetailsPage: React.FC<ICharacterProperties> = ({
   };
 
   const randomValue = () => {
-    let value = randomUniqueValue(
+    const value = randomUniqueValue(
       character.values,
       character.speciesStep?.species,
       character.educationStep?.primaryDiscipline,

--- a/WebTools/src/solo/page/soloEarlyOutlookDetailsPage.tsx
+++ b/WebTools/src/solo/page/soloEarlyOutlookDetailsPage.tsx
@@ -52,7 +52,7 @@ const SoloEarlyOutlookDetailsPage: React.FC<ICharacterProperties> = ({
   const selectRandomFocus = () => {
     let done = false;
     while (!done) {
-      let focus = localizedFocus(
+      const focus = localizedFocus(
         FocusRandomTable(character.upbringingStep?.discipline),
       );
       if (character.focuses.indexOf(focus) < 0) {

--- a/WebTools/src/solo/page/soloEarlyOutlookPage.tsx
+++ b/WebTools/src/solo/page/soloEarlyOutlookPage.tsx
@@ -161,7 +161,7 @@ const SoloEarlyOutlookPage: React.FC<ICharacterProperties> = ({
     if (randomUpbringing != null) {
       settingsList = [UpbringingsHelper.getUpbringing(randomUpbringing)];
     }
-    let settingRows = settingsList.map((e, i) => toTableRow(e, i));
+    const settingRows = settingsList.map((e, i) => toTableRow(e, i));
 
     return (
       <>
@@ -218,7 +218,7 @@ const SoloEarlyOutlookPage: React.FC<ICharacterProperties> = ({
     if (randomCaste != null) {
       settingsList = [UpbringingsHelper.getCaste(randomCaste)];
     }
-    let settingRows = settingsList.map((e, i) => toTableRow(e, i));
+    const settingRows = settingsList.map((e, i) => toTableRow(e, i));
 
     return (
       <>
@@ -273,7 +273,7 @@ const SoloEarlyOutlookPage: React.FC<ICharacterProperties> = ({
     if (randomAsperation != null) {
       settingsList = [UpbringingsHelper.getAspiration(randomAsperation)];
     }
-    let settingRows = settingsList.map((e, i) => toTableRow(e, i));
+    const settingRows = settingsList.map((e, i) => toTableRow(e, i));
 
     return (
       <>

--- a/WebTools/src/solo/page/soloEducationDetailsPage.tsx
+++ b/WebTools/src/solo/page/soloEducationDetailsPage.tsx
@@ -68,7 +68,7 @@ const SoloEducationDetailsPage: React.FC<ICharacterProperties> = ({
   };
 
   const randomValue = () => {
-    let value = randomUniqueValue(
+    const value = randomUniqueValue(
       character.values,
       character.speciesStep?.species,
       character.educationStep?.primaryDiscipline,
@@ -79,7 +79,7 @@ const SoloEducationDetailsPage: React.FC<ICharacterProperties> = ({
   const selectRandomFocus = (index: number) => {
     let done = false;
     while (!done) {
-      let focus = localizedFocus(
+      const focus = localizedFocus(
         FocusRandomTable(character.educationStep?.primaryDiscipline),
       );
       if (character.focuses.indexOf(focus) < 0) {

--- a/WebTools/src/solo/page/soloEraSelectionPage.tsx
+++ b/WebTools/src/solo/page/soloEraSelectionPage.tsx
@@ -33,13 +33,13 @@ const SoloEraSelectionPage: React.FC<ISoloEraSelectionPage> = ({
   const eraSelected = (era: Era) => {
     store.dispatch(setEra(era));
     if (stereotype === Stereotype.SoloStarship) {
-      let starship = store.getState().starship?.starship;
-      let serviceYear = eraDefaultYear(era);
+      const starship = store.getState().starship?.starship;
+      const serviceYear = eraDefaultYear(era);
       if (
         starship?.serviceYear != null &&
         starship?.serviceYear !== serviceYear
       ) {
-        let newStarship = Starship.createSoloStarship(era);
+        const newStarship = Starship.createSoloStarship(era);
         newStarship.serviceYear = serviceYear;
         store.dispatch(createStarship(newStarship));
       } else {

--- a/WebTools/src/solo/page/soloFinalPage.tsx
+++ b/WebTools/src/solo/page/soloFinalPage.tsx
@@ -53,7 +53,7 @@ const SoloFinalPage: React.FC<ICharacterProperties> = ({ character }) => {
   }
 
   const assignmentOptions = () => {
-    let result = [
+    const result = [
       new DropDownElement('', t('Common.text.select')),
       new DropDownElement('other', 'Other'),
     ];
@@ -85,7 +85,7 @@ const SoloFinalPage: React.FC<ICharacterProperties> = ({ character }) => {
           setLoadingExport(false);
 
           setTimeout(() => {
-            let c = store.getState().character.currentCharacter;
+            const c = store.getState().character.currentCharacter;
             CharacterSheetDialog.show(
               CharacterSheetRegistry.getCharacterSheets(c),
               'sta-solo-character',
@@ -98,7 +98,7 @@ const SoloFinalPage: React.FC<ICharacterProperties> = ({ character }) => {
   };
 
   const rankOptions = () => {
-    let result = [
+    const result = [
       new DropDownElement('', t('Common.text.select')),
       new DropDownElement('other', 'Other'),
     ];
@@ -122,7 +122,7 @@ const SoloFinalPage: React.FC<ICharacterProperties> = ({ character }) => {
       setShowRankOther(true);
     } else {
       if (id !== '') {
-        let rank = RanksHelper.instance().getRank(id as Rank);
+        const rank = RanksHelper.instance().getRank(id as Rank);
         store.dispatch(setCharacterRank(rank.name, id as Rank));
       }
 
@@ -145,7 +145,7 @@ const SoloFinalPage: React.FC<ICharacterProperties> = ({ character }) => {
       if (showAssignmentOther) {
         setShowAssignmentOther(false);
       }
-      let role = RolesHelper.instance.getSoloRole(assignment as Role);
+      const role = RolesHelper.instance.getSoloRole(assignment as Role);
       if (role) {
         store.dispatch(setCharacterAssignment(assignment as Role));
       }
@@ -158,7 +158,7 @@ const SoloFinalPage: React.FC<ICharacterProperties> = ({ character }) => {
 
   const showViewPage = () => {
     setTimeout(() => {
-      let c = store.getState().character.currentCharacter;
+      const c = store.getState().character.currentCharacter;
       const value = marshaller.encodeSoloCharacter(c);
       window.open('/view?s=' + value, '_blank');
     });

--- a/WebTools/src/solo/page/soloFinishingTouchesPage.tsx
+++ b/WebTools/src/solo/page/soloFinishingTouchesPage.tsx
@@ -71,7 +71,7 @@ const SoloFinishingTouchesPage: React.FC<ICharacterProperties> = ({
   };
 
   const randomValue = () => {
-    let value = randomUniqueValue(
+    const value = randomUniqueValue(
       character.values,
       character.speciesStep?.species,
       character.educationStep?.primaryDiscipline,

--- a/WebTools/src/solo/page/soloSpeciesPage.tsx
+++ b/WebTools/src/solo/page/soloSpeciesPage.tsx
@@ -52,7 +52,7 @@ const SoloSpeciesPage: React.FC<ISoloSpeciesPageProperties> = ({
   } else if (randomSpecies === Species.Custom) {
     speciesList = [];
   }
-  let speciesRows = speciesList.map((s, i) => {
+  const speciesRows = speciesList.map((s, i) => {
     const attributes =
       s.id === Species.Ktarian ? (
         <div key={'species-' + s.id}>

--- a/WebTools/src/solo/page/soloStarhipFinalPage.tsx
+++ b/WebTools/src/solo/page/soloStarhipFinalPage.tsx
@@ -52,7 +52,7 @@ const SoloStarshipFinalPage: React.FC<ISoloStarshipFinalProperties> = ({
           setLoadingExport(false);
 
           setTimeout(() => {
-            let s = store.getState().starship?.starship;
+            const s = store.getState().starship?.starship;
             CharacterSheetDialog.show(
               CharacterSheetRegistry.getStarshipSheets(s),
               'sta-solo-starship',
@@ -123,7 +123,7 @@ const SoloStarshipFinalPage: React.FC<ISoloStarshipFinalProperties> = ({
               store.dispatch(setStarshipTraits(ev.target.value))
             }
             onBlur={(ev) => {
-              let temp = ev.target.value.replace(/\n/g, ', ');
+              const temp = ev.target.value.replace(/\n/g, ', ');
               store.dispatch(setStarshipTraits(temp));
             }}
             value={starship.traits}

--- a/WebTools/src/solo/page/soloStarshipSpaceframePage.tsx
+++ b/WebTools/src/solo/page/soloStarshipSpaceframePage.tsx
@@ -44,7 +44,7 @@ const SoloStarshipSpaceframePage: React.FC<
       SpaceframeHelper.instance().getSpaceframe(randomSpaceframe),
     ];
   }
-  let selectionRows = selectionList.map((s, i) => {
+  const selectionRows = selectionList.map((s, i) => {
     const departments = (
       <>
         <StatView

--- a/WebTools/src/solo/page/soloStarshipTalentsPage.tsx
+++ b/WebTools/src/solo/page/soloStarshipTalentsPage.tsx
@@ -32,15 +32,15 @@ const SoloStarshipTalentsPage: React.FC<ISoloStarshipTalentsProperties> = ({
 
   const randomTalents = () => {
     let talents = [];
-    let count = starship.additionalTalents?.length;
+    const count = starship.additionalTalents?.length;
     if (count > 0 && count < starship?.spaceframeModel?.scale) {
       talents = starship.additionalTalents.map((t) => t.name);
     }
 
     while (talents.length < starship?.spaceframeModel?.scale) {
-      let name = StarshipRandomTalentTable();
+      const name = StarshipRandomTalentTable();
       if (talents.indexOf(name) < 0) {
-        let talent = TalentsHelper.getTalent(name);
+        const talent = TalentsHelper.getTalent(name);
         if (talent != null && isTalentAllowed(talent)) {
           talents.push(name);
         } else if (talent == null) {
@@ -49,7 +49,7 @@ const SoloStarshipTalentsPage: React.FC<ISoloStarshipTalentsProperties> = ({
       }
     }
 
-    let selectedTalents = talents.map((n) => new SelectedTalent(n));
+    const selectedTalents = talents.map((n) => new SelectedTalent(n));
     store.dispatch(setAdditionalTalents(selectedTalents));
   };
 
@@ -106,7 +106,7 @@ const SoloStarshipTalentsPage: React.FC<ISoloStarshipTalentsProperties> = ({
   const talentRows = talents.map((t, i) => {
     let prerequisites = undefined;
     t.prerequisites.forEach((p) => {
-      let desc = p.describe();
+      const desc = p.describe();
       if (desc) {
         if (prerequisites == null) {
           prerequisites = desc;
@@ -116,12 +116,12 @@ const SoloStarshipTalentsPage: React.FC<ISoloStarshipTalentsProperties> = ({
       }
     });
 
-    let description =
+    const description =
       starship.version === 1
         ? t.localizedDescription
         : t.localizedDescription2e;
 
-    let lines = description.split('\n').map((l, i) => {
+    const lines = description.split('\n').map((l, i) => {
       return (
         <div className={i === 0 ? '' : 'mt-2'} key={'d-' + i}>
           {replaceDiceWithArrowhead(l)}

--- a/WebTools/src/solo/table/careerLengthRandomTable.ts
+++ b/WebTools/src/solo/table/careerLengthRandomTable.ts
@@ -2,7 +2,7 @@ import { D20 } from '../../common/die';
 import { Career } from '../../helpers/careerEnum';
 
 export const CareerLengthRandomTable = () => {
-  let roll = D20.roll();
+  const roll = D20.roll();
   switch (roll) {
     case 1:
     case 2:

--- a/WebTools/src/solo/table/educationRandomTable.ts
+++ b/WebTools/src/solo/table/educationRandomTable.ts
@@ -3,7 +3,7 @@ import { D20 } from '../../common/die';
 import { Track } from '../../helpers/trackEnum';
 
 export const EducationCategoryRandomTable = () => {
-  let roll = D20.roll();
+  const roll = D20.roll();
   switch (roll) {
     case 1:
     case 2:

--- a/WebTools/src/solo/table/environmentRandomTable.ts
+++ b/WebTools/src/solo/table/environmentRandomTable.ts
@@ -2,7 +2,7 @@ import { D20 } from '../../common/die';
 import { Environment } from '../../helpers/environments';
 
 export const EnvironmentSettingRandomTable = () => {
-  let roll = D20.roll();
+  const roll = D20.roll();
   switch (roll) {
     case 1:
     case 2:
@@ -33,7 +33,7 @@ export const EnvironmentSettingRandomTable = () => {
 };
 
 export const EnvironmentConditionRandomTable = () => {
-  let roll = D20.roll();
+  const roll = D20.roll();
   switch (roll) {
     case 1:
     case 2:

--- a/WebTools/src/solo/table/eraRandomTable.ts
+++ b/WebTools/src/solo/table/eraRandomTable.ts
@@ -40,7 +40,7 @@ export const eraRandomTable: TableRoll<Era> = () => {
 };
 
 export const eraRandomTableForStarships: TableRoll<Era> = () => {
-  let roll = D20.roll();
+  const roll = D20.roll();
   let era = null;
 
   while (era == null) {

--- a/WebTools/src/solo/table/focusRandomTable.ts
+++ b/WebTools/src/solo/table/focusRandomTable.ts
@@ -3,7 +3,7 @@ import { Department } from '../../helpers/department';
 
 const FocusCommandRandomTable = () => {
   const tableRoll = D20.roll();
-  let roll = D20.roll();
+  const roll = D20.roll();
 
   if (tableRoll <= 10) {
     switch (roll) {
@@ -98,7 +98,7 @@ const FocusCommandRandomTable = () => {
 
 const FocusConnRandomTable = () => {
   const tableRoll = D20.roll();
-  let roll = D20.roll();
+  const roll = D20.roll();
 
   if (tableRoll <= 10) {
     switch (roll) {
@@ -193,7 +193,7 @@ const FocusConnRandomTable = () => {
 
 const FocusSecurityRandomTable = () => {
   const tableRoll = D20.roll();
-  let roll = D20.roll();
+  const roll = D20.roll();
 
   if (tableRoll <= 10) {
     switch (roll) {
@@ -288,7 +288,7 @@ const FocusSecurityRandomTable = () => {
 
 const FocusEngineeringRandomTable = () => {
   const tableRoll = D20.roll();
-  let roll = D20.roll();
+  const roll = D20.roll();
 
   if (tableRoll <= 10) {
     switch (roll) {
@@ -383,7 +383,7 @@ const FocusEngineeringRandomTable = () => {
 
 const FocusScienceRandomTable = () => {
   const tableRoll = D20.roll();
-  let roll = D20.roll();
+  const roll = D20.roll();
 
   if (tableRoll <= 10) {
     switch (roll) {
@@ -478,7 +478,7 @@ const FocusScienceRandomTable = () => {
 
 const FocusMedicineRandomTable = () => {
   const tableRoll = D20.roll();
-  let roll = D20.roll();
+  const roll = D20.roll();
 
   if (tableRoll <= 10) {
     switch (roll) {
@@ -576,7 +576,7 @@ export const FocusRandomTableWithHints = (
   hints: string[] = [],
 ) => {
   if (D20.roll() <= 10 && hints.length > 0) {
-    let i = Math.floor(hints.length * Math.random());
+    const i = Math.floor(hints.length * Math.random());
     return hints[i];
   } else {
     return FocusRandomTable(skill);

--- a/WebTools/src/solo/table/speciesRandomTable.ts
+++ b/WebTools/src/solo/table/speciesRandomTable.ts
@@ -3,12 +3,12 @@ import { Era } from '../../helpers/erasEnum';
 import { Species } from '../../helpers/speciesEnum';
 
 export const SpeciesRandomTable = (era: Era) => {
-  let tables = [
+  const tables = [
     EnterpriseSpeciesRandomTable,
     OriginalSeriesSpeciesRandomTable,
     NextGenerationSpeciesRandomTable,
   ];
-  let table =
+  const table =
     tables[Math.min(tables.length - 1, Math.floor(Math.random() * (era + 1)))];
 
   return table();

--- a/WebTools/src/solo/table/starshipRandomTable.ts
+++ b/WebTools/src/solo/table/starshipRandomTable.ts
@@ -4,7 +4,7 @@ import { Era } from '../../helpers/erasEnum';
 import { Spaceframe } from '../../helpers/spaceframeEnum';
 
 export const SpaceframeRandomTable = (era: Era) => {
-  let tables = [
+  const tables = [
     EnterpriseSpaceframeRandomTable,
     OriginalSeriesSpaceframeRandomTable,
     NextGenerationSpaceframeRandomTable,

--- a/WebTools/src/solo/table/valueRandomTable.ts
+++ b/WebTools/src/solo/table/valueRandomTable.ts
@@ -5,9 +5,9 @@ import { Species } from '../../helpers/speciesEnum';
 import { hasSource } from '../../state/contextFunctions';
 
 export const ValueRandomTable = (species?: Species, skill?: Department) => {
-  let roll = D20.roll();
+  const roll = D20.roll();
   if (roll <= 15 && hasSource(Source.ContinuingMissions)) {
-    let subRoll = D20.roll();
+    const subRoll = D20.roll();
     if (subRoll <= 10) {
       if (
         species != null &&
@@ -50,7 +50,7 @@ export const randomUniqueValue = (
 };
 
 const StandardValuesTable = () => {
-  let roll = D20.roll();
+  const roll = D20.roll();
   switch (roll) {
     case 1:
       return 'A good mystery is irresistible';
@@ -97,7 +97,7 @@ const StandardValuesTable = () => {
 };
 
 const VulcanValuesTable = (): string => {
-  let roll = D20.roll();
+  const roll = D20.roll();
   switch (roll) {
     case 1:
       return 'A logical mind is a focused mind';
@@ -144,7 +144,7 @@ const VulcanValuesTable = (): string => {
 };
 
 const KlingonValuesTable = (): string => {
-  let roll = D20.roll();
+  const roll = D20.roll();
   switch (roll) {
     case 1:
       return 'Warriors are judged by their deeds';
@@ -195,7 +195,7 @@ const speciesRandomValues: { [species: number]: () => string } = {
   [Species.Klingon]: KlingonValuesTable,
 };
 const ConnValuesTable = () => {
-  let roll = D20.roll() + D20.roll() + D20.roll();
+  const roll = D20.roll() + D20.roll() + D20.roll();
   switch (roll) {
     case 3:
       return 'In space, speed is life';
@@ -318,7 +318,7 @@ const ConnValuesTable = () => {
 };
 
 const EngineeringValuesTable = () => {
-  let roll = D20.roll() + D20.roll() + D20.roll();
+  const roll = D20.roll() + D20.roll() + D20.roll();
   switch (roll) {
     case 3:
       return 'A place for everything and everything in its place';
@@ -441,7 +441,7 @@ const EngineeringValuesTable = () => {
 };
 
 const ScienceValuesTable = () => {
-  let roll = D20.roll() + D20.roll() + D20.roll();
+  const roll = D20.roll() + D20.roll() + D20.roll();
   switch (roll) {
     case 3:
       return 'The universe is a cosmic laboratory';
@@ -564,7 +564,7 @@ const ScienceValuesTable = () => {
 };
 
 const MedicineValuesTable = () => {
-  let roll = D20.roll() + D20.roll() + D20.roll();
+  const roll = D20.roll() + D20.roll() + D20.roll();
   switch (roll) {
     case 3:
       return 'A good physician treats the disease; a great physician treats the patient';
@@ -687,7 +687,7 @@ const MedicineValuesTable = () => {
 };
 
 const SecurityValuesTable = () => {
-  let roll = D20.roll() + D20.roll() + D20.roll();
+  const roll = D20.roll() + D20.roll() + D20.roll();
   switch (roll) {
     case 3:
       return 'A good defense is the best offense';
@@ -810,7 +810,7 @@ const SecurityValuesTable = () => {
 };
 
 const CommandValuesTable = () => {
-  let roll = D20.roll() + D20.roll() + D20.roll();
+  const roll = D20.roll() + D20.roll() + D20.roll();
   switch (roll) {
     case 3:
       return "A captain's place is on the bridge";
@@ -942,7 +942,7 @@ const disciplineRandomValues: { [species: number]: () => string } = {
 };
 
 const GeneralValuesTable = () => {
-  let roll = D20.roll() + D20.roll() + D20.roll();
+  const roll = D20.roll() + D20.roll() + D20.roll();
   switch (roll) {
     case 3:
       return 'Infinite diversity in infinite combinations';

--- a/WebTools/src/starship/model/buildPoints.ts
+++ b/WebTools/src/starship/model/buildPoints.ts
@@ -10,19 +10,19 @@ export class BuildPoints {
     version: number,
   ) {
     if (buildType === ShipBuildType.Pod) {
-      let base = 16;
-      let improvement = Math.floor((serviceYear - 2200) / 25);
+      const base = 16;
+      const improvement = Math.floor((serviceYear - 2200) / 25);
       return base + improvement;
     } else if (buildType === ShipBuildType.Shuttlecraft) {
-      let base = 19;
-      let improvement = Math.floor((serviceYear - 2200) / 10);
+      const base = 19;
+      const improvement = Math.floor((serviceYear - 2200) / 10);
       return base + improvement;
     } else if (buildType === ShipBuildType.Runabout) {
-      let base = 29;
-      let improvement = Math.floor((serviceYear - 2200) / 10);
+      const base = 29;
+      const improvement = Math.floor((serviceYear - 2200) / 10);
       return base + improvement;
     } else {
-      let base = version === 1 ? (serviceYear > 2400 ? 60 : 40) : 40;
+      const base = version === 1 ? (serviceYear > 2400 ? 60 : 40) : 40;
       let improvement =
         version === 1
           ? serviceYear > 2400

--- a/WebTools/src/starship/model/randomStarshipCharacterTypes.ts
+++ b/WebTools/src/starship/model/randomStarshipCharacterTypes.ts
@@ -79,7 +79,7 @@ export class RandomStarshipCharacterTypes {
   }
 
   getType(type: RandomStarshipCharacterType) {
-    let types = this.types.filter((t) => t.type === type);
+    const types = this.types.filter((t) => t.type === type);
     return types.length === 1 ? types[0] : null;
   }
 }

--- a/WebTools/src/starship/model/serviceRecord.ts
+++ b/WebTools/src/starship/model/serviceRecord.ts
@@ -58,12 +58,12 @@ export class ServiceRecordModel {
   }
 
   get name() {
-    let key = makeKey('ServiceRecord.', ServiceRecord[this.type]);
+    const key = makeKey('ServiceRecord.', ServiceRecord[this.type]);
     return i18next.t(key);
   }
 
   get description() {
-    let key = makeKey(
+    const key = makeKey(
       'ServiceRecord.',
       ServiceRecord[this.type],
       '.description',
@@ -163,7 +163,7 @@ export class ServiceRecordList {
   }
 
   getByType(type: ServiceRecord) {
-    let result = this.records.filter((s) => s.type === type);
+    const result = this.records.filter((s) => s.type === type);
     return result.length > 0 ? result[0] : undefined;
   }
 }

--- a/WebTools/src/starship/model/starshipGenerator.ts
+++ b/WebTools/src/starship/model/starshipGenerator.ts
@@ -200,7 +200,7 @@ export const starshipGenerator = (config: IStarshipConfiguration) => {
     // While there remain elements to shuffle...
     while (currentIndex !== 0) {
       // Pick a remaining element...
-      let randomIndex = Math.floor(Math.random() * currentIndex);
+      const randomIndex = Math.floor(Math.random() * currentIndex);
       currentIndex--;
 
       // And swap it with the current element.
@@ -212,7 +212,7 @@ export const starshipGenerator = (config: IStarshipConfiguration) => {
     return array;
   };
 
-  let result = Starship.createStandardStarship(
+  const result = Starship.createStandardStarship(
     config.era,
     convertStarshipType(config.type),
     isSecondEdition() ? 2 : 1,
@@ -294,7 +294,7 @@ export const starshipGenerator = (config: IStarshipConfiguration) => {
           result.spaceframeModel.talents.map((t) => t.name).indexOf(t.name) < 0,
       );
     if (missionProfileTalents?.length) {
-      let talent =
+      const talent =
         missionProfileTalents[
           Math.floor(Math.random() * missionProfileTalents.length)
         ];
@@ -303,14 +303,14 @@ export const starshipGenerator = (config: IStarshipConfiguration) => {
   }
 
   if (result.spaceframeModel?.isMissionPodAvailable) {
-    let pods = MissionPodHelper.instance().getMissionPods(result);
+    const pods = MissionPodHelper.instance().getMissionPods(result);
     if (pods?.length) {
       result.missionPodModel = pods[Math.floor(Math.random() * pods.length)];
     }
   }
 
   for (let i = 0; i < result.numberOfRefits; i++) {
-    let systems = allSystems().filter((s) => result.getSystemValue(s) < 12);
+    const systems = allSystems().filter((s) => result.getSystemValue(s) < 12);
     result.refits.push(systems[Math.floor(Math.random() * systems.length)]);
   }
 
@@ -320,26 +320,26 @@ export const starshipGenerator = (config: IStarshipConfiguration) => {
       (result.type === CharacterType.Romulan ||
         (isKlingonWarriorType(result.type) && result.serviceYear > 2300))
     ) {
-      let talent = TalentsHelper.getTalent('Cloaking Device');
+      const talent = TalentsHelper.getTalent('Cloaking Device');
       result.additionalTalents.push(new SelectedTalent(talent.name));
     } else {
       const talents = TalentsHelper.getStarshipOrStationTalents(result);
       if (talents?.length) {
-        let model = talents[Math.floor(Math.random() * talents.length)];
-        let talent = new SelectedTalent(model.name);
+        const model = talents[Math.floor(Math.random() * talents.length)];
+        const talent = new SelectedTalent(model.name);
         if (
           talent.name === TALENT_NAME_DEDICATED_PERSONNEL ||
           talent.name === TALENT_NAME_EXPANSIVE_DEPARTMENT
         ) {
-          let departments = DepartmentsHelper.instance.getDepartments();
+          const departments = DepartmentsHelper.instance.getDepartments();
           talent.department =
             departments[Math.floor(Math.random() * departments.length)];
         } else if (talent.name === TALENT_NAME_REDUNDANT_SYSTEMS) {
-          let systems = allSystems();
+          const systems = allSystems();
           talent.system = systems[Math.floor(Math.random() * systems.length)];
         } else if (talent.name === TALENT_NAME_EXPANDED_MUNITIONS) {
         } else if (talent.name === TALENT_NAME_ADDITIONAL_PROPULSION_SYSTEM) {
-          let systems = PropulsionSystemModel.types;
+          const systems = PropulsionSystemModel.types;
           talent.selection =
             systems[Math.floor(Math.random() * systems.length)].type;
         }
@@ -351,7 +351,7 @@ export const starshipGenerator = (config: IStarshipConfiguration) => {
   if (result.version > 1) {
     if (result.type === CharacterType.Starfleet && D20.roll() > 12) {
       const records = ServiceRecordList.instance.records;
-      let record = records[Math.floor(Math.random() * records.length)];
+      const record = records[Math.floor(Math.random() * records.length)];
 
       if (
         record.type !== ServiceRecord.AgingRelic ||

--- a/WebTools/src/starship/model/starshipNameTable.ts
+++ b/WebTools/src/starship/model/starshipNameTable.ts
@@ -524,7 +524,7 @@ const chooseOptions = (
     type === RandomStarshipCharacterType.Klingon ||
     isKlingonWarriorType(spaceframeType)
   ) {
-    let result = [...klingonEnterpriseEraNames];
+    const result = [...klingonEnterpriseEraNames];
     switch (era) {
       case Era.NextGeneration:
         Array.prototype.push.apply(result, klingonTngEraNames);
@@ -533,13 +533,13 @@ const chooseOptions = (
     }
     return result;
   } else if (type === RandomStarshipCharacterType.Romulan) {
-    let result = [...starshipRomulanNames];
+    const result = [...starshipRomulanNames];
     return result;
   } else if (type === RandomStarshipCharacterType.Civilian) {
-    let result = [...starshipCivilianNames];
+    const result = [...starshipCivilianNames];
     return result;
   } else {
-    let result = [...starshipEnterpriseEraNames];
+    const result = [...starshipEnterpriseEraNames];
     switch (era) {
       case Era.OriginalSeries:
         Array.prototype.push.apply(result, starshipTosEraName);
@@ -565,8 +565,8 @@ export const StarshipRandomNameTable = (
   spaceframeType?: CharacterType,
   spaceframe?: Spaceframe,
 ) => {
-  let options = chooseOptions(era, type, spaceframeType, spaceframe);
-  let index = Math.floor(Math.random() * options.length);
+  const options = chooseOptions(era, type, spaceframeType, spaceframe);
+  const index = Math.floor(Math.random() * options.length);
 
   return options[index];
 };

--- a/WebTools/src/starship/page/extraStarshipTalentChoicesPage.tsx
+++ b/WebTools/src/starship/page/extraStarshipTalentChoicesPage.tsx
@@ -63,7 +63,7 @@ const ExtraStarshipTalentChoicesPage: React.FC<
     ) {
       Dialog.show(t('Common.error.department'));
     } else {
-      let step = workflow.peekNextStep();
+      const step = workflow.peekNextStep();
       store.dispatch(nextStarshipWorkflowStep());
       Navigation.navigateToPage(step.page);
     }
@@ -79,7 +79,7 @@ const ExtraStarshipTalentChoicesPage: React.FC<
             starship={starship}
             isChecked={(d) => selection.department === d}
             onSelectDepartment={(d) => {
-              let temp = selection?.copy();
+              const temp = selection?.copy();
               if (temp) {
                 temp.department = d;
               }
@@ -102,7 +102,7 @@ const ExtraStarshipTalentChoicesPage: React.FC<
             starship={starship}
             isChecked={(s) => selection.system === s}
             onSelectSystem={(s) => {
-              let temp = selection?.copy();
+              const temp = selection?.copy();
               if (temp) {
                 temp.system = s;
               }

--- a/WebTools/src/starship/page/finalStarshipDetailsPage.tsx
+++ b/WebTools/src/starship/page/finalStarshipDetailsPage.tsx
@@ -86,7 +86,7 @@ const FinalStarshipDetailsPage: React.FC<
       starship.serviceYear &&
       (starship.registry == null || starship.registry.length === 0)
     ) {
-      let registry = RegistryNumber.generate(
+      const registry = RegistryNumber.generate(
         starship.serviceYear,
         starship.type,
         starship.spaceframeModel,
@@ -150,7 +150,7 @@ const FinalStarshipDetailsPage: React.FC<
               store.dispatch(setStarshipTraits(ev.target.value))
             }
             onBlur={(ev) => {
-              let temp = ev.target.value.replace(/\n/g, ', ');
+              const temp = ev.target.value.replace(/\n/g, ', ');
               store.dispatch(setStarshipTraits(temp));
             }}
             value={starship.traits}

--- a/WebTools/src/starship/page/missionPodSelectionPage.tsx
+++ b/WebTools/src/starship/page/missionPodSelectionPage.tsx
@@ -56,7 +56,7 @@ class MissionPodSelectionPage extends React.Component<
     } else if (this.props.starship.hasUnreplacedMissionPodOverlaps()) {
       Dialog.show(t('MissionPodReplacement.errorMissing'));
     } else {
-      let step = this.props.workflow.peekNextStep();
+      const step = this.props.workflow.peekNextStep();
       store.dispatch(nextStarshipWorkflowStep());
       Navigation.navigateToPage(step.page);
     }

--- a/WebTools/src/starship/page/missionProfileTalentSelectionPage.tsx
+++ b/WebTools/src/starship/page/missionProfileTalentSelectionPage.tsx
@@ -46,9 +46,9 @@ const MissionProfileTalentSelectionPage: React.FC<
   };
 
   const getTalents = () => {
-    let talents: RankedTalent[] = [];
+    const talents: RankedTalent[] = [];
     starship?.missionProfileStep?.type?.talents?.forEach((t) => {
-      let talent =
+      const talent =
         t instanceof SelectedTalent
           ? (t as SelectedTalent).talentModel
           : (t as TalentModel);
@@ -78,7 +78,7 @@ const MissionProfileTalentSelectionPage: React.FC<
     } else if (starship.spaceframeModel?.isMissionPodAvailable) {
       Navigation.navigateToPage(PageIdentity.MissionPodSelection);
     } else {
-      let step = workflow.peekNextStep();
+      const step = workflow.peekNextStep();
       store.dispatch(nextStarshipWorkflowStep());
       Navigation.navigateToPage(step.page);
     }

--- a/WebTools/src/starship/page/randomStarshipPage.tsx
+++ b/WebTools/src/starship/page/randomStarshipPage.tsx
@@ -31,7 +31,7 @@ const RandomStarshipPage: React.FC<IRandomStarshipProperties> = ({ era }) => {
   const [campaignYear, setCampaignYear] = useState(eraDefaultYear(era));
 
   const createStarship = () => {
-    let starship = starshipGenerator({
+    const starship = starshipGenerator({
       era: era,
       campaignYear: campaignYear,
       type: type,

--- a/WebTools/src/starship/page/selectStarshipToolPage.tsx
+++ b/WebTools/src/starship/page/selectStarshipToolPage.tsx
@@ -75,8 +75,8 @@ class SelectStarshipToolPage extends React.Component<WithTranslation, {}> {
   }
 
   startSimplifiedWorkflow() {
-    let workflow = ShipBuildWorkflow.createSimpleBuildWorkflow();
-    let stats = new SimpleStats();
+    const workflow = ShipBuildWorkflow.createSimpleBuildWorkflow();
+    const stats = new SimpleStats();
     stats.systems = [7, 7, 7, 7, 7, 7];
     stats.scale = 3;
     store.dispatch(
@@ -90,7 +90,7 @@ class SelectStarshipToolPage extends React.Component<WithTranslation, {}> {
         isSecondEdition() ? 2 : 1,
       ),
     );
-    let page = workflow.currentStep().page;
+    const page = workflow.currentStep().page;
     this.goToPage(page);
   }
 

--- a/WebTools/src/starship/page/serviceRecordPage.tsx
+++ b/WebTools/src/starship/page/serviceRecordPage.tsx
@@ -143,7 +143,7 @@ const ServiceRecordPage: React.FC<IServiceRecordPageProperties> = ({
     );
   };
 
-  let serviceRecords = ServiceRecordList.instance.records
+  const serviceRecords = ServiceRecordList.instance.records
     .filter((r) => hasSource(r.source))
     .filter((r) => r.starshipType == null || r.starshipType === starship.type);
   serviceRecords.sort((r1, r2) => {

--- a/WebTools/src/starship/page/simpleStarshipPage.tsx
+++ b/WebTools/src/starship/page/simpleStarshipPage.tsx
@@ -344,12 +344,12 @@ export class BaseSimpleStarshipPage extends React.Component<
   }
 
   getSystem(system: System) {
-    let result = this.props.starship.getSystemValue(system);
+    const result = this.props.starship.getSystemValue(system);
     return result == null ? 0 : result;
   }
 
   getDepartment(department: Department) {
-    let result = this.props.starship.departments[department];
+    const result = this.props.starship.departments[department];
     return result == null ? 0 : result;
   }
 
@@ -373,7 +373,7 @@ export class BaseSimpleStarshipPage extends React.Component<
     if (!this.props.starship.className) {
       Dialog.show('Please provide a name for this class of ship.');
     } else {
-      let step = this.props.workflow.peekNextStep();
+      const step = this.props.workflow.peekNextStep();
       store.dispatch(nextStarshipWorkflowStep());
       Navigation.navigateToPage(step.page);
     }

--- a/WebTools/src/starship/page/smallCraftStatsPage.tsx
+++ b/WebTools/src/starship/page/smallCraftStatsPage.tsx
@@ -107,7 +107,7 @@ class SmallCraftStatsPage extends BaseSimpleStarshipPage {
   }
 
   getAppearanceOptions() {
-    let result = [new DropDownElement('', '')];
+    const result = [new DropDownElement('', '')];
     result.push(
       ...SpaceframeAppearanceModel.getAllAppearanceModels(
         this.props.starship.type,
@@ -155,7 +155,7 @@ class SmallCraftStatsPage extends BaseSimpleStarshipPage {
     } else if (this.sumTotalDepartments() < this.getDepartmentPoints()) {
       Dialog.show('You have not distributed all the Department Points');
     } else {
-      let { starship } = this.props;
+      const { starship } = this.props;
       store.dispatch(nextStarshipWorkflowStep());
       if (starship.buildType === ShipBuildType.Pod) {
         Navigation.navigateToPage(PageIdentity.StarshipWeaponsSelection);

--- a/WebTools/src/starship/page/spaceframeSelectionPage.tsx
+++ b/WebTools/src/starship/page/spaceframeSelectionPage.tsx
@@ -52,8 +52,8 @@ const SpaceframeSelectionPage: React.FC<ISpaceframeSelectionPageProperties> = ({
       // no change
     } else if (newTab === SpaceframeTab.Custom) {
       if (!starship.spaceframeModel?.isCustom) {
-        let scale = 3;
-        let systems = PointAllocator.allocatePointsEvenly(
+        const scale = 3;
+        const systems = PointAllocator.allocatePointsEvenly(
           BuildPoints.systemPointsForType(
             ShipBuildType.Starship,
             starship.serviceYear,
@@ -62,10 +62,10 @@ const SpaceframeSelectionPage: React.FC<ISpaceframeSelectionPageProperties> = ({
             starship.version,
           ),
         );
-        let departments = PointAllocator.allocatePointsEvenly(
+        const departments = PointAllocator.allocatePointsEvenly(
           BuildPoints.departmentPointsForType(ShipBuildType.Starship),
         );
-        let spaceframe = SpaceframeModel.createCustomSpaceframe(
+        const spaceframe = SpaceframeModel.createCustomSpaceframe(
           starship?.type,
           starship?.serviceYear,
           systems,
@@ -110,7 +110,7 @@ const SpaceframeSelectionPage: React.FC<ISpaceframeSelectionPageProperties> = ({
       ) {
         Navigation.navigateToPage(PageIdentity.ExtraStarshipTalentChoice);
       } else {
-        let step = workflow.peekNextStep();
+        const step = workflow.peekNextStep();
         store.dispatch(nextStarshipWorkflowStep());
         Navigation.navigateToPage(step.page);
       }

--- a/WebTools/src/starship/page/starshipTalentsPage.tsx
+++ b/WebTools/src/starship/page/starshipTalentsPage.tsx
@@ -55,7 +55,7 @@ const StarshipTalentsPage: React.FC<ISimpleStarshipPageProperties> = ({
     } else if (message) {
       Dialog.show(message);
     } else {
-      let step = workflow.peekNextStep();
+      const step = workflow.peekNextStep();
       store.dispatch(nextStarshipWorkflowStep());
       Navigation.navigateToPage(step.page);
     }
@@ -72,7 +72,7 @@ const StarshipTalentsPage: React.FC<ISimpleStarshipPageProperties> = ({
       } else {
         let count = 0;
         temp = temp.filter((t) => {
-          let result =
+          const result =
             t.talent !== rankedTalent.name || count + 1 !== rankedTalent.rank;
           if (t.name === rankedTalent.name) {
             count++;
@@ -114,26 +114,26 @@ const StarshipTalentsPage: React.FC<ISimpleStarshipPageProperties> = ({
   };
 
   const talentList = () => {
-    let talents = starship
+    const talents = starship
       ? TalentsHelper.getStarshipOrStationTalents(starship, true)
       : [];
 
-    let rankedTalents = [];
+    const rankedTalents = [];
     talents
       .filter((t) => !t.isSpecialRule(starship.version))
       .forEach((t) => {
         if (t.maxRank > 1 || isMultiSelectionTalent(t)) {
-          let initialCount =
+          const initialCount =
             starship.talentsWithoutAdditional?.filter(
               (s) => s.talent === t.name,
             )?.length ?? 0;
-          let count =
+          const count =
             starship.talents?.filter((s) => s.talent === t.name)?.length ?? 0;
           for (let i = initialCount; i < count + 1; i++) {
             rankedTalents.push(new RankedTalent(t, i + 1));
           }
         } else {
-          let count =
+          const count =
             starship.talentsWithoutAdditional?.filter(
               (s) => s.talent === t.name,
             )?.length ?? 0;

--- a/WebTools/src/starship/page/starshipTypeSelectionPage.tsx
+++ b/WebTools/src/starship/page/starshipTypeSelectionPage.tsx
@@ -48,7 +48,7 @@ class StarshipTypeSelectionPage extends React.Component<
 
   render() {
     const { t } = this.props;
-    let typeSelection = hasSource(Source.KlingonCore) ? (
+    const typeSelection = hasSource(Source.KlingonCore) ? (
       <div className="col-lg-6">
         <div className="my-3">
           <Header level={2}>{t('StarshipTypeSelection.shipPolity')}</Header>
@@ -68,7 +68,7 @@ class StarshipTypeSelectionPage extends React.Component<
       </div>
     ) : undefined;
 
-    let buildTypeSelection = (
+    const buildTypeSelection = (
       <div className="my-3">
         <Header level={2}>{t('StarshipTypeSelection.shipBuildType')}</Header>
         <p>{t('StarshipTypeSelection.whatShipBuildType')}</p>
@@ -134,10 +134,10 @@ class StarshipTypeSelectionPage extends React.Component<
       this.state.buildType != null &&
       this.state.buildType.type !== ShipBuildType.Starship
     ) {
-      let workflow = ShipBuildWorkflow.createSmallCraftBuildWorkflow(
+      const workflow = ShipBuildWorkflow.createSmallCraftBuildWorkflow(
         this.state.buildType.type,
       );
-      let stats = new SimpleStats();
+      const stats = new SimpleStats();
       stats.scale =
         this.state.buildType.type === ShipBuildType.Runabout ? 2 : 1;
       stats.systems = PointAllocator.allocatePointsEvenly(
@@ -165,7 +165,7 @@ class StarshipTypeSelectionPage extends React.Component<
       );
       Navigation.navigateToPage(PageIdentity.SmallCraftStats);
     } else if (this.state.type != null) {
-      let workflow = ShipBuildWorkflow.createStarshipBuildWorkflow(
+      const workflow = ShipBuildWorkflow.createStarshipBuildWorkflow(
         isSecondEdition() ? 2 : 1,
       );
       store.dispatch(

--- a/WebTools/src/starship/view/addWeaponView.tsx
+++ b/WebTools/src/starship/view/addWeaponView.tsx
@@ -160,7 +160,7 @@ const AddWeaponView: React.FC<IAddWeaponViewProperties> = ({
 
   const addWeaponFunction = () => {
     if (weaponType.type === WeaponType.ENERGY) {
-      let weapon = Weapon.createStarshipWeapon(
+      const weapon = Weapon.createStarshipWeapon(
         '',
         weaponType.type,
         loadType,
@@ -168,7 +168,7 @@ const AddWeaponView: React.FC<IAddWeaponViewProperties> = ({
       );
       addWeapon(weapon);
     } else {
-      let weapon = Weapon.createStarshipWeapon('', weaponType.type, loadType);
+      const weapon = Weapon.createStarshipWeapon('', weaponType.type, loadType);
       addWeapon(weapon);
     }
     onClose();

--- a/WebTools/src/starship/view/customSpaceframeView.tsx
+++ b/WebTools/src/starship/view/customSpaceframeView.tsx
@@ -39,17 +39,17 @@ const CustomSpaceframeView: React.FC<IStarshipProperties> = ({ starship }) => {
   const { t } = useTranslation();
 
   const setScale = (delta: number) => {
-    let newScale = starship.scale + delta;
-    let systems = [...starship.systems];
-    let sum = starship.spaceframeModel?.sumSystemPoints ?? 0;
-    let newTotalPoints = BuildPoints.systemPointsForType(
+    const newScale = starship.scale + delta;
+    const systems = [...starship.systems];
+    const sum = starship.spaceframeModel?.sumSystemPoints ?? 0;
+    const newTotalPoints = BuildPoints.systemPointsForType(
       starship.buildType,
       starship.spaceframeModel.serviceYear,
       starship.type,
       newScale,
       starship.version,
     );
-    let systemDelta =
+    const systemDelta =
       newTotalPoints -
       BuildPoints.systemPointsForType(
         starship.buildType,
@@ -86,7 +86,7 @@ const CustomSpaceframeView: React.FC<IStarshipProperties> = ({ starship }) => {
   };
 
   const getCurrentSystemValuesSortedMaxToMin = () => {
-    let result = [];
+    const result = [];
     allSystems().forEach((s) =>
       result.push(new SystemValue(s, starship.systems[s])),
     );
@@ -100,16 +100,16 @@ const CustomSpaceframeView: React.FC<IStarshipProperties> = ({ starship }) => {
   };
 
   const setServiceYear = (serviceYear: string) => {
-    let year = parseInt(serviceYear);
-    let systems = getCurrentSystemValuesSortedMaxToMin();
-    let newTotalPoints = BuildPoints.systemPointsForType(
+    const year = parseInt(serviceYear);
+    const systems = getCurrentSystemValuesSortedMaxToMin();
+    const newTotalPoints = BuildPoints.systemPointsForType(
       starship.buildType,
       year,
       starship.type,
       starship.scale,
       starship.version,
     );
-    let systemDelta =
+    const systemDelta =
       newTotalPoints -
       BuildPoints.systemPointsForType(
         starship.buildType,
@@ -122,7 +122,7 @@ const CustomSpaceframeView: React.FC<IStarshipProperties> = ({ starship }) => {
     store.dispatch(changeStarshipSpaceframeServiceYear(year));
 
     if (systemDelta !== 0) {
-      let deltas = [0, 0, 0, 0, 0, 0];
+      const deltas = [0, 0, 0, 0, 0, 0];
       let sumOfDeltas = 0;
       for (let i = 0; i < 5; i++) {
         deltas[i] = systems[5].value - systems[i].value;
@@ -130,7 +130,7 @@ const CustomSpaceframeView: React.FC<IStarshipProperties> = ({ starship }) => {
       }
 
       if (systemDelta !== sumOfDeltas) {
-        let distribution = PointAllocator.allocatePointsEvenly(
+        const distribution = PointAllocator.allocatePointsEvenly(
           systemDelta - sumOfDeltas,
         );
         for (let i = 0; i < distribution.length; i++) {
@@ -139,14 +139,14 @@ const CustomSpaceframeView: React.FC<IStarshipProperties> = ({ starship }) => {
       }
 
       for (let i = 0; i < deltas.length; i++) {
-        let system = systems[i].system;
+        const system = systems[i].system;
         store.dispatch(changeStarshipSpaceframeSystem(deltas[i], system));
       }
     }
   };
 
   const getSystem = (system: System) => {
-    let result = starship.getSystemValue(system);
+    const result = starship.getSystemValue(system);
     return result == null ? 0 : result;
   };
 
@@ -174,7 +174,7 @@ const CustomSpaceframeView: React.FC<IStarshipProperties> = ({ starship }) => {
   };
 
   const getDepartment = (department: Department) => {
-    let result = starship.departments[department];
+    const result = starship.departments[department];
     return result == null ? 0 : result;
   };
 
@@ -201,7 +201,7 @@ const CustomSpaceframeView: React.FC<IStarshipProperties> = ({ starship }) => {
   };
 
   const getAppearanceOptions = () => {
-    let result = [new DropDownElement('', '')];
+    const result = [new DropDownElement('', '')];
     result.push(
       ...SpaceframeAppearanceModel.getAllAppearanceModels(
         starship.type,

--- a/WebTools/src/starship/view/missionPodReplacementSelection.tsx
+++ b/WebTools/src/starship/view/missionPodReplacementSelection.tsx
@@ -24,7 +24,7 @@ const MissionPodReplacementSelection: React.FC<
   }
 
   const setReplacement = (podIndex: number, talent?: SelectedTalent) => {
-    let replacements = [...(starship.missionPodReplacements ?? [])];
+    const replacements = [...(starship.missionPodReplacements ?? [])];
     while (replacements.length <= podIndex) {
       replacements.push(undefined);
     }

--- a/WebTools/src/starship/view/missionProfileSelection.tsx
+++ b/WebTools/src/starship/view/missionProfileSelection.tsx
@@ -29,7 +29,7 @@ class MissionProfileSelection extends React.Component<
       .getMissionProfiles(this.props.starship)
       .map((m, i) => {
         const talents = m.talents.map((talent, ti) => {
-          let t =
+          const t =
             talent instanceof SelectedTalent
               ? (talent as SelectedTalent).talentModel
               : (talent as TalentModel);

--- a/WebTools/src/starship/view/serviceYearView.tsx
+++ b/WebTools/src/starship/view/serviceYearView.tsx
@@ -23,7 +23,7 @@ export const ServiceYearSelector: React.FC<IServiceYearProperties> = ({
           type="number"
           defaultValue={campaignYear.toString()}
           onChange={(e) => {
-            let value = e.target.value;
+            const value = e.target.value;
             onChange(parseInt(value));
           }}
         />

--- a/WebTools/src/starship/view/spaceframeSelection.tsx
+++ b/WebTools/src/starship/view/spaceframeSelection.tsx
@@ -45,7 +45,7 @@ const SpaceframeSelection: React.FC<ISpaceframeSelectionProperties> = ({
     }
   };
 
-  let overrideCheckbox = (
+  const overrideCheckbox = (
     <CheckBox
       isChecked={allowAllFrames}
       text={t('SpaceframeSelectionPage.ignoreEndOfService')}
@@ -54,7 +54,7 @@ const SpaceframeSelection: React.FC<ISpaceframeSelectionProperties> = ({
     />
   );
 
-  let spaceframes = SpaceframeHelper.instance().getSpaceframes(
+  const spaceframes = SpaceframeHelper.instance().getSpaceframes(
     starship,
     allowAllFrames,
   );
@@ -68,7 +68,7 @@ const SpaceframeSelection: React.FC<ISpaceframeSelectionProperties> = ({
 
   const chooseDefaultVariant = (spaceframe: Spaceframe) => {
     if (SpaceframeVariantModel.hasVariants(spaceframe)) {
-      let variants = SpaceframeVariantModel.variantsBySpaceframe(spaceframe);
+      const variants = SpaceframeVariantModel.variantsBySpaceframe(spaceframe);
       return variants?.length ? variants[0]?.id : undefined;
     } else {
       return undefined;

--- a/WebTools/src/starship/view/starshipStats.tsx
+++ b/WebTools/src/starship/view/starshipStats.tsx
@@ -23,7 +23,7 @@ class StarshipStats extends React.Component<IStarshipStatsProperties, {}> {
   }
 
   renderAsSpaceframe() {
-    let model = this.props.model as SpaceframeModel;
+    const model = this.props.model as SpaceframeModel;
     return (
       <div className="stats-block">
         <div className="stats-row">
@@ -117,7 +117,7 @@ class StarshipStats extends React.Component<IStarshipStatsProperties, {}> {
   }
 
   renderAsMissionPod() {
-    let model = this.props.model as MissionPodModel;
+    const model = this.props.model as MissionPodModel;
     return (
       <div className="stats-block">
         <div className="stats-row">
@@ -204,7 +204,7 @@ class StarshipStats extends React.Component<IStarshipStatsProperties, {}> {
     );
   }
   renderAsMissionProfile() {
-    let model = this.props.model as MissionProfileModel;
+    const model = this.props.model as MissionProfileModel;
     return (
       <div className="stats-block">
         <div className="stats-row pt-2">

--- a/WebTools/src/state/characterActions.ts
+++ b/WebTools/src/state/characterActions.ts
@@ -111,7 +111,7 @@ export enum StepContext {
 }
 
 export function setCharacter(character: Character, replacementHash?: number) {
-  let payload = { character: character, replacementHash: replacementHash };
+  const payload = { character: character, replacementHash: replacementHash };
   return {
     type: SET_CHARACTER,
     payload: payload,
@@ -119,7 +119,7 @@ export function setCharacter(character: Character, replacementHash?: number) {
 }
 
 export function addCharacterBorgImplant(type: BorgImplantType) {
-  let payload = { type: type };
+  const payload = { type: type };
   return {
     type: ADD_CHARACTER_BORG_IMPLANT,
     payload: payload,
@@ -127,7 +127,7 @@ export function addCharacterBorgImplant(type: BorgImplantType) {
 }
 
 export function addCharacterBorgImplantSpeciesOption(type: BorgImplantType) {
-  let payload = { type: type };
+  const payload = { type: type };
   return {
     type: ADD_CHARACTER_BORG_IMPLANT_SPECIES_OPTION,
     payload: payload,
@@ -135,7 +135,7 @@ export function addCharacterBorgImplantSpeciesOption(type: BorgImplantType) {
 }
 
 export function addCharacterUntappedPotentialAttribute(attribute: Attribute) {
-  let payload = { attribute: attribute };
+  const payload = { attribute: attribute };
   return {
     type: ADD_CHARACTER_UNTAPPED_POTENTIAL_ATTRIBUTE,
     payload: payload,
@@ -143,7 +143,7 @@ export function addCharacterUntappedPotentialAttribute(attribute: Attribute) {
 }
 
 export function removeCharacterBorgImplant(type: BorgImplantType) {
-  let payload = { type: type };
+  const payload = { type: type };
   return {
     type: REMOVE_CHARACTER_BORG_IMPLANT,
     payload: payload,
@@ -151,7 +151,7 @@ export function removeCharacterBorgImplant(type: BorgImplantType) {
 }
 
 export function removeCharacterBorgImplantSpeciesOption(type: BorgImplantType) {
-  let payload = { type: type };
+  const payload = { type: type };
   return {
     type: REMOVE_CHARACTER_BORG_IMPLANT_SPECIES_OPTION,
     payload: payload,
@@ -166,7 +166,7 @@ export function setCharacterSpecies(
   customSpeciesName?: string,
   decrementAttributes: Attribute[] = [],
 ) {
-  let payload = {
+  const payload = {
     species: species,
     attributes: attributes,
     mixedSpecies: mixedSpecies,
@@ -174,7 +174,7 @@ export function setCharacterSpecies(
     customSpeciesName: customSpeciesName,
     decrementAttributes: decrementAttributes,
   };
-  let ability = SpeciesAbilityList.instance.getBySpecies(species);
+  const ability = SpeciesAbilityList.instance.getBySpecies(species);
   if (ability && (ability.source == null || hasSource(ability.source))) {
     payload['ability'] = ability;
   }
@@ -185,7 +185,7 @@ export function setCharacterSpecies(
 }
 
 export function setSupportingCharacterSupervisory(supervisory: boolean) {
-  let payload = { supervisory: supervisory };
+  const payload = { supervisory: supervisory };
   return {
     type: SET_SUPPORTING_CHARACTER_SUPERVISORY,
     payload: payload,
@@ -193,7 +193,7 @@ export function setSupportingCharacterSupervisory(supervisory: boolean) {
 }
 
 export function setSupportingCharacterDepartments(disciplines: Department[]) {
-  let payload = { disciplines: disciplines };
+  const payload = { disciplines: disciplines };
   return {
     type: SET_SUPPORTING_CHARACTER_DISCIPLINES,
     payload: payload,
@@ -201,7 +201,7 @@ export function setSupportingCharacterDepartments(disciplines: Department[]) {
 }
 
 export function setNpcCharacterDepartments(departments: number[]) {
-  let payload = { departments: departments };
+  const payload = { departments: departments };
   return {
     type: SET_NPC_CHARACTER_DEPARTMENTS,
     payload: payload,
@@ -209,7 +209,7 @@ export function setNpcCharacterDepartments(departments: number[]) {
 }
 
 export function setNpcCharacterAttributes(attributes: number[]) {
-  let payload = { attributes: attributes };
+  const payload = { attributes: attributes };
   return {
     type: SET_NPC_CHARACTER_ATTRIBUTES,
     payload: payload,
@@ -217,7 +217,7 @@ export function setNpcCharacterAttributes(attributes: number[]) {
 }
 
 export function setNpcCharacterTalents(talents: SelectedTalent[]) {
-  let payload = { talents: talents };
+  const payload = { talents: talents };
   return {
     type: SET_NPC_CHARACTER_TALENTS,
     payload: payload,
@@ -227,7 +227,7 @@ export function setNpcCharacterTalents(talents: SelectedTalent[]) {
 export function addNpcCharacterEquipment(
   equipment: EquipmentType | EquipmentModel,
 ) {
-  let payload = { equipment: equipment };
+  const payload = { equipment: equipment };
   return {
     type: ADD_NPC_CHARACTER_EQUIPMENT,
     payload: payload,
@@ -235,7 +235,7 @@ export function addNpcCharacterEquipment(
 }
 
 export function addNpcCharacterWeapon(weapon: PersonalWeaponType) {
-  let payload = { weapon: weapon };
+  const payload = { weapon: weapon };
   return {
     type: ADD_NPC_CHARACTER_WEAPON,
     payload: payload,
@@ -245,7 +245,7 @@ export function addNpcCharacterWeapon(weapon: PersonalWeaponType) {
 export function removeNpcCharacterEquipment(
   equipment: EquipmentType | EquipmentModel,
 ) {
-  let payload = { equipment: equipment };
+  const payload = { equipment: equipment };
   return {
     type: REMOVE_NPC_CHARACTER_EQUIPMENT,
     payload: payload,
@@ -253,7 +253,7 @@ export function removeNpcCharacterEquipment(
 }
 
 export function removeNpcCharacterWeapon(weapon: PersonalWeaponType) {
-  let payload = { weapon: weapon };
+  const payload = { weapon: weapon };
   return {
     type: REMOVE_NPC_CHARACTER_WEAPON,
     payload: payload,
@@ -261,7 +261,7 @@ export function removeNpcCharacterWeapon(weapon: PersonalWeaponType) {
 }
 
 export function setSupportingCharacterAttributes(attributes: Attribute[]) {
-  let payload = { attributes: attributes };
+  const payload = { attributes: attributes };
   return {
     type: SET_SUPPORTING_CHARACTER_ATTRIBUTES,
     payload: payload,
@@ -272,7 +272,7 @@ export function setCharacterEnvironment(
   environment: Environment,
   otherSpecies?: Species,
 ) {
-  let payload = { environment: environment, otherSpecies: otherSpecies };
+  const payload = { environment: environment, otherSpecies: otherSpecies };
   return {
     type: SET_CHARACTER_ENVIRONMENT,
     payload: payload,
@@ -280,7 +280,7 @@ export function setCharacterEnvironment(
 }
 
 export function setCharacterEducation(track: Track, enlisted: boolean = false) {
-  let payload = { track: track, enlisted: enlisted };
+  const payload = { track: track, enlisted: enlisted };
   return {
     type: SET_CHARACTER_EDUCATION,
     payload: payload,
@@ -299,7 +299,7 @@ export function addCharacterCareerEvent(
   attribute?: Attribute,
   discipline?: Department,
 ) {
-  let payload = {
+  const payload = {
     eventId: eventId,
     attribute: attribute,
     discipline: discipline,
@@ -315,7 +315,7 @@ export function setCharacterEarlyOutlook(
   earlyOutlook: EarlyOutlookModel,
   accepted: boolean = true,
 ) {
-  let payload = { earlyOutlook: earlyOutlook, accepted: accepted };
+  const payload = { earlyOutlook: earlyOutlook, accepted: accepted };
   return {
     type: SET_CHARACTER_EARLY_OUTLOOK,
     payload: payload,
@@ -327,7 +327,7 @@ export function setCharacterFocus(
   context: StepContext,
   index: number = 0,
 ) {
-  let payload = { focus: focus, context: context, index: index };
+  const payload = { focus: focus, context: context, index: index };
   return {
     type: SET_CHARACTER_FOCUS,
     payload: payload,
@@ -339,7 +339,7 @@ export function addCharacterTalentFocus(
   talent: string,
   index: number = 0,
 ) {
-  let payload = { focus: focus, talent: talent, index: index };
+  const payload = { focus: focus, talent: talent, index: index };
   return {
     type: ADD_CHARACTER_TALENT_FOCUS,
     payload: payload,
@@ -350,7 +350,7 @@ export function setCharacterSpeciesAbilityFocus(
   focus: string,
   index: number = 0,
 ) {
-  let payload = { focus: focus, index: index };
+  const payload = { focus: focus, index: index };
   return {
     type: ADD_CHARACTER_SPECIES_ABILITY_FOCUS,
     payload: payload,
@@ -360,7 +360,7 @@ export function setCharacterSpeciesAbilityFocus(
 export function setCharacterSpeciesAbilityChoice(
   choice?: SpeciesAbilityChoice,
 ) {
-  let payload = { choice: choice };
+  const payload = { choice: choice };
   return {
     type: SET_CHARACTER_SPECIES_ABILITY_CHOICE,
     payload: payload,
@@ -368,7 +368,7 @@ export function setCharacterSpeciesAbilityChoice(
 }
 
 export function addCharacterLogEntry(logEntry: LogEntry) {
-  let payload = { logEntry: logEntry };
+  const payload = { logEntry: logEntry };
   return {
     type: ADD_CHARACTER_LOG_ENTRY,
     payload: payload,
@@ -379,9 +379,9 @@ export function addCharacterTalentValue(
   value: string,
   talent: string | ITalent,
 ) {
-  let talentName =
+  const talentName =
     typeof talent === 'string' ? (talent as string) : (talent as ITalent).name;
-  let payload = { value: value, talent: talentName };
+  const payload = { value: value, talent: talentName };
   return {
     type: ADD_CHARACTER_TALENT_VALUE,
     payload: payload,
@@ -392,7 +392,7 @@ export function addCharacterTalent(
   talent: ITalent | SelectedTalent,
   context: StepContext,
 ) {
-  let payload = { talent: talent, context: context };
+  const payload = { talent: talent, context: context };
   return {
     type: ADD_CHARACTER_TALENT,
     payload: payload,
@@ -400,7 +400,7 @@ export function addCharacterTalent(
 }
 
 export function setCharacterValue(value: string, context: StepContext) {
-  let payload = { value: value, context: context };
+  const payload = { value: value, context: context };
   return {
     type: SET_CHARACTER_VALUE,
     payload: payload,
@@ -411,7 +411,7 @@ export function updateCharacterGeneralEditValueChange(
   oldValue: ValueAssembly,
   newValue: string,
 ) {
-  let payload = { oldValue: oldValue, newValue: newValue };
+  const payload = { oldValue: oldValue, newValue: newValue };
   return {
     type: UPDATE_CHARACTER_GENERAL_EDIT_VALUE,
     payload: payload,
@@ -422,7 +422,7 @@ export function updateCharacterGeneralEditFocusChange(
   oldValue: FocusAssembly,
   newValue: string,
 ) {
-  let payload = { oldValue: oldValue, newValue: newValue };
+  const payload = { oldValue: oldValue, newValue: newValue };
   return {
     type: UPDATE_CHARACTER_GENERAL_EDIT_FOCUS,
     payload: payload,
@@ -433,7 +433,7 @@ export function updateCharacterGeneralEditTalentChange(
   oldValue: TalentAssembly,
   newValue: SelectedTalent,
 ) {
-  let payload = { oldValue: oldValue, newValue: newValue };
+  const payload = { oldValue: oldValue, newValue: newValue };
   return {
     type: UPDATE_CHARACTER_GENERAL_EDIT_TALENT,
     payload: payload,
@@ -441,8 +441,8 @@ export function updateCharacterGeneralEditTalentChange(
 }
 
 export function updateCharacterGeneralEditSpeciesAbility(species: Species) {
-  let payload = {};
-  let ability = SpeciesAbilityList.instance.getBySpecies(species);
+  const payload = {};
+  const ability = SpeciesAbilityList.instance.getBySpecies(species);
   if (ability && (ability.source == null || hasSource(ability.source))) {
     payload['ability'] = ability;
   }
@@ -454,7 +454,7 @@ export function updateCharacterGeneralEditSpeciesAbility(species: Species) {
 }
 
 export function addNpcCharacterValue(value: string, index: number) {
-  let payload = { value: value, index: index };
+  const payload = { value: value, index: index };
   return {
     type: ADD_NPC_CHARACTER_VALUE,
     payload: payload,
@@ -462,7 +462,7 @@ export function addNpcCharacterValue(value: string, index: number) {
 }
 
 export function setCharacterName(name: string) {
-  let payload = { name: name };
+  const payload = { name: name };
   return {
     type: SET_CHARACTER_NAME,
     payload: payload,
@@ -470,7 +470,7 @@ export function setCharacterName(name: string) {
 }
 
 export function setCharacterPastime(pastime: string) {
-  let payload = { pastime: pastime };
+  const payload = { pastime: pastime };
   return {
     type: SET_CHARACTER_PASTIME,
     payload: payload,
@@ -478,7 +478,7 @@ export function setCharacterPastime(pastime: string) {
 }
 
 export function setCharacterAge(age: Age) {
-  let payload = { age: age };
+  const payload = { age: age };
   return {
     type: SET_CHARACTER_AGE,
     payload: payload,
@@ -486,7 +486,7 @@ export function setCharacterAge(age: Age) {
 }
 
 export function setCharacterLineage(lineage: string) {
-  let payload = { lineage: lineage };
+  const payload = { lineage: lineage };
   return {
     type: SET_CHARACTER_LINEAGE,
     payload: payload,
@@ -494,7 +494,7 @@ export function setCharacterLineage(lineage: string) {
 }
 
 export function setCharacterHouse(house: string) {
-  let payload = { house: house };
+  const payload = { house: house };
   return {
     type: SET_CHARACTER_HOUSE,
     payload: payload,
@@ -505,7 +505,7 @@ export function setCharacterCareerEventTrait(
   trait: string,
   context: StepContext,
 ) {
-  let payload = { trait: trait, context: context };
+  const payload = { trait: trait, context: context };
   return {
     type: SET_CHARACTER_CAREER_EVENT_TRAIT,
     payload: payload,
@@ -513,7 +513,7 @@ export function setCharacterCareerEventTrait(
 }
 
 export function setCharacterAdditionalTraits(traits: string) {
-  let payload = { traits: traits };
+  const payload = { traits: traits };
   return {
     type: SET_CHARACTER_ADDITIONAL_TRAITS,
     payload: payload,
@@ -521,7 +521,7 @@ export function setCharacterAdditionalTraits(traits: string) {
 }
 
 export function setCharacterRank(name: string, rank?: Rank) {
-  let payload = { name: name, rank: rank };
+  const payload = { name: name, rank: rank };
   return {
     type: SET_CHARACTER_RANK,
     payload: payload,
@@ -532,7 +532,7 @@ export function setCharacterAssignment(
   role?: string | Role,
   secondaryRole?: Role,
 ) {
-  let payload = { role: role, secondaryRole: secondaryRole };
+  const payload = { role: role, secondaryRole: secondaryRole };
   return {
     type: SET_CHARACTER_ROLE,
     payload: payload,
@@ -540,7 +540,7 @@ export function setCharacterAssignment(
 }
 
 export function setCharacterAssignedShip(assignedShip: string) {
-  let payload = { assignedShip: assignedShip };
+  const payload = { assignedShip: assignedShip };
   return {
     type: SET_CHARACTER_ASSIGNED_SHIP,
     payload: payload,
@@ -548,7 +548,7 @@ export function setCharacterAssignedShip(assignedShip: string) {
 }
 
 export function setCharacterPronouns(pronouns: string) {
-  let payload = { pronouns: pronouns };
+  const payload = { pronouns: pronouns };
   return {
     type: SET_CHARACTER_PRONOUNS,
     payload: payload,
@@ -556,7 +556,7 @@ export function setCharacterPronouns(pronouns: string) {
 }
 
 export function setCharacterType(type: CharacterType) {
-  let payload = { type: type };
+  const payload = { type: type };
   return {
     type: SET_CHARACTER_TYPE,
     payload: payload,
@@ -564,7 +564,7 @@ export function setCharacterType(type: CharacterType) {
 }
 
 export function setCharacterCareerLength(careerLength: Career) {
-  let payload = { careerLength: careerLength };
+  const payload = { careerLength: careerLength };
   return {
     type: SET_CHARACTER_CAREER_LENGTH,
     payload: payload,
@@ -577,7 +577,7 @@ export function modifyCharacterAttribute(
   positive: boolean = true,
   forceDecrement: boolean = false,
 ) {
-  let payload = {
+  const payload = {
     attribute: attribute,
     context: context,
     positive: positive,
@@ -596,7 +596,7 @@ export function modifyCharacterDiscipline(
   primaryDisciplines: Department[] = [],
   forceDecrement: boolean = false,
 ) {
-  let payload = {
+  const payload = {
     discipline: discipline,
     context: context,
     positive: positive,
@@ -610,7 +610,7 @@ export function modifyCharacterDiscipline(
 }
 
 export function modifyCharacterReputation(delta: number) {
-  let payload = { delta: delta };
+  const payload = { delta: delta };
   return {
     type: MODIFY_CHARACTER_REPUTATION,
     payload: payload,
@@ -621,7 +621,7 @@ export function modifyCharacterRank(
   rank: CharacterRank,
   type: ModificationType.Promotion | ModificationType.Demotion,
 ) {
-  let payload = { rank: rank, type: type };
+  const payload = { rank: rank, type: type };
   return {
     type: MODIFY_CHARACTER_RANK,
     payload: payload,
@@ -635,7 +635,7 @@ export function modifyCharacterAddAdvancement(
   logEntry?: LogEntry,
   logEntryCallback?: LogEntry,
 ) {
-  let payload = {
+  const payload = {
     type: type,
     value: value,
     logEntry: logEntry,

--- a/WebTools/src/state/characterReducer.ts
+++ b/WebTools/src/state/characterReducer.ts
@@ -128,7 +128,7 @@ const withCharacter = (
   action: any,
   mutate: (temp: Character, action: any) => void,
 ): CharacterState => {
-  let temp = state.currentCharacter.copy();
+  const temp = state.currentCharacter.copy();
   mutate(temp, action);
   return {
     ...state,
@@ -143,7 +143,7 @@ const characterReducer = (
 ) => {
   switch (action.type) {
     case SET_CHARACTER: {
-      let temp = action.payload.character.copy();
+      const temp = action.payload.character.copy();
       return {
         ...state,
         currentCharacter: temp,
@@ -153,7 +153,7 @@ const characterReducer = (
     }
     case SET_CHARACTER_SPECIES:
       return withCharacter(state, action, (temp, action) => {
-        let originalStep = temp.speciesStep;
+        const originalStep = temp.speciesStep;
         temp.speciesStep = new SpeciesStep(action.payload.species);
         if (action.payload.attributes) {
           temp.speciesStep.attributes = [...action.payload.attributes];
@@ -190,7 +190,7 @@ const characterReducer = (
           }
         }
         if (temp.version > 1) {
-          let ability = action.payload.ability;
+          const ability = action.payload.ability;
           if (ability) {
             temp.speciesStep.ability = ability;
           }
@@ -218,7 +218,7 @@ const characterReducer = (
       });
     case SET_CHARACTER_EDUCATION:
       return withCharacter(state, action, (temp, action) => {
-        let originalStep = temp.educationStep;
+        const originalStep = temp.educationStep;
         temp.educationStep = new EducationStep(
           action.payload.track,
           action.payload.enlisted,
@@ -241,7 +241,7 @@ const characterReducer = (
       });
     case SET_CHARACTER_FINISHING_TOUCHES:
       return withCharacter(state, action, (temp, action) => {
-        let originalStep = temp.finishingStep;
+        const originalStep = temp.finishingStep;
         temp.finishingStep = new FinishingStep();
         if (originalStep) {
           temp.finishingStep.attributes = [...originalStep.attributes];
@@ -259,7 +259,7 @@ const characterReducer = (
       });
     case SET_CHARACTER_ENVIRONMENT:
       return withCharacter(state, action, (temp, action) => {
-        let originalStep = temp.environmentStep;
+        const originalStep = temp.environmentStep;
         temp.environmentStep = new EnvironmentStep(
           action.payload.environment,
           action.payload.otherSpecies,
@@ -278,7 +278,7 @@ const characterReducer = (
       });
     case SET_CHARACTER_EARLY_OUTLOOK:
       return withCharacter(state, action, (temp, action) => {
-        let originalStep = temp.upbringingStep;
+        const originalStep = temp.upbringingStep;
         temp.upbringingStep = new UpbringingStep(
           action.payload.earlyOutlook,
           action.payload.accepted,
@@ -304,14 +304,14 @@ const characterReducer = (
           if (positive) {
             temp.speciesStep.attributes.push(action.payload.attribute);
             if (temp.speciesStep.attributes.length > 3) {
-              let attributes = [...temp.speciesStep.attributes];
+              const attributes = [...temp.speciesStep.attributes];
               attributes.splice(0, attributes.length - 3);
               temp.speciesStep.attributes = attributes;
             }
           } else if (
             temp.speciesStep.attributes.includes(action.payload.attribute)
           ) {
-            let attributes = [...temp.speciesStep.attributes];
+            const attributes = [...temp.speciesStep.attributes];
             attributes.splice(
               temp.speciesStep.attributes.indexOf(action.payload.attribute),
               1,
@@ -378,7 +378,7 @@ const characterReducer = (
           if (positive) {
             temp.finishingStep.attributes.push(attribute);
           } else {
-            let index = temp.finishingStep.attributes.indexOf(attribute);
+            const index = temp.finishingStep.attributes.indexOf(attribute);
             if (index >= 0) {
               temp.finishingStep.attributes.splice(index, 1);
             }
@@ -459,7 +459,7 @@ const characterReducer = (
       });
     case REMOVE_NPC_CHARACTER_EQUIPMENT:
       return withCharacter(state, action, (temp, action) => {
-        let equipment = action.payload.equipment;
+        const equipment = action.payload.equipment;
         if (temp.npcGenerationStep?.equipment != null) {
           temp.npcGenerationStep.equipment =
             temp.npcGenerationStep.equipment.filter((e) => {
@@ -480,7 +480,7 @@ const characterReducer = (
       });
     case REMOVE_NPC_CHARACTER_WEAPON:
       return withCharacter(state, action, (temp, action) => {
-        let weapon = action.payload.weapon;
+        const weapon = action.payload.weapon;
         if (temp.npcGenerationStep?.weapons != null) {
           temp.npcGenerationStep.weapons =
             temp.npcGenerationStep.weapons.filter((e) => e !== weapon);
@@ -495,7 +495,7 @@ const characterReducer = (
       });
     case ADD_CHARACTER_CAREER_EVENT:
       return withCharacter(state, action, (temp, action) => {
-        let event = new CareerEventStep(action.payload.eventId);
+        const event = new CareerEventStep(action.payload.eventId);
         if (action.payload.attribute != null) {
           event.attribute = action.payload.attribute;
         }
@@ -525,7 +525,7 @@ const characterReducer = (
       });
     case SET_CHARACTER_TYPE:
       return withCharacter(state, action, (temp, action) => {
-        let originalType = temp.type;
+        const originalType = temp.type;
         temp.type = action.payload.type;
         if (temp.type !== originalType) {
           if (temp.educationStep) {
@@ -550,14 +550,14 @@ const characterReducer = (
       });
     case ADD_CHARACTER_UNTAPPED_POTENTIAL_ATTRIBUTE:
       return withCharacter(state, action, (temp, action) => {
-        let talent = temp.getTalentByName(TALENT_NAME_UNTAPPED_POTENTIAL);
+        const talent = temp.getTalentByName(TALENT_NAME_UNTAPPED_POTENTIAL);
         if (talent) {
           talent.attribute = action.payload.attribute;
         }
       });
     case ADD_CHARACTER_BORG_IMPLANT:
       return withCharacter(state, action, (temp, action) => {
-        let talent = temp.getTalentByName(TALENT_NAME_BORG_IMPLANTS);
+        const talent = temp.getTalentByName(TALENT_NAME_BORG_IMPLANTS);
         if (talent) {
           talent.implants.push(action.payload.type);
           while (talent.implants.length > 3) {
@@ -580,7 +580,7 @@ const characterReducer = (
       });
     case REMOVE_CHARACTER_BORG_IMPLANT:
       return withCharacter(state, action, (temp, action) => {
-        let talent = temp.getTalentByName(TALENT_NAME_BORG_IMPLANTS);
+        const talent = temp.getTalentByName(TALENT_NAME_BORG_IMPLANTS);
         if (talent) {
           const index = talent.implants.indexOf(action.payload.type);
           if (index >= 0) {
@@ -611,8 +611,8 @@ const characterReducer = (
           temp.speciesStep.abilityOptions = new SpeciesAbilityOptions();
         }
         if (temp.speciesStep?.abilityOptions != null) {
-          let index = action.payload.index;
-          let focus = action.payload.focus;
+          const index = action.payload.index;
+          const focus = action.payload.focus;
           while (temp.speciesStep.abilityOptions.focuses.length < index) {
             temp.speciesStep.abilityOptions.focuses[
               temp.speciesStep.abilityOptions.focuses.length
@@ -635,7 +635,7 @@ const characterReducer = (
       });
     case ADD_CHARACTER_TALENT_FOCUS:
       return withCharacter(state, action, (temp, action) => {
-        let talent = temp.getTalentByName(action.payload.talent);
+        const talent = temp.getTalentByName(action.payload.talent);
         if (talent) {
           const index = action.payload.index;
           for (let i = talent.focuses.length; i <= index; i++) {
@@ -646,14 +646,14 @@ const characterReducer = (
       });
     case ADD_CHARACTER_TALENT_VALUE:
       return withCharacter(state, action, (temp, action) => {
-        let talent = temp.getTalentByName(action.payload.talent);
+        const talent = temp.getTalentByName(action.payload.talent);
         if (talent) {
           talent.value = action.payload.value;
         }
       });
     case ADD_CHARACTER_TALENT:
       return withCharacter(state, action, (temp, action) => {
-        let t = action.payload.talent;
+        const t = action.payload.talent;
         let talent = undefined;
         if (t != null && t instanceof SelectedTalent) {
           talent = (t as SelectedTalent).copy();
@@ -667,7 +667,7 @@ const characterReducer = (
         } else if (action.payload.context === StepContext.Education) {
           temp.educationStep.talent = talent;
         } else if (action.payload.context === StepContext.Career) {
-          let original = temp.careerStep;
+          const original = temp.careerStep;
           if (temp.careerStep == null) {
             temp.careerStep = new CareerStep();
           }
@@ -776,7 +776,7 @@ const characterReducer = (
       });
     case UPDATE_CHARACTER_GENERAL_EDIT_VALUE:
       return withCharacter(state, action, (temp, action) => {
-        let oldValue = action.payload.oldValue as ValueAssembly;
+        const oldValue = action.payload.oldValue as ValueAssembly;
 
         if (
           oldValue.context === AssemblyContext.FinishingTouches &&
@@ -799,16 +799,16 @@ const characterReducer = (
         ) {
           temp.environmentStep.value = action.payload.newValue;
         } else if (oldValue.context === AssemblyContext.Talent) {
-          let talent = temp.talents[oldValue.contextIndex];
+          const talent = temp.talents[oldValue.contextIndex];
           talent.value = action.payload.newValue;
         } else if (oldValue.context === AssemblyContext.Improvement) {
-          let improvement = temp.improvements[oldValue.contextIndex];
+          const improvement = temp.improvements[oldValue.contextIndex];
           if (
             improvement instanceof LogEntry &&
             improvement.valuesUsed?.length &&
             oldValue.index != null
           ) {
-            let values = improvement.valuesUsed;
+            const values = improvement.valuesUsed;
             values[oldValue.index] = action.payload.newValue;
           } else if (
             improvement instanceof CharacterAdvancementStep &&
@@ -820,7 +820,7 @@ const characterReducer = (
       });
     case UPDATE_CHARACTER_GENERAL_EDIT_FOCUS:
       return withCharacter(state, action, (temp, action) => {
-        let oldValue = action.payload.oldValue as FocusAssembly;
+        const oldValue = action.payload.oldValue as FocusAssembly;
 
         if (
           oldValue.context === AssemblyContext.CareerEvent &&
@@ -845,10 +845,10 @@ const characterReducer = (
           temp.speciesStep.abilityOptions.focuses[oldValue.index] =
             action.payload.newValue;
         } else if (oldValue.context === AssemblyContext.Talent) {
-          let talent = temp.talents[oldValue.contextIndex];
+          const talent = temp.talents[oldValue.contextIndex];
           talent.focuses[oldValue.index] = action.payload.newValue;
         } else if (oldValue.context === AssemblyContext.Improvement) {
-          let improvement = temp.improvements[oldValue.contextIndex];
+          const improvement = temp.improvements[oldValue.contextIndex];
           if (
             improvement instanceof CharacterAdvancementStep &&
             improvement.choice === CharacterAdvancementChoice.Focus
@@ -859,7 +859,7 @@ const characterReducer = (
       });
     case UPDATE_CHARACTER_GENERAL_EDIT_TALENT:
       return withCharacter(state, action, (temp, action) => {
-        let oldValue = action.payload.oldValue as TalentAssembly;
+        const oldValue = action.payload.oldValue as TalentAssembly;
 
         if (oldValue.context === AssemblyContext.Species && temp.speciesStep) {
           temp.speciesStep.talent = action.payload.newValue;
@@ -884,7 +884,7 @@ const characterReducer = (
         ) {
           temp.finishingStep.talent = action.payload.newValue;
         } else if (oldValue.context === AssemblyContext.Improvement) {
-          let improvement = temp.improvements[oldValue.contextIndex];
+          const improvement = temp.improvements[oldValue.contextIndex];
           if (
             improvement instanceof CharacterAdvancementStep &&
             improvement.choice === CharacterAdvancementChoice.Talent
@@ -899,7 +899,7 @@ const characterReducer = (
           if (temp.npcGenerationStep == null) {
             temp.npcGenerationStep = new NpcGenerationStep();
           }
-          let index = action.payload.index ?? 0;
+          const index = action.payload.index ?? 0;
           for (let i = temp.npcGenerationStep.values.length; i <= index; i++) {
             temp.npcGenerationStep.values.push('');
           }
@@ -912,7 +912,7 @@ const characterReducer = (
           if (temp.supportingStep == null) {
             temp.supportingStep = new SupportingStep();
           }
-          let index = action.payload.index ?? 0;
+          const index = action.payload.index ?? 0;
           for (let i = temp.supportingStep.focuses.length; i <= index; i++) {
             temp.supportingStep.focuses.push('');
           }
@@ -921,7 +921,7 @@ const characterReducer = (
           if (temp.npcGenerationStep == null) {
             temp.npcGenerationStep = new NpcGenerationStep();
           }
-          let index = action.payload.index ?? 0;
+          const index = action.payload.index ?? 0;
           for (let i = temp.npcGenerationStep.focuses.length; i <= index; i++) {
             temp.npcGenerationStep.focuses.push('');
           }
@@ -996,7 +996,7 @@ const characterReducer = (
         ) {
           if (action.payload.forceDecrement) {
             if (positive) {
-              let value = temp.departments[discipline];
+              const value = temp.departments[discipline];
               temp.educationStep.decrementDisciplines.splice(
                 temp.educationStep.decrementDisciplines.indexOf(discipline),
                 1,
@@ -1079,7 +1079,7 @@ const characterReducer = (
           if (positive) {
             temp.finishingStep.disciplines.push(discipline);
           } else {
-            let index = temp.finishingStep.disciplines.indexOf(discipline);
+            const index = temp.finishingStep.disciplines.indexOf(discipline);
             if (index >= 0) {
               temp.finishingStep.disciplines.splice(index, 1);
             }
@@ -1107,7 +1107,7 @@ const characterReducer = (
         if (temp.improvements == null) {
           temp.improvements = [];
         }
-        let improvement = new CharacterAdvancementStep();
+        const improvement = new CharacterAdvancementStep();
         improvement.choice = action.payload.type;
         if (action.payload.type === CharacterAdvancementChoice.Talent) {
           improvement.value = (action.payload.value as SelectedTalent).copy();

--- a/WebTools/src/state/contextActions.ts
+++ b/WebTools/src/state/contextActions.ts
@@ -16,7 +16,7 @@ export const SET_ALLOW_ESOTERIC_TALENTS = 'SET_ALLOW_ESOTERIC_TALENTS';
  */
 
 export function addSource(source: Source) {
-  let payload = source;
+  const payload = source;
   return {
     type: ADD_SOURCE,
     payload: payload,
@@ -24,7 +24,7 @@ export function addSource(source: Source) {
 }
 
 export function removeSource(source: Source) {
-  let payload = source;
+  const payload = source;
   return {
     type: REMOVE_SOURCE,
     payload: payload,
@@ -32,7 +32,7 @@ export function removeSource(source: Source) {
 }
 
 export function setSources(sources: Source[]) {
-  let payload = sources;
+  const payload = sources;
   return {
     type: SET_SOURCES,
     payload: payload,
@@ -40,7 +40,7 @@ export function setSources(sources: Source[]) {
 }
 
 export function setEra(era: Era) {
-  let payload = era;
+  const payload = era;
   return {
     type: SET_ERA,
     payload: payload,
@@ -48,7 +48,7 @@ export function setEra(era: Era) {
 }
 
 export function setAllowCrossSpeciesTalents(value: boolean) {
-  let payload = value;
+  const payload = value;
   return {
     type: SET_ALLOW_CROSS_SPECIES_TALENTS,
     payload: payload,
@@ -56,7 +56,7 @@ export function setAllowCrossSpeciesTalents(value: boolean) {
 }
 
 export function setAllowEsotericTalents(value: boolean) {
-  let payload = value;
+  const payload = value;
   return {
     type: SET_ALLOW_ESOTERIC_TALENTS,
     payload: payload,

--- a/WebTools/src/state/contextFunctions.ts
+++ b/WebTools/src/state/contextFunctions.ts
@@ -10,8 +10,8 @@ export function hasSource(s: Source) {
 }
 
 export function hasAnySource(sources: Source[]) {
-  var result: boolean = false;
-  for (var s of sources) {
+  let result: boolean = false;
+  for (const s of sources) {
     result =
       result ||
       hasSource(s) ||

--- a/WebTools/src/state/contextReducer.ts
+++ b/WebTools/src/state/contextReducer.ts
@@ -10,7 +10,7 @@ import {
 } from './contextActions';
 
 const persistContext = (sources: Source[]) => {
-  let contextData = {
+  const contextData = {
     sources: sources?.length ? sources.map((s) => Source[s]) : [],
   };
   window.localStorage.setItem(
@@ -22,7 +22,7 @@ const persistContext = (sources: Source[]) => {
 let initialData = null;
 
 const getInitialData = () => {
-  let base = {
+  const base = {
     sources: [Source.Core],
     era: Era.NextGeneration,
     allowCrossSpeciesTalents: false,
@@ -31,10 +31,10 @@ const getInitialData = () => {
   if (initialData == null) {
     initialData = { ...base };
     try {
-      let dataJson = window.localStorage.getItem('settings.contextData');
+      const dataJson = window.localStorage.getItem('settings.contextData');
       if (dataJson) {
-        let data = JSON.parse(dataJson);
-        let selectedSources = [];
+        const data = JSON.parse(dataJson);
+        const selectedSources = [];
         if (data?.sources?.length) {
           SourcesHelper.getSources().forEach((s) => {
             if (data.sources.indexOf(Source[s.id]) >= 0) {
@@ -62,7 +62,7 @@ const getInitialData = () => {
 const contextReducer = (state = getInitialData(), action) => {
   switch (action.type) {
     case SET_SOURCES: {
-      let newSources = action.payload;
+      const newSources = action.payload;
       if (
         newSources.indexOf(Source.Core2ndEdition) >= 0 &&
         state.sources.indexOf(Source.Core) >= 0
@@ -84,8 +84,8 @@ const contextReducer = (state = getInitialData(), action) => {
       if (state.sources.indexOf(action.payload) >= 0) {
         return state;
       } else {
-        let newSource = action.payload;
-        let existing = [...state.sources];
+        const newSource = action.payload;
+        const existing = [...state.sources];
         if (
           newSource === Source.Core2ndEdition &&
           existing.indexOf(Source.Core) >= 0
@@ -123,7 +123,7 @@ const contextReducer = (state = getInitialData(), action) => {
         ) {
           return state;
         } else {
-          let sources = [...state.sources];
+          const sources = [...state.sources];
           sources.splice(state.sources.indexOf(action.payload), 1);
           persistContext(sources);
           return {

--- a/WebTools/src/state/gmTrackerActions.ts
+++ b/WebTools/src/state/gmTrackerActions.ts
@@ -8,7 +8,7 @@ export const SET_GM_TRACKED_CHARACTER_STRESS =
 export const SET_GM_TRACKED_CHARACTER_NOTES = 'SET_GM_TRACKED_CHARACTER_NOTES';
 
 export function addGMTrackedCharacter(character: Character) {
-  let payload = { character: character };
+  const payload = { character: character };
   return {
     type: ADD_GM_TRACKED_CHARACTER,
     payload: payload,
@@ -16,7 +16,7 @@ export function addGMTrackedCharacter(character: Character) {
 }
 
 export function removeGMTrackedCharacter(character: CharacterWithTracking) {
-  let payload = { character: character };
+  const payload = { character: character };
   return {
     type: REMOVE_GM_TRACKED_CHARACTER,
     payload: payload,
@@ -27,7 +27,7 @@ export function setGMTrackedCharacterStress(
   character: CharacterWithTracking,
   stress: number,
 ) {
-  let payload = { character: character, stress: stress };
+  const payload = { character: character, stress: stress };
   return {
     type: SET_GM_TRACKED_CHARACTER_STRESS,
     payload: payload,
@@ -38,7 +38,7 @@ export function setGMTrackedCharacterNotes(
   character: CharacterWithTracking,
   notes: string,
 ) {
-  let payload = { character: character, notes: notes };
+  const payload = { character: character, notes: notes };
   return {
     type: SET_GM_TRACKED_CHARACTER_NOTES,
     payload: payload,

--- a/WebTools/src/state/gmTrackerReducer.ts
+++ b/WebTools/src/state/gmTrackerReducer.ts
@@ -21,8 +21,8 @@ const gmTracker = (state: IGMTrackerState = { characters: [] }, action) => {
         ],
       };
     case REMOVE_GM_TRACKED_CHARACTER: {
-      let characters = [...state.characters];
-      let index = characters
+      const characters = [...state.characters];
+      const index = characters
         .map((c, i) => (c.id === action.payload.character?.id ? i : -1))
         .filter((index) => index !== -1);
       if (index.length) {
@@ -34,13 +34,13 @@ const gmTracker = (state: IGMTrackerState = { characters: [] }, action) => {
       };
     }
     case SET_GM_TRACKED_CHARACTER_STRESS: {
-      let characters = [...state.characters];
-      let index = characters
+      const characters = [...state.characters];
+      const index = characters
         .map((c, i) => (c.id === action.payload.character?.id ? i : -1))
         .filter((index) => index !== -1);
       if (index.length) {
-        let existing = characters[index[0]];
-        let tracking = new CharacterWithTracking(existing.character);
+        const existing = characters[index[0]];
+        const tracking = new CharacterWithTracking(existing.character);
         tracking.id = existing.id;
         tracking.currentStress = action.payload.stress;
         tracking.notes = existing.notes;
@@ -52,13 +52,13 @@ const gmTracker = (state: IGMTrackerState = { characters: [] }, action) => {
       };
     }
     case SET_GM_TRACKED_CHARACTER_NOTES: {
-      let characters = [...state.characters];
-      let index = characters
+      const characters = [...state.characters];
+      const index = characters
         .map((c, i) => (c.id === action.payload.character?.id ? i : -1))
         .filter((index) => index !== -1);
       if (index.length) {
-        let existing = characters[index[0]];
-        let tracking = new CharacterWithTracking(existing.character);
+        const existing = characters[index[0]];
+        const tracking = new CharacterWithTracking(existing.character);
         tracking.id = existing.id;
         tracking.currentStress = existing.currentStress;
         tracking.notes = action.payload.notes;

--- a/WebTools/src/state/safetyActions.ts
+++ b/WebTools/src/state/safetyActions.ts
@@ -6,7 +6,7 @@ export function setSafetyEvaluation(
   category: string,
   evaluation: SafetyEvaluationType,
 ) {
-  let payload = { category: category, evaluation: evaluation };
+  const payload = { category: category, evaluation: evaluation };
   return {
     type: SET_SAFETY_EVALUATION,
     payload: payload,

--- a/WebTools/src/state/safetyReducer.ts
+++ b/WebTools/src/state/safetyReducer.ts
@@ -9,7 +9,7 @@ const safety = (state: any = initialState, action) => {
       const category = action.payload.category;
       const evaluation = action.payload.evaluation;
 
-      let temp = { ...state };
+      const temp = { ...state };
       temp[category] = evaluation;
 
       return temp;

--- a/WebTools/src/state/savedConstructActions.ts
+++ b/WebTools/src/state/savedConstructActions.ts
@@ -12,7 +12,7 @@ export function saveCharacterToLocalStorage(
 ) {
   const name = character.nameAndAbbreviatedRank;
   const marshalled = marshaller.encodeCharacter(character);
-  let payload = {
+  const payload = {
     type: 'Character',
     name: name,
     marshalled: marshalled,
@@ -31,7 +31,7 @@ export function saveStarshipToLocalStorage(
 ) {
   const name = starship.name;
   const marshalled = marshaller.encodeStarship(starship);
-  let payload = {
+  const payload = {
     type: 'Starship',
     name: name,
     marshalled: marshalled,

--- a/WebTools/src/state/savedConstructReducer.ts
+++ b/WebTools/src/state/savedConstructReducer.ts
@@ -2,7 +2,7 @@ import { ILocalStorageConstructRecord } from '../common/iLocalStorageConstructRe
 import { SAVE_CONSTRUCT_TO_LOCAL_STORAGE } from './savedConstructActions';
 
 const persistItems = (records: ILocalStorageConstructRecord[]) => {
-  let data = {
+  const data = {
     records: records ?? [],
   };
   window.localStorage.setItem('constructs.records', JSON.stringify(data));
@@ -10,11 +10,11 @@ const persistItems = (records: ILocalStorageConstructRecord[]) => {
 
 const getInitialData = () => {
   const base = { records: [] };
-  let initialData = { ...base };
+  const initialData = { ...base };
   try {
-    let dataJson = window.localStorage.getItem('constructs.records');
+    const dataJson = window.localStorage.getItem('constructs.records');
     if (dataJson) {
-      let data = JSON.parse(dataJson);
+      const data = JSON.parse(dataJson);
       if (data.records) {
         initialData.records = data.records;
       }
@@ -29,7 +29,7 @@ const savedConstructReducer = (state = getInitialData(), action) => {
   switch (action.type) {
     case SAVE_CONSTRUCT_TO_LOCAL_STORAGE: {
       let records = [...state.records];
-      let hash = action.payload.hash;
+      const hash = action.payload.hash;
       if (action.payload.replacementHash != null) {
         records = records.filter(
           (r) => r.hash !== action.payload.replacementHash,

--- a/WebTools/src/state/starActions.ts
+++ b/WebTools/src/state/starActions.ts
@@ -7,7 +7,7 @@ export const SET_SECTOR_NAME = 'SET_SECTOR_NAME';
 export const SET_STAR_SYSTEM_NAME = 'SET_STAR_SYSTEM_NAME';
 
 export function setStar(starSystem: StarSystem) {
-  let payload = { starSystem: starSystem };
+  const payload = { starSystem: starSystem };
   return {
     type: SET_STAR,
     payload: payload,
@@ -15,7 +15,7 @@ export function setStar(starSystem: StarSystem) {
 }
 
 export function setSector(sector: Sector) {
-  let payload = { sector: sector };
+  const payload = { sector: sector };
   return {
     type: SET_SECTOR,
     payload: payload,
@@ -23,7 +23,7 @@ export function setSector(sector: Sector) {
 }
 
 export function setSectorName(name: string) {
-  let payload = { name: name };
+  const payload = { name: name };
   return {
     type: SET_SECTOR_NAME,
     payload: payload,
@@ -31,7 +31,7 @@ export function setSectorName(name: string) {
 }
 
 export function setStarSystemName(name: string) {
-  let payload = { name: name };
+  const payload = { name: name };
   return {
     type: SET_STAR_SYSTEM_NAME,
     payload: payload,

--- a/WebTools/src/state/starReducer.ts
+++ b/WebTools/src/state/starReducer.ts
@@ -23,18 +23,20 @@ const star = (
         sector: action.payload.sector,
       };
     case SET_SECTOR_NAME: {
-      let name = action.payload.name;
-      let systems = state.sector.systems.map((s) => {
-        let system = s.clone();
+      const name = action.payload.name;
+      const systems = state.sector.systems.map((s) => {
+        const system = s.clone();
         system.rootName = name;
         return system;
       });
-      let sector = new Sector(state.sector.prefix);
+      const sector = new Sector(state.sector.prefix);
       sector.id = state.sector.id;
       sector.simpleName = name;
       sector.systems = systems;
 
-      let starSystem = state.starSystem ? state.starSystem.clone() : undefined;
+      const starSystem = state.starSystem
+        ? state.starSystem.clone()
+        : undefined;
       if (starSystem) {
         starSystem.rootName = name;
       }
@@ -45,17 +47,19 @@ const star = (
       };
     }
     case SET_STAR_SYSTEM_NAME: {
-      let starSystem = state.starSystem ? state.starSystem.clone() : undefined;
+      const starSystem = state.starSystem
+        ? state.starSystem.clone()
+        : undefined;
       if (starSystem) {
         starSystem.friendlyName = action.payload.name;
-        let systems = state.sector.systems.map((s) => {
+        const systems = state.sector.systems.map((s) => {
           if (s.id === starSystem.id) {
             return starSystem;
           } else {
             return s;
           }
         });
-        let sector = new Sector(state.sector.prefix);
+        const sector = new Sector(state.sector.prefix);
         sector.id = state.sector.id;
         sector.simpleName = state.sector.simpleName;
         sector.systems = systems;

--- a/WebTools/src/state/starshipActions.ts
+++ b/WebTools/src/state/starshipActions.ts
@@ -60,7 +60,7 @@ export const SET_STARSHIP_SPACEFRAME_APPEARANCE =
   'SET_STARSHIP_SPACEFRAME_APPEARANCE';
 
 export function createStarship(starship: Starship, hash?: number) {
-  let payload = { starship: starship, hash: hash };
+  const payload = { starship: starship, hash: hash };
   return {
     type: CREATE_STARSHIP,
     payload: payload,
@@ -76,7 +76,7 @@ export function createNewStarship(
   buildType: ShipBuildType = ShipBuildType.Starship,
   version: number = 1,
 ) {
-  let payload = {
+  const payload = {
     type: type,
     era: era,
     serviceYear: serviceYear,
@@ -92,7 +92,7 @@ export function createNewStarship(
 }
 
 export function changeStarshipScale(delta: number) {
-  let payload = { delta: delta };
+  const payload = { delta: delta };
   return {
     type: CHANGE_STARSHIP_SCALE,
     payload: payload,
@@ -100,7 +100,7 @@ export function changeStarshipScale(delta: number) {
 }
 
 export function changeStarshipSpaceframeScale(delta: number) {
-  let payload = { delta: delta };
+  const payload = { delta: delta };
   return {
     type: CHANGE_STARSHIP_SPACEFRAME_SCALE,
     payload: payload,
@@ -108,7 +108,7 @@ export function changeStarshipSpaceframeScale(delta: number) {
 }
 
 export function changeStarshipSpaceframeServiceYear(year: number) {
-  let payload = { serviceYear: year };
+  const payload = { serviceYear: year };
   return {
     type: CHANGE_STARSHIP_SPACEFRAME_SERVICE_YEAR,
     payload: payload,
@@ -116,7 +116,7 @@ export function changeStarshipSpaceframeServiceYear(year: number) {
 }
 
 export function setStarshipServiceYear(year: number) {
-  let payload = { serviceYear: year };
+  const payload = { serviceYear: year };
   return {
     type: SET_STARSHIP_SERVICE_YEAR,
     payload: payload,
@@ -124,7 +124,7 @@ export function setStarshipServiceYear(year: number) {
 }
 
 export function changeStarshipSimpleClassName(className: string) {
-  let payload = { className: className };
+  const payload = { className: className };
   return {
     type: CHANGE_STARSHIP_SIMPLE_CLASS_NAME,
     payload: payload,
@@ -132,7 +132,7 @@ export function changeStarshipSimpleClassName(className: string) {
 }
 
 export function changeStarshipSpaceframeClassName(className: string) {
-  let payload = { className: className };
+  const payload = { className: className };
   return {
     type: CHANGE_STARSHIP_SPACEFRAME_CLASS_NAME,
     payload: payload,
@@ -140,7 +140,7 @@ export function changeStarshipSpaceframeClassName(className: string) {
 }
 
 export function setStarshipName(name: string) {
-  let payload = { name: name };
+  const payload = { name: name };
   return {
     type: SET_STARSHIP_NAME,
     payload: payload,
@@ -151,7 +151,7 @@ export function setStarshipSpaceframe(
   spaceframe: SpaceframeModel,
   variant?: SpaceframeVariant,
 ) {
-  let payload = { spaceframe: spaceframe, variant: variant };
+  const payload = { spaceframe: spaceframe, variant: variant };
   return {
     type: SET_STARSHIP_SPACEFRAME,
     payload: payload,
@@ -159,7 +159,7 @@ export function setStarshipSpaceframe(
 }
 
 export function setStarshipSpaceframeTalents(talents: SelectedTalent[]) {
-  let payload = { talents: talents };
+  const payload = { talents: talents };
   return {
     type: SET_STARSHIP_SPACEFRAME_TALENTS,
     payload: payload,
@@ -173,7 +173,7 @@ export function setStarshipServiceRecord(
   removedTalent?: string,
   replacedTalent?: SelectedTalent,
 ) {
-  let payload = {
+  const payload = {
     serviceRecord: serviceRecord,
     talent: talent,
     selection: selection,
@@ -190,7 +190,7 @@ export function setStarshipMissionProfile(
   missionProfile: MissionProfileModel,
   system?: System,
 ) {
-  let payload = { missionProfile: missionProfile, system: system };
+  const payload = { missionProfile: missionProfile, system: system };
   return {
     type: SET_STARSHIP_MISSION_PROFILE,
     payload: payload,
@@ -198,7 +198,7 @@ export function setStarshipMissionProfile(
 }
 
 export function setStarshipMissionProfileTalent(talent: SelectedTalent) {
-  let payload = { talent: talent };
+  const payload = { talent: talent };
   return {
     type: SET_STARSHIP_MISSION_PROFILE_TALENT,
     payload: payload,
@@ -209,7 +209,7 @@ export function setStarshipMissionPod(
   missionPod: MissionPodModel,
   replacements?: (SelectedTalent | undefined)[],
 ) {
-  let payload = { missionPod: missionPod, replacements: replacements ?? [] };
+  const payload = { missionPod: missionPod, replacements: replacements ?? [] };
   return {
     type: SET_STARSHIP_MISSION_POD,
     payload: payload,
@@ -217,7 +217,7 @@ export function setStarshipMissionPod(
 }
 
 export function addStarshipRefit(refit: System) {
-  let payload = { refit: refit };
+  const payload = { refit: refit };
   return {
     type: ADD_STARSHIP_REFIT,
     payload: payload,
@@ -225,7 +225,7 @@ export function addStarshipRefit(refit: System) {
 }
 
 export function deleteStarshipRefit(refit: System) {
-  let payload = { refit: refit };
+  const payload = { refit: refit };
   return {
     type: DELETE_STARSHIP_REFIT,
     payload: payload,
@@ -233,7 +233,7 @@ export function deleteStarshipRefit(refit: System) {
 }
 
 export function setStarshipRegistry(registry: string) {
-  let payload = { registry: registry };
+  const payload = { registry: registry };
   return {
     type: SET_STARSHIP_REGISTRY,
     payload: payload,
@@ -241,7 +241,7 @@ export function setStarshipRegistry(registry: string) {
 }
 
 export function setStarshipTraits(traits: string) {
-  let payload = { traits: traits };
+  const payload = { traits: traits };
   return {
     type: SET_STARSHIP_TRAITS,
     payload: payload,
@@ -251,7 +251,7 @@ export function setStarshipTraits(traits: string) {
 export function setStarshipSpaceframeAppearance(
   appearance?: SpaceframeAppearance,
 ) {
-  let payload = { appearance: appearance };
+  const payload = { appearance: appearance };
   return {
     type: SET_STARSHIP_SPACEFRAME_APPEARANCE,
     payload: payload,
@@ -259,7 +259,7 @@ export function setStarshipSpaceframeAppearance(
 }
 
 export function setAdditionalTalents(talents: SelectedTalent[]) {
-  let payload = { talents: talents };
+  const payload = { talents: talents };
   return {
     type: SET_ADDITIONAL_TALENTS,
     payload: payload,
@@ -267,7 +267,7 @@ export function setAdditionalTalents(talents: SelectedTalent[]) {
 }
 
 export function changeStarshipSimpleSystem(delta: number, system: System) {
-  let payload = { delta: delta, system: system };
+  const payload = { delta: delta, system: system };
   return {
     type: CHANGE_STARSHIP_SIMPLE_SYSTEM,
     payload: payload,
@@ -275,7 +275,7 @@ export function changeStarshipSimpleSystem(delta: number, system: System) {
 }
 
 export function changeStarshipSpaceframeSystem(delta: number, system: System) {
-  let payload = { delta: delta, system: system };
+  const payload = { delta: delta, system: system };
   return {
     type: CHANGE_STARSHIP_SPACEFRAME_SYSTEM,
     payload: payload,
@@ -286,7 +286,7 @@ export function changeStarshipSimpleDepartment(
   delta: number,
   department: Department,
 ) {
-  let payload = { delta: delta, department: department };
+  const payload = { delta: delta, department: department };
   return {
     type: CHANGE_STARSHIP_SIMPLE_DEPARTMENT,
     payload: payload,
@@ -297,7 +297,7 @@ export function changeStarshipSpaceframeDepartment(
   delta: number,
   department: Department,
 ) {
-  let payload = { delta: delta, department: department };
+  const payload = { delta: delta, department: department };
   return {
     type: CHANGE_STARSHIP_SPACEFRAME_DEPARTMENT,
     payload: payload,
@@ -319,7 +319,7 @@ export function rewindToStarshipWorkflowStep(step: number) {
 }
 
 export function addStarshipWeapon(weapon: Weapon) {
-  let payload = { weapon: weapon };
+  const payload = { weapon: weapon };
   return {
     type: ADD_STARSHIP_WEAPON,
     payload: payload,
@@ -327,7 +327,7 @@ export function addStarshipWeapon(weapon: Weapon) {
 }
 
 export function deleteStarshipWeapon(weapon: Weapon) {
-  let payload = { weapon: weapon };
+  const payload = { weapon: weapon };
   return {
     type: DELETE_STARSHIP_WEAPON,
     payload: payload,
@@ -339,7 +339,7 @@ export function modifyStarshipAddAdvancement(
   value: System | Department | SelectedTalent,
   removeValue?: System | Department | SelectedTalent,
 ) {
-  let payload = { type: type, value: value };
+  const payload = { type: type, value: value };
   if (removeValue != null) {
     payload['remove'] = removeValue;
   }

--- a/WebTools/src/state/starshipReducer.ts
+++ b/WebTools/src/state/starshipReducer.ts
@@ -55,7 +55,7 @@ const withStarship = (
   action: any,
   mutate: (s: Starship, action: any) => void,
 ): StarshipState => {
-  let s = state.starship.copy();
+  const s = state.starship.copy();
   mutate(s, action);
   return {
     ...state,
@@ -73,8 +73,8 @@ const starshipReducer = (
 ) => {
   switch (action.type) {
     case CREATE_STARSHIP: {
-      let s = action.payload.starship;
-      let hash = action.payload.hash;
+      const s = action.payload.starship;
+      const hash = action.payload.hash;
       return {
         ...state,
         starship: s.copy(),
@@ -83,8 +83,8 @@ const starshipReducer = (
     }
 
     case MODIFY_STARSHIP_ADD_ADVANCEMENT: {
-      let temp = state.starship.copy();
-      let improvement = new StarshipAdvancementStep();
+      const temp = state.starship.copy();
+      const improvement = new StarshipAdvancementStep();
       improvement.choice = action.payload.type;
       if (action.payload.type === StarshipAdvancementChoice.Talent) {
         improvement.value = (action.payload.value as SelectedTalent).copy();
@@ -108,7 +108,7 @@ const starshipReducer = (
     }
 
     case CREATE_NEW_STARSHIP: {
-      let s = Starship.createStandardStarship(
+      const s = Starship.createStandardStarship(
         action.payload.era,
         action.payload.type,
         action.payload.version,
@@ -143,8 +143,8 @@ const starshipReducer = (
     case CHANGE_STARSHIP_SPACEFRAME_SCALE:
       return withStarship(state, action, (s, action) => {
         if (s?.spaceframeModel?.isCustom) {
-          let original = s.spaceframeStep;
-          let spaceframe = s.spaceframeModel.copy();
+          const original = s.spaceframeStep;
+          const spaceframe = s.spaceframeModel.copy();
           spaceframe.scale += action.payload.delta;
           s.spaceframeStep = new SpaceframeStep(spaceframe);
           if (original?.appearance != null) {
@@ -156,8 +156,8 @@ const starshipReducer = (
     case CHANGE_STARSHIP_SPACEFRAME_SERVICE_YEAR:
       return withStarship(state, action, (s, action) => {
         if (s?.spaceframeModel?.isCustom) {
-          let original = s.spaceframeStep;
-          let spaceframe = s.spaceframeModel.copy();
+          const original = s.spaceframeStep;
+          const spaceframe = s.spaceframeModel.copy();
           spaceframe.serviceYear = action.payload.serviceYear;
           s.spaceframeStep = new SpaceframeStep(spaceframe);
           if (original?.appearance != null) {
@@ -172,8 +172,8 @@ const starshipReducer = (
     case CHANGE_STARSHIP_SPACEFRAME_CLASS_NAME:
       return withStarship(state, action, (s, action) => {
         if (s?.spaceframeModel?.isCustom) {
-          let original = s.spaceframeStep;
-          let spaceframe = s.spaceframeModel.copy();
+          const original = s.spaceframeStep;
+          const spaceframe = s.spaceframeModel.copy();
           spaceframe.name = action.payload.className;
           s.spaceframeStep = new SpaceframeStep(spaceframe);
           if (original?.appearance != null) {
@@ -197,7 +197,7 @@ const starshipReducer = (
         if (action.payload.serviceRecord == null) {
           s.serviceRecordStep = null;
         } else {
-          let original = s.serviceRecordStep;
+          const original = s.serviceRecordStep;
           s.serviceRecordStep = new ServiceRecordStep(
             action.payload.serviceRecord,
           );
@@ -225,7 +225,7 @@ const starshipReducer = (
       });
     case SET_STARSHIP_SPACEFRAME:
       return withStarship(state, action, (s, action) => {
-        let original = s.spaceframeModel;
+        const original = s.spaceframeModel;
         s.spaceframeStep = new SpaceframeStep(action.payload.spaceframe);
         if (original != null && s.spaceframeModel?.scale < original?.scale) {
           s.pruneExcessTalents();
@@ -234,7 +234,7 @@ const starshipReducer = (
       });
     case SET_STARSHIP_SPACEFRAME_TALENTS:
       return withStarship(state, action, (s, action) => {
-        let newStep = s.spaceframeStep.copy();
+        const newStep = s.spaceframeStep.copy();
         newStep.talents = action.payload.talents;
         s.spaceframeStep = newStep;
       });
@@ -264,7 +264,7 @@ const starshipReducer = (
         if (s.missionPodModel == null) {
           s.missionPodReplacements = [];
         } else {
-          let replacements = (action.payload.replacements ?? []).map((r) =>
+          const replacements = (action.payload.replacements ?? []).map((r) =>
             r?.copy(),
           );
           while (replacements.length < s.missionPodModel.talents.length) {
@@ -282,7 +282,7 @@ const starshipReducer = (
       });
     case ADD_STARSHIP_REFIT:
       return withStarship(state, action, (s, action) => {
-        let refits = [...s.refits, action.payload.refit];
+        const refits = [...s.refits, action.payload.refit];
         while (refits.length > s.numberOfRefits) {
           refits.splice(0, 1);
         }
@@ -290,8 +290,8 @@ const starshipReducer = (
       });
     case DELETE_STARSHIP_REFIT:
       return withStarship(state, action, (s, action) => {
-        let refits = [...s.refits];
-        let index = refits.indexOf(action.payload.refit);
+        const refits = [...s.refits];
+        const index = refits.indexOf(action.payload.refit);
         if (index >= 0) {
           refits.splice(index, 1);
         }
@@ -333,8 +333,8 @@ const starshipReducer = (
     case CHANGE_STARSHIP_SPACEFRAME_SYSTEM:
       return withStarship(state, action, (s, action) => {
         if (s?.spaceframeModel?.isCustom) {
-          let original = s.spaceframeStep;
-          let spaceframe = s.spaceframeModel.copy();
+          const original = s.spaceframeStep;
+          const spaceframe = s.spaceframeModel.copy();
           spaceframe.systems[action.payload.system] += action.payload.delta;
           s.spaceframeStep = new SpaceframeStep(spaceframe);
           if (original?.appearance != null) {
@@ -353,8 +353,8 @@ const starshipReducer = (
     case CHANGE_STARSHIP_SPACEFRAME_DEPARTMENT:
       return withStarship(state, action, (s, action) => {
         if (s?.spaceframeModel?.isCustom) {
-          let original = s.spaceframeStep;
-          let spaceframe = s.spaceframeModel.copy();
+          const original = s.spaceframeStep;
+          const spaceframe = s.spaceframeModel.copy();
           spaceframe.departments[action.payload.department] +=
             action.payload.delta;
           s.spaceframeStep = new SpaceframeStep(spaceframe);
@@ -373,7 +373,7 @@ const starshipReducer = (
       });
     case NEXT_STARSHIP_WORKFLOW_STEP: {
       if (state.workflow) {
-        let w = new ShipBuildWorkflow(state.workflow.steps);
+        const w = new ShipBuildWorkflow(state.workflow.steps);
         w.currentStepIndex = state.workflow.currentStepIndex + 1;
         return {
           ...state,
@@ -385,7 +385,7 @@ const starshipReducer = (
     }
     case REWIND_TO_STARSHIP_WORKFLOW_STEP: {
       if (state.workflow) {
-        let w = new ShipBuildWorkflow(state.workflow.steps);
+        const w = new ShipBuildWorkflow(state.workflow.steps);
         w.currentStepIndex = action.payload.index;
         return {
           ...state,

--- a/WebTools/src/state/stationActions.ts
+++ b/WebTools/src/state/stationActions.ts
@@ -24,7 +24,7 @@ export const SET_STATION_FRAME = 'SET_STATION_FRAME';
 export const SET_STATION_FRAME_APPEARANCE = 'SET_STATION_FRAME_APPEARANCE';
 
 export function createStation(station: Station) {
-  let payload = { station: station };
+  const payload = { station: station };
   return {
     type: CREATE_STATION,
     payload: payload,
@@ -32,7 +32,7 @@ export function createStation(station: Station) {
 }
 
 export function setStationMissionProfile(missionProfile: MissionProfile) {
-  let payload = { missionProfile: missionProfile };
+  const payload = { missionProfile: missionProfile };
   return {
     type: SET_STATION_MISSION_PROFILE,
     payload: payload,
@@ -40,7 +40,7 @@ export function setStationMissionProfile(missionProfile: MissionProfile) {
 }
 
 export function setStationMissionProfileTalent(talent: SelectedTalent) {
-  let payload = { talent: talent };
+  const payload = { talent: talent };
   return {
     type: SET_STATION_MISSION_PROFILE_TALENT,
     payload: payload,
@@ -48,7 +48,7 @@ export function setStationMissionProfileTalent(talent: SelectedTalent) {
 }
 
 export function setStationName(name: String) {
-  let payload = { name: name };
+  const payload = { name: name };
   return {
     type: SET_STATION_NAME,
     payload: payload,
@@ -56,7 +56,7 @@ export function setStationName(name: String) {
 }
 
 export function setStationCustomScale(scale: number) {
-  let payload = { scale: scale };
+  const payload = { scale: scale };
   return {
     type: SET_STATION_CUSTOM_SCALE,
     payload: payload,
@@ -64,7 +64,7 @@ export function setStationCustomScale(scale: number) {
 }
 
 export function setStationTraits(traits: String[]) {
-  let payload = { traits: traits };
+  const payload = { traits: traits };
   return {
     type: SET_STATION_TRAITS,
     payload: payload,
@@ -72,7 +72,7 @@ export function setStationTraits(traits: String[]) {
 }
 
 export function changeStationCustomFrameSystem(delta: number, system: System) {
-  let payload = { delta: delta, system: system };
+  const payload = { delta: delta, system: system };
   return {
     type: MODIFY_STATION_CUSTOM_FRAME_SYSTEM,
     payload: payload,
@@ -83,7 +83,7 @@ export function changeStationCustomFrameDepartment(
   delta: number,
   department: Department,
 ) {
-  let payload = { delta: delta, department: department };
+  const payload = { delta: delta, department: department };
   return {
     type: MODIFY_STATION_CUSTOM_FRAME_DEPARTMENT,
     payload: payload,
@@ -91,7 +91,7 @@ export function changeStationCustomFrameDepartment(
 }
 
 export function addStationWeapon(weapon: Weapon) {
-  let payload = { weapon: weapon };
+  const payload = { weapon: weapon };
   return {
     type: ADD_STATION_WEAPON,
     payload: payload,
@@ -99,7 +99,7 @@ export function addStationWeapon(weapon: Weapon) {
 }
 
 export function deleteStationWeapon(weapon: Weapon) {
-  let payload = { weapon: weapon };
+  const payload = { weapon: weapon };
   return {
     type: DELETE_STATION_WEAPON,
     payload: payload,
@@ -107,7 +107,7 @@ export function deleteStationWeapon(weapon: Weapon) {
 }
 
 export function setStationAdditionalTalents(talents: SelectedTalent[]) {
-  let payload = { talents: talents };
+  const payload = { talents: talents };
   return {
     type: SET_STATION_ADDITIONAL_TALENTS,
     payload: payload,
@@ -115,7 +115,7 @@ export function setStationAdditionalTalents(talents: SelectedTalent[]) {
 }
 
 export function setStationFrame(frame: StationFrame) {
-  let payload = { frame: frame };
+  const payload = { frame: frame };
   return {
     type: SET_STATION_FRAME,
     payload: payload,
@@ -123,7 +123,7 @@ export function setStationFrame(frame: StationFrame) {
 }
 
 export function setStationFrameAppearance(appearance: StationFrameAppearance) {
-  let payload = { appearance: appearance };
+  const payload = { appearance: appearance };
   return {
     type: SET_STATION_FRAME_APPEARANCE,
     payload: payload,

--- a/WebTools/src/state/stationReducer.ts
+++ b/WebTools/src/state/stationReducer.ts
@@ -30,7 +30,7 @@ const withStation = (
   action: any,
   mutate: (s: Station, action: any) => void,
 ): StationState => {
-  let s = state.station?.copy();
+  const s = state.station?.copy();
   if (s) {
     mutate(s, action);
   }
@@ -46,7 +46,7 @@ const stationReducer = (
 ) => {
   switch (action.type) {
     case CREATE_STATION: {
-      let s = action.payload.station;
+      const s = action.payload.station;
       console.log('Create a station');
       return {
         ...state,
@@ -139,7 +139,7 @@ const stationReducer = (
         ) {
           s.stationFrameStep = new CustomStationSpaceframeStep();
         }
-        let system = action.payload.system;
+        const system = action.payload.system;
         s.stationFrameStep.systems[system] += action.payload.delta;
         if (s.stationFrameStep.systems[system] > s.maxSystemValue) {
           s.stationFrameStep.systems[system] = s.maxSystemValue;
@@ -153,7 +153,7 @@ const stationReducer = (
         ) {
           s.stationFrameStep = new CustomStationSpaceframeStep();
         }
-        let department = action.payload.department;
+        const department = action.payload.department;
         s.stationFrameStep.departments[department] += action.payload.delta;
         if (s.stationFrameStep.departments[department] > s.maxDepartmentValue) {
           s.stationFrameStep.departments[department] = s.maxDepartmentValue;
@@ -191,12 +191,12 @@ const stationReducer = (
     case SET_STATION_FRAME:
       return withStation(state, action, (s, action) => {
         if (action.payload.frame === StationFrame.Custom) {
-          let scale = s.scale;
+          const scale = s.scale;
           s.stationFrameStep = CustomStationSpaceframeStep.create(scale);
         } else {
-          let temp = new StandardStationSpaceframeStep(action.payload.frame);
+          const temp = new StandardStationSpaceframeStep(action.payload.frame);
           s.stationFrameStep = temp;
-          let frameModel = temp.model;
+          const frameModel = temp.model;
           if (frameModel.missionProfiles?.length === 1) {
             s.missionProfileStep = new StationMissionProfileStep(
               temp.model.missionProfiles[0].profile,

--- a/WebTools/src/state/tableActions.ts
+++ b/WebTools/src/state/tableActions.ts
@@ -8,7 +8,7 @@ export const REPLACE_TABLE_COLLECTION = 'REPLACE_TABLE_COLLECTION';
 export const DELETE_TABLE_COLLECTION = 'DELETE_TABLE_COLLECTION';
 
 export function setTableCollectionSelection(selection: TableCollection) {
-  let payload = { selection: selection };
+  const payload = { selection: selection };
   return {
     type: SET_TABLE_COLLECTION_SELECTION,
     payload: payload,
@@ -16,7 +16,7 @@ export function setTableCollectionSelection(selection: TableCollection) {
 }
 
 export function importTableCollection(collection: TableCollection) {
-  let payload = { collection: collection };
+  const payload = { collection: collection };
   return {
     type: IMPORT_TABLE_COLLECTION,
     payload: payload,
@@ -24,7 +24,7 @@ export function importTableCollection(collection: TableCollection) {
 }
 
 export function setTableForEditing(collection: TableCollection) {
-  let payload = { collection: collection };
+  const payload = { collection: collection };
   return {
     type: SET_TABLE_FOR_EDITING,
     payload: payload,
@@ -32,7 +32,7 @@ export function setTableForEditing(collection: TableCollection) {
 }
 
 export function addTableCollection(collection: TableCollection) {
-  let payload = { collection: collection };
+  const payload = { collection: collection };
   return {
     type: ADD_TABLE_COLLECTION,
     payload: payload,
@@ -40,7 +40,7 @@ export function addTableCollection(collection: TableCollection) {
 }
 
 export function deleteTableCollection(collection: TableCollection) {
-  let payload = { collection: collection };
+  const payload = { collection: collection };
   return {
     type: DELETE_TABLE_COLLECTION,
     payload: payload,
@@ -51,7 +51,7 @@ export function replaceTableCollection(
   uuid: string,
   collection: TableCollection,
 ) {
-  let payload = {
+  const payload = {
     uuid: uuid,
     collection: collection,
   };

--- a/WebTools/src/state/tableFunctions.ts
+++ b/WebTools/src/state/tableFunctions.ts
@@ -5,8 +5,8 @@ export const isTableCollectionAlreadyImported = (
   uuid: string,
   encodedCollection: string,
 ) => {
-  let collections = store.getState().table?.collections;
-  let matches = collections
+  const collections = store.getState().table?.collections;
+  const matches = collections
     .filter((c) => c.uuid === uuid)
     .filter((c) => TableMarshaller.instance.marshall(c) === encodedCollection);
   return matches.length > 0;

--- a/WebTools/src/state/tableReducer.ts
+++ b/WebTools/src/state/tableReducer.ts
@@ -316,7 +316,7 @@ const tableCollection2 = new TableCollection(
 );
 
 const persistTables = (tables: TableCollection[]) => {
-  let data = {
+  const data = {
     collections: tables?.length
       ? tables.map((s) => TableMarshaller.instance.marshall(s))
       : [],
@@ -331,7 +331,7 @@ let initialData: {
 } = null;
 
 const getInitialData = () => {
-  let base = {
+  const base = {
     selection: null,
     collections: [tableCollection, tableCollection2],
   };
@@ -340,7 +340,7 @@ const getInitialData = () => {
     initialData = { ...base };
   }
 
-  let temp =
+  const temp =
     typeof window !== 'undefined' && window?.localStorage
       ? window.localStorage.getItem('settings.tableData')
       : null;
@@ -363,8 +363,8 @@ const tableReducer = (state = getInitialData(), action) => {
   switch (action.type) {
     case IMPORT_TABLE_COLLECTION:
     case ADD_TABLE_COLLECTION: {
-      let collections = [...state.collections];
-      let collection = action.payload.collection;
+      const collections = [...state.collections];
+      const collection = action.payload.collection;
       collections.push(collection);
       persistTables(collections);
       return {
@@ -373,13 +373,13 @@ const tableReducer = (state = getInitialData(), action) => {
       };
     }
     case SET_TABLE_COLLECTION_SELECTION: {
-      let temp = { ...state };
+      const temp = { ...state };
       temp.selection = action.payload.selection;
       return temp;
     }
     case DELETE_TABLE_COLLECTION: {
-      let temp = { ...state };
-      let tableCollection = action.payload.collection;
+      const temp = { ...state };
+      const tableCollection = action.payload.collection;
       temp.collections = temp.collections.filter(
         (t) => t.uuid !== tableCollection.uuid,
       );
@@ -387,13 +387,13 @@ const tableReducer = (state = getInitialData(), action) => {
       return temp;
     }
     case SET_TABLE_FOR_EDITING: {
-      let temp = { ...state };
+      const temp = { ...state };
       temp.editing = action.payload.collection;
       return temp;
     }
     case REPLACE_TABLE_COLLECTION: {
-      let temp = { ...state };
-      let tableCollection = action.payload.collection;
+      const temp = { ...state };
+      const tableCollection = action.payload.collection;
       temp.collections = temp.collections.filter(
         (t) => t.uuid !== action.payload.uuid,
       );

--- a/WebTools/src/state/tokenActions.ts
+++ b/WebTools/src/state/tokenActions.ts
@@ -50,7 +50,7 @@ export function createNewToken(
   const hash = marshalledCharacter?.length
     ? cyrb53(marshalledCharacter)
     : undefined;
-  let payload = {
+  const payload = {
     token: token,
     marshalledCharacter: marshalledCharacter,
     characterName: characterName,
@@ -65,7 +65,7 @@ export function createNewToken(
 }
 
 export function setTokenSpecies(species: Species) {
-  let payload = { species: species };
+  const payload = { species: species };
   return {
     type: SET_TOKEN_SPECIES,
     payload: payload,
@@ -73,7 +73,7 @@ export function setTokenSpecies(species: Species) {
 }
 
 export function setTokenSecondarySpecies(species: Species) {
-  let payload = { species: species };
+  const payload = { species: species };
   return {
     type: SET_TOKEN_SECONDARY_SPECIES,
     payload: payload,
@@ -81,7 +81,7 @@ export function setTokenSecondarySpecies(species: Species) {
 }
 
 export function setUniformEra(era: UniformEra) {
-  let payload = { era: era };
+  const payload = { era: era };
   return {
     type: SET_TOKEN_UNIFORM_ERA,
     payload: payload,
@@ -89,7 +89,7 @@ export function setUniformEra(era: UniformEra) {
 }
 
 export function setTokenDivisionColor(color: string) {
-  let payload = { color: color };
+  const payload = { color: color };
   return {
     type: SET_TOKEN_DIVISION_COLOR,
     payload: payload,
@@ -97,7 +97,7 @@ export function setTokenDivisionColor(color: string) {
 }
 
 export function setTokenRank(rank: Rank) {
-  let payload = { rank: rank };
+  const payload = { rank: rank };
   return {
     type: SET_TOKEN_RANK,
     payload: payload,
@@ -105,7 +105,7 @@ export function setTokenRank(rank: Rank) {
 }
 
 export function setTokenSkinColor(color: string) {
-  let payload = { color: color };
+  const payload = { color: color };
   return {
     type: SET_TOKEN_SKIN_COLOR,
     payload: payload,
@@ -113,7 +113,7 @@ export function setTokenSkinColor(color: string) {
 }
 
 export function setTokenEyeColor(color: string) {
-  let payload = { color: color };
+  const payload = { color: color };
   return {
     type: SET_TOKEN_EYE_COLOR,
     payload: payload,
@@ -121,7 +121,7 @@ export function setTokenEyeColor(color: string) {
 }
 
 export function setTokenHairColor(color: string) {
-  let payload = { color: color };
+  const payload = { color: color };
   return {
     type: SET_TOKEN_HAIR_COLOR,
     payload: payload,
@@ -129,7 +129,7 @@ export function setTokenHairColor(color: string) {
 }
 
 export function setTokenLipstickColor(color: string) {
-  let payload = { color: color };
+  const payload = { color: color };
   return {
     type: SET_TOKEN_LIPSTICK_COLOR,
     payload: payload,
@@ -137,7 +137,7 @@ export function setTokenLipstickColor(color: string) {
 }
 
 export function setTokenHairType(hairType: HairType) {
-  let payload = { hairType: hairType };
+  const payload = { hairType: hairType };
   return {
     type: SET_TOKEN_HAIR_TYPE,
     payload: payload,
@@ -145,7 +145,7 @@ export function setTokenHairType(hairType: HairType) {
 }
 
 export function setTokenHeadType(headType: HeadType) {
-  let payload = { headType: headType };
+  const payload = { headType: headType };
   return {
     type: SET_TOKEN_HEAD_TYPE,
     payload: payload,
@@ -153,7 +153,7 @@ export function setTokenHeadType(headType: HeadType) {
 }
 
 export function setTokenMouthType(mouthType: MouthType) {
-  let payload = { mouthType: mouthType };
+  const payload = { mouthType: mouthType };
   return {
     type: SET_TOKEN_MOUTH_TYPE,
     payload: payload,
@@ -161,7 +161,7 @@ export function setTokenMouthType(mouthType: MouthType) {
 }
 
 export function setTokenEyeType(eyeType: EyeType) {
-  let payload = { eyeType: eyeType };
+  const payload = { eyeType: eyeType };
   return {
     type: SET_TOKEN_EYE_TYPE,
     payload: payload,
@@ -169,7 +169,7 @@ export function setTokenEyeType(eyeType: EyeType) {
 }
 
 export function setTokenNoseType(noseType: NoseType) {
-  let payload = { noseType: noseType };
+  const payload = { noseType: noseType };
   return {
     type: SET_TOKEN_NOSE_TYPE,
     payload: payload,
@@ -177,7 +177,7 @@ export function setTokenNoseType(noseType: NoseType) {
 }
 
 export function setTokenBodyType(type: BodyType) {
-  let payload = { type: type };
+  const payload = { type: type };
   return {
     type: SET_TOKEN_BODY_TYPE,
     payload: payload,
@@ -185,7 +185,7 @@ export function setTokenBodyType(type: BodyType) {
 }
 
 export function setTokenUniformVariantType(type: UniformVariantType) {
-  let payload = { type: type };
+  const payload = { type: type };
   return {
     type: SET_TOKEN_UNIFORM_VARIANT_TYPE,
     payload: payload,
@@ -193,7 +193,7 @@ export function setTokenUniformVariantType(type: UniformVariantType) {
 }
 
 export function setTokenFacialHairTypes(types: FacialHairType[]) {
-  let payload = { types: types };
+  const payload = { types: types };
   return {
     type: SET_TOKEN_FACIAL_HAIR_TYPE,
     payload: payload,
@@ -201,7 +201,7 @@ export function setTokenFacialHairTypes(types: FacialHairType[]) {
 }
 
 export function setTokenExtrasTypes(types: ExtraType[]) {
-  let payload = { types: types };
+  const payload = { types: types };
   return {
     type: SET_TOKEN_EXTRAS_TYPE,
     payload: payload,
@@ -209,7 +209,7 @@ export function setTokenExtrasTypes(types: ExtraType[]) {
 }
 
 export function setTokenNasoLabialFoldType(type: NasoLabialFoldType) {
-  let payload = { type: type };
+  const payload = { type: type };
   return {
     type: SET_TOKEN_NASO_LABIAL_FOLD_TYPE,
     payload: payload,
@@ -217,7 +217,7 @@ export function setTokenNasoLabialFoldType(type: NasoLabialFoldType) {
 }
 
 export function setTokenSpeciesOption(option: SpeciesOption) {
-  let payload = { option: option };
+  const payload = { option: option };
   return {
     type: SET_TOKEN_SPECIES_OPTION,
     payload: payload,
@@ -225,14 +225,14 @@ export function setTokenSpeciesOption(option: SpeciesOption) {
 }
 
 export function setTokenRounded(rounded: boolean) {
-  let payload = { rounded: rounded };
+  const payload = { rounded: rounded };
   return {
     type: SET_TOKEN_ROUNDED,
     payload: payload,
   };
 }
 export function setTokenBordered(bordered: boolean) {
-  let payload = { bordered: bordered };
+  const payload = { bordered: bordered };
   return {
     type: SET_TOKEN_BORDERED,
     payload: payload,

--- a/WebTools/src/state/tokenReducer.ts
+++ b/WebTools/src/state/tokenReducer.ts
@@ -75,39 +75,39 @@ const token = (state: TokenState = { token: initialState }, action) => {
   switch (action.type) {
     case SET_TOKEN_SECONDARY_SPECIES:
     case SET_TOKEN_SPECIES: {
-      let token = state.token;
+      const token = state.token;
       let newSpecies = action.payload.species;
       let skinColor = token.skinColor;
-      let palette = SpeciesRestrictions.getSkinColors(newSpecies);
+      const palette = SpeciesRestrictions.getSkinColors(newSpecies);
       if (palette.indexOf(skinColor) < 0) {
         skinColor = palette[Math.floor(palette.length / 2)];
       }
       let hairColour = token.hairColor;
-      let hairColours = SpeciesRestrictions.getHairColors(newSpecies);
+      const hairColours = SpeciesRestrictions.getHairColors(newSpecies);
       if (hairColours.indexOf(hairColour) < 0) {
         hairColour = hairColours[0];
       }
 
       let hairType = token.hairType;
-      let hairTypes = SpeciesRestrictions.getHairTypes(newSpecies);
+      const hairTypes = SpeciesRestrictions.getHairTypes(newSpecies);
       if (hairTypes.indexOf(hairType) < 0) {
         hairType = SpeciesRestrictions.getDefaultHairType(newSpecies);
       }
 
       let noseType = token.noseType;
-      let noseTypes = SpeciesRestrictions.getNoseTypes(newSpecies);
+      const noseTypes = SpeciesRestrictions.getNoseTypes(newSpecies);
       if (noseTypes.indexOf(noseType) < 0) {
         noseType = noseTypes[0];
       }
 
       let headType = token.headType;
-      let headTypes = SpeciesRestrictions.getHeadTypes(newSpecies);
+      const headTypes = SpeciesRestrictions.getHeadTypes(newSpecies);
       if (headTypes.indexOf(headType) < 0) {
         headType = headTypes[0];
       }
 
       let mouthType = token.mouthType;
-      let mouthTypes = SpeciesRestrictions.getMouthTypes(newSpecies);
+      const mouthTypes = SpeciesRestrictions.getMouthTypes(newSpecies);
       if (mouthTypes.indexOf(mouthType) < 0) {
         mouthType = mouthTypes[0];
       }
@@ -118,18 +118,18 @@ const token = (state: TokenState = { token: initialState }, action) => {
       }
 
       let eyeColor = token.eyeColor;
-      let speciesEyeColours = SpeciesRestrictions.getEyeColors(
+      const speciesEyeColours = SpeciesRestrictions.getEyeColors(
         action.payload.species,
       );
       if (speciesEyeColours.indexOf(eyeColor) < 0) {
         eyeColor = speciesEyeColours[Math.floor(speciesEyeColours.length / 2)];
       }
       let option = token.speciesOption;
-      let options = SpeciesRestrictions.getSpeciesOptions(newSpecies);
+      const options = SpeciesRestrictions.getSpeciesOptions(newSpecies);
       if (options.indexOf(option) < 0) {
         option = SpeciesOption.Option1;
       }
-      let extras = token.extras.filter((e) =>
+      const extras = token.extras.filter((e) =>
         action.type === SET_TOKEN_SECONDARY_SPECIES
           ? SpeciesRestrictions.isExtraAvailableFor(
               e,
@@ -148,15 +148,15 @@ const token = (state: TokenState = { token: initialState }, action) => {
       let uniformEra = token.uniformEra;
       let colour = token.divisionColor;
       let rank = token.rankIndicator;
-      let uniforms = SpeciesRestrictions.getUniformTypes(newSpecies);
+      const uniforms = SpeciesRestrictions.getUniformTypes(newSpecies);
       if (uniforms.indexOf(uniformEra) < 0) {
         uniformEra = uniforms[0];
 
-        let newColourOptions = DivisionColors.getColors(
+        const newColourOptions = DivisionColors.getColors(
           action.payload.era,
           rank,
         );
-        let index = DivisionColors.indexOf(token.uniformEra, colour);
+        const index = DivisionColors.indexOf(token.uniformEra, colour);
         if (index >= 0 && index < newColourOptions.length) {
           colour = newColourOptions[index].color;
         } else {
@@ -170,7 +170,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       }
 
       let variant = token.variant;
-      let variants = UniformVariantRestrictions.getAvailableVariants(
+      const variants = UniformVariantRestrictions.getAvailableVariants(
         uniformEra,
         token.bodyType,
         newSpecies,
@@ -219,13 +219,13 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_UNIFORM_ERA: {
-      let token = state.token;
+      const token = state.token;
       let colour = token.divisionColor;
-      let newColourOptions = DivisionColors.getColors(
+      const newColourOptions = DivisionColors.getColors(
         action.payload.era,
         token.rankIndicator,
       );
-      let index = DivisionColors.indexOf(token.uniformEra, colour);
+      const index = DivisionColors.indexOf(token.uniformEra, colour);
       if (index >= 0 && index < newColourOptions.length) {
         colour = newColourOptions[index].color;
       } else {
@@ -248,7 +248,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
         )[0];
       }
       let variant = token.variant;
-      let variants = UniformVariantRestrictions.getAvailableVariants(
+      const variants = UniformVariantRestrictions.getAvailableVariants(
         action.payload.era,
         bodyType,
         token.species,
@@ -258,7 +258,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       if (variants.indexOf(variant) < 0) {
         variant = UniformVariantType.Base;
       }
-      let extras = token.extras.filter((e) =>
+      const extras = token.extras.filter((e) =>
         SpeciesRestrictions.isExtraAvailableFor(
           e,
           token.species,
@@ -281,9 +281,9 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_DIVISION_COLOR: {
-      let token = state.token;
+      const token = state.token;
       let variant = token.variant;
-      let variants = UniformVariantRestrictions.getAvailableVariants(
+      const variants = UniformVariantRestrictions.getAvailableVariants(
         token.uniformEra,
         token.bodyType,
         token.species,
@@ -304,9 +304,9 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_RANK: {
-      let token = { ...state.token };
-      let variant = token.variant;
-      let variants = UniformVariantRestrictions.getAvailableVariants(
+      const token = { ...state.token };
+      const variant = token.variant;
+      const variants = UniformVariantRestrictions.getAvailableVariants(
         token.uniformEra,
         token.bodyType,
         token.species,
@@ -317,7 +317,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
         token.variant = UniformVariantType.Base;
       }
       token.rankIndicator = action.payload.rank;
-      let colours = DivisionColors.getColors(
+      const colours = DivisionColors.getColors(
         token.uniformEra,
         token.rankIndicator,
       );
@@ -334,7 +334,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_HAIR_TYPE: {
-      let token = state.token;
+      const token = state.token;
       return {
         ...state,
         token: {
@@ -344,7 +344,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_HEAD_TYPE: {
-      let token = state.token;
+      const token = state.token;
       return {
         ...state,
         token: {
@@ -354,7 +354,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_NOSE_TYPE: {
-      let token = state.token;
+      const token = state.token;
       return {
         ...state,
         token: {
@@ -364,7 +364,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_NASO_LABIAL_FOLD_TYPE: {
-      let token = state.token;
+      const token = state.token;
       return {
         ...state,
         token: {
@@ -374,9 +374,9 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_BODY_TYPE: {
-      let token = state.token;
+      const token = state.token;
       let variant = token.variant;
-      let variants = UniformVariantRestrictions.getAvailableVariants(
+      const variants = UniformVariantRestrictions.getAvailableVariants(
         token.uniformEra,
         action.payload.type,
         token.species,
@@ -396,7 +396,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_UNIFORM_VARIANT_TYPE: {
-      let token = state.token;
+      const token = state.token;
       return {
         ...state,
         token: {
@@ -406,7 +406,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_EYE_TYPE: {
-      let token = state.token;
+      const token = state.token;
       return {
         ...state,
         token: {
@@ -416,7 +416,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_MOUTH_TYPE: {
-      let token = state.token;
+      const token = state.token;
       return {
         ...state,
         token: {
@@ -426,7 +426,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_FACIAL_HAIR_TYPE: {
-      let token = state.token;
+      const token = state.token;
       return {
         ...state,
         token: {
@@ -436,7 +436,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_EXTRAS_TYPE: {
-      let token = state.token;
+      const token = state.token;
       return {
         ...state,
         token: {
@@ -446,7 +446,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_EYE_COLOR: {
-      let token = state.token;
+      const token = state.token;
       return {
         ...state,
         token: {
@@ -456,7 +456,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_HAIR_COLOR: {
-      let token = state.token;
+      const token = state.token;
       return {
         ...state,
         token: {
@@ -466,7 +466,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_LIPSTICK_COLOR: {
-      let token = state.token;
+      const token = state.token;
       return {
         ...state,
         token: {
@@ -476,7 +476,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_SKIN_COLOR: {
-      let token = state.token;
+      const token = state.token;
       return {
         ...state,
         token: {
@@ -486,7 +486,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
       };
     }
     case SET_TOKEN_SPECIES_OPTION: {
-      let token = state.token;
+      const token = state.token;
       return {
         ...state,
         token: {
@@ -497,7 +497,7 @@ const token = (state: TokenState = { token: initialState }, action) => {
     }
     case CREATE_NEW_TOKEN: {
       const newToken = action.payload.token;
-      let token: Token = { ...initialState };
+      const token: Token = { ...initialState };
       if (newToken) {
         token.species = newToken.primarySpecies;
         token.secondarySpecies = newToken.secondarySpecies;

--- a/WebTools/src/station/page/stationFinalPage.tsx
+++ b/WebTools/src/station/page/stationFinalPage.tsx
@@ -57,11 +57,11 @@ const StationFinalPage: React.FC<IStationPageProperties> = ({ station }) => {
                   className="w-100"
                   rows={8}
                   onChange={(ev) => {
-                    let temp = ev.target.value.split(',');
+                    const temp = ev.target.value.split(',');
                     store.dispatch(setStationTraits(temp));
                   }}
                   onBlur={(ev) => {
-                    let temp = ev.target.value.split(',');
+                    const temp = ev.target.value.split(',');
                     store.dispatch(setStationTraits(temp));
                   }}
                   value={station.traits}

--- a/WebTools/src/station/page/stationMissionProfileSelectionPage.tsx
+++ b/WebTools/src/station/page/stationMissionProfileSelectionPage.tsx
@@ -43,10 +43,10 @@ const StationMissionProfileSelectionPage: React.FC<IStationPageProperties> = ({
 
   let availableProfiles = MissionProfiles.instance.getStationMissionProfiles();
   if (station?.stationFrameStep instanceof StandardStationSpaceframeStep) {
-    let model = (station.stationFrameStep as StandardStationSpaceframeStep)
+    const model = (station.stationFrameStep as StandardStationSpaceframeStep)
       .model;
     if (model.missionProfiles?.length) {
-      let temp = model.missionProfiles.map((p) => p.profile);
+      const temp = model.missionProfiles.map((p) => p.profile);
       availableProfiles = availableProfiles.filter((p) => temp.includes(p.id));
     }
   }
@@ -77,10 +77,10 @@ const StationMissionProfileSelectionPage: React.FC<IStationPageProperties> = ({
   };
 
   const getTalents = () => {
-    let talents: RankedTalent[] = [];
+    const talents: RankedTalent[] = [];
 
     selectedProfile?.talents?.forEach((t) => {
-      let talent =
+      const talent =
         t instanceof SelectedTalent
           ? (t as SelectedTalent).talentModel
           : (t as TalentModel);

--- a/WebTools/src/station/page/stationSpaceframePage.tsx
+++ b/WebTools/src/station/page/stationSpaceframePage.tsx
@@ -93,7 +93,7 @@ const StationSpaceframePage: React.FC<IStationPageProperties> = ({
   };
 
   const getAppearanceItems = () => {
-    let result = StationFrameAppearanceModel.getAllAppearanceModels().map(
+    const result = StationFrameAppearanceModel.getAllAppearanceModels().map(
       (m) => new DropDownElement(m.id, m.localizedName),
     );
     result.unshift(new DropDownElement('', t('Common.text.select')));
@@ -142,12 +142,12 @@ const StationSpaceframePage: React.FC<IStationPageProperties> = ({
   };
 
   const getSystem = (system: System) => {
-    let result = station.systems[system];
+    const result = station.systems[system];
     return result == null ? 0 : result;
   };
 
   const getDepartment = (department: Department) => {
-    let result = station.departments[department];
+    const result = station.departments[department];
     return result == null ? 0 : result;
   };
 

--- a/WebTools/src/station/page/stationTalentsPage.tsx
+++ b/WebTools/src/station/page/stationTalentsPage.tsx
@@ -66,7 +66,7 @@ const StationTalentsPage: React.FC<IStationPageProperties> = ({ station }) => {
       } else {
         let count = 0;
         temp = temp.filter((t) => {
-          let result =
+          const result =
             t.talent !== rankedTalent.name || count + 1 !== rankedTalent.rank;
           if (t.name === rankedTalent.name) {
             count++;
@@ -108,22 +108,22 @@ const StationTalentsPage: React.FC<IStationPageProperties> = ({ station }) => {
   };
 
   const talentList = () => {
-    let talents = station
+    const talents = station
       ? TalentsHelper.getStarshipOrStationTalents(station, true)
       : [];
 
-    let rankedTalents = [];
+    const rankedTalents = [];
     talents.forEach((t) => {
       if (t.maxRank > 1 || isMultiSelectionTalent(t)) {
-        let initialCount =
+        const initialCount =
           station.baseTalents?.filter((s) => s.talent === t.name)?.length ?? 0;
-        let count =
+        const count =
           station.talents?.filter((s) => s.talent === t.name)?.length ?? 0;
         for (let i = initialCount; i < count + 1; i++) {
           rankedTalents.push(new RankedTalent(t, i + 1));
         }
       } else if (!station.hasBaseTalent(t.name)) {
-        let count =
+        const count =
           station.baseTalents?.filter((s) => s.talent === t.name)?.length ?? 0;
         if (count === 0) {
           rankedTalents.push(new RankedTalent(t));

--- a/WebTools/src/station/view/scaleSelector.tsx
+++ b/WebTools/src/station/view/scaleSelector.tsx
@@ -27,7 +27,7 @@ export const ScaleSelector: React.FC<IScaleSelectorProperties> = ({
           max={25}
           defaultValue={scale.toString()}
           onChange={(e) => {
-            let value = e.target.value;
+            const value = e.target.value;
             onChange(parseInt(value));
           }}
         />

--- a/WebTools/src/station/view/stationProfileView.tsx
+++ b/WebTools/src/station/view/stationProfileView.tsx
@@ -22,8 +22,8 @@ const StationProfileView: React.FC<IStationProfileProperties> = ({
   close,
 }) => {
   const { t } = useTranslation();
-  let station = store.getState().station?.station as Station;
-  let containerClass = showProfile
+  const station = store.getState().station?.station as Station;
+  const containerClass = showProfile
     ? 'sheet-container sheet-container-visible pe-3'
     : 'sheet-container sheet-container-hidden pe-3';
   const eraModel =

--- a/WebTools/src/supportingcharacters/modify/additionalTalentInfo.tsx
+++ b/WebTools/src/supportingcharacters/modify/additionalTalentInfo.tsx
@@ -59,7 +59,7 @@ export const AdditionalTalentInfo: React.FC<
     return (
       <CollaborationDepartmentSelectionView
         onDepartmentSelection={(d) => {
-          let temp = talentSelection.copy();
+          const temp = talentSelection.copy();
           if (temp) {
             temp.department = d;
           }
@@ -74,7 +74,7 @@ export const AdditionalTalentInfo: React.FC<
     return (
       <DefensiveTrainingAttackTypeSelectionView
         onSelection={(a) => {
-          let temp = talentSelection.copy();
+          const temp = talentSelection.copy();
           if (temp) {
             temp.selection = a as AttackType;
           }
@@ -89,7 +89,7 @@ export const AdditionalTalentInfo: React.FC<
     return (
       <AugmentedAbilitySelectionView
         onAttributeSelection={(a) => {
-          let temp = talentSelection.copy();
+          const temp = talentSelection.copy();
           if (temp) {
             temp.attribute = a;
           }
@@ -104,7 +104,7 @@ export const AdditionalTalentInfo: React.FC<
     return (
       <UntappedPotentialSelectionView
         onAttributeSelection={(a) => {
-          let temp = talentSelection.copy();
+          const temp = talentSelection.copy();
           if (temp) {
             temp.attribute = a;
           }
@@ -119,7 +119,7 @@ export const AdditionalTalentInfo: React.FC<
     return (
       <VisitEveryStarSelectionView
         onSelection={(f) => {
-          let temp = talentSelection.copy();
+          const temp = talentSelection.copy();
           if (temp) {
             temp.focuses = f as string[];
           }
@@ -134,7 +134,7 @@ export const AdditionalTalentInfo: React.FC<
     return (
       <ExpandedProgramSelectionView
         onSelection={(f) => {
-          let temp = talentSelection.copy();
+          const temp = talentSelection.copy();
           if (temp) {
             temp.focuses = f as string[];
           }
@@ -148,7 +148,7 @@ export const AdditionalTalentInfo: React.FC<
     return (
       <WarriorsSpiritSelectionView
         onSelection={(w) => {
-          let temp = talentSelection.copy();
+          const temp = talentSelection.copy();
           if (temp) {
             temp.selection = w as SpecialWeapon;
           }
@@ -162,14 +162,14 @@ export const AdditionalTalentInfo: React.FC<
     return (
       <WisdomOfYearsSelectionView
         onFocusSelection={(f) => {
-          let temp = talentSelection.copy();
+          const temp = talentSelection.copy();
           if (temp) {
             temp.focuses = [f];
           }
           setTalentSelection(temp);
         }}
         onValueSelection={(v) => {
-          let temp = talentSelection.copy();
+          const temp = talentSelection.copy();
           if (temp) {
             temp.value = v;
           }
@@ -185,7 +185,7 @@ export const AdditionalTalentInfo: React.FC<
     return (
       <BoldOrCautiousDepartmentSelectionView
         onDepartmentSelection={(d) => {
-          let temp = talentSelection?.copy();
+          const temp = talentSelection?.copy();
           if (temp) {
             temp.department = d;
           }

--- a/WebTools/src/supportingcharacters/modify/modifySupportCharacterPage.tsx
+++ b/WebTools/src/supportingcharacters/modify/modifySupportCharacterPage.tsx
@@ -231,8 +231,8 @@ const ModifySupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
 
   const viewCharacter = () => {
     setTimeout(() => {
-      let c = store.getState().character.currentCharacter;
-      let hash = store.getState().character.replacementHash;
+      const c = store.getState().character.currentCharacter;
+      const hash = store.getState().character.replacementHash;
       store.dispatch(saveCharacterToLocalStorage(c, hash));
       const value = marshaller.encodeSupportingCharacter(c);
       navigate('/view?s=' + value);
@@ -240,7 +240,7 @@ const ModifySupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
   };
 
   const randomValue = () => {
-    let value = randomUniqueValue(
+    const value = randomUniqueValue(
       character?.values ?? [],
       character?.speciesStep?.species,
     );
@@ -250,7 +250,7 @@ const ModifySupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
   const randomFocus = () => {
     let done = false;
     while (!done) {
-      let f = FocusRandomTable();
+      const f = FocusRandomTable();
       if (!character?.focuses?.includes(f)) {
         done = true;
         setFocusSelection(f);

--- a/WebTools/src/supportingcharacters/supportingCharacterAttributes.tsx
+++ b/WebTools/src/supportingcharacters/supportingCharacterAttributes.tsx
@@ -43,8 +43,8 @@ const SupportingCharacterAttributes: React.FC<ICharacterProperties> = ({
   };
 
   const swapAttributeValues = (from: Attribute, to: Attribute) => {
-    let attributeList = [...character.supportingStep?.attributes];
-    let newList = attributeList.map((d) => {
+    const attributeList = [...character.supportingStep?.attributes];
+    const newList = attributeList.map((d) => {
       if (d === from) {
         return to;
       } else if (d === to) {

--- a/WebTools/src/supportingcharacters/supportingCharacterDisciplines.tsx
+++ b/WebTools/src/supportingcharacters/supportingCharacterDisciplines.tsx
@@ -30,8 +30,8 @@ const SupportingCharacterDisciplines: React.FC<ICharacterProperties> = ({
   };
 
   const swapValues = (from: Department, to: Department) => {
-    let disciplineList = [...character.supportingStep?.disciplines];
-    let newList = disciplineList.map((d) => {
+    const disciplineList = [...character.supportingStep?.disciplines];
+    const newList = disciplineList.map((d) => {
       if (d === from) {
         return to;
       } else if (d === to) {

--- a/WebTools/src/supportingcharacters/supportingCharacterPage.tsx
+++ b/WebTools/src/supportingcharacters/supportingCharacterPage.tsx
@@ -79,7 +79,7 @@ const SupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
         ({ CharacterSheetRegistry }) => {
           setLoadingExport(false);
           setTimeout(() => {
-            let c = store.getState().character.currentCharacter;
+            const c = store.getState().character.currentCharacter;
             store.dispatch(saveCharacterToLocalStorage(c));
             CharacterSheetDialog.show(
               CharacterSheetRegistry.getSupportingCharacterSheet(c),
@@ -94,7 +94,7 @@ const SupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
 
   const selectSpecies = (selection: Species) => {
     if (selection !== Species.Custom) {
-      let speciesModel = SpeciesHelper.getSpeciesByType(selection);
+      const speciesModel = SpeciesHelper.getSpeciesByType(selection);
       if (speciesModel.isAttributeSelectionRequired) {
         store.dispatch(setCharacterSpecies(selection));
       } else {
@@ -146,11 +146,11 @@ const SupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
       store.dispatch(setCharacterRank(undefined));
       setShowRank(false);
     } else if (character.type === CharacterType.Cadet) {
-      let rank = RanksHelper.instance().getRank(Rank.CadetFourthClass);
+      const rank = RanksHelper.instance().getRank(Rank.CadetFourthClass);
       store.dispatch(setCharacterRank(rank.name, rank.id));
       setShowRank(true);
     } else {
-      let ranks = RanksHelper.instance().getRanksByType(
+      const ranks = RanksHelper.instance().getRanksByType(
         characterType,
         character.version,
       );
@@ -162,7 +162,7 @@ const SupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
           if (characterType === CharacterType.Starfleet) {
             selectRank(Rank.Ensign);
           } else {
-            let middleRank = ranks[Math.floor(ranks.length / 2)];
+            const middleRank = ranks[Math.floor(ranks.length / 2)];
             selectRank(middleRank.id);
           }
         }
@@ -174,7 +174,7 @@ const SupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
   const selectRandomFocus = (index: number) => {
     let done = false;
     while (!done) {
-      let focus = localizedFocus(
+      const focus = localizedFocus(
         FocusRandomTableWithHints(character.supportingStep?.disciplines[0]),
       );
       if (character.focuses.indexOf(focus) < 0) {
@@ -187,7 +187,7 @@ const SupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
   };
 
   const selectRandomValue = () => {
-    let value = randomUniqueValue(
+    const value = randomUniqueValue(
       character.values,
       character.speciesStep?.species,
       character.supportingStep?.disciplines[0],
@@ -196,7 +196,7 @@ const SupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
   };
 
   useEffect(() => {
-    let character = Character.createSupportingCharacter(
+    const character = Character.createSupportingCharacter(
       store.getState().context.era,
       isSecondEdition() ? 2 : 1,
     );
@@ -204,7 +204,7 @@ const SupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
   }, []);
 
   const getSpeciesList = () => {
-    let speciesList = SpeciesHelper.getSpecies(CharacterType.Starfleet).map(
+    const speciesList = SpeciesHelper.getSpecies(CharacterType.Starfleet).map(
       (s) => {
         return new DropDownElement(s.id, s.localizedName);
       },
@@ -217,7 +217,7 @@ const SupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
   };
 
   const characterAgeAsIndex = () => {
-    let age = character.age;
+    const age = character.age;
     let result = -1;
     AgeHelper.getAllChildAges().forEach((a, i) => {
       if (a.name === age.name) {
@@ -276,7 +276,7 @@ const SupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
     }
   };
 
-  let ageDiv =
+  const ageDiv =
     hasSource(Source.PlayersGuide) && character?.age?.isChild ? (
       <div className="mt-4">
         <div className="page-text-aligned">
@@ -292,7 +292,7 @@ const SupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
       </div>
     ) : null;
 
-  let supervisoryDiv =
+  const supervisoryDiv =
     character &&
     character?.version > 1 &&
     character?.type !== CharacterType.Child ? (

--- a/WebTools/src/table/model/editableTable.ts
+++ b/WebTools/src/table/model/editableTable.ts
@@ -160,7 +160,7 @@ export class EditableTable {
   }
 
   fillGaps() {
-    let values = [
+    const values = [
       1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
     ];
 
@@ -169,14 +169,14 @@ export class EditableTable {
     [...this.rows]
       .filter((r) => r.edited)
       .forEach((r) => {
-        let overlaps = this.rows.filter(
+        const overlaps = this.rows.filter(
           (r2) => !r2.edited && r.overlapsRangeOf(r2),
         );
         overlaps.forEach((r2) => this.rows.splice(this.rows.indexOf(r2), 1));
       });
 
     this.rows.forEach((r) => {
-      let to = r.to == null ? r.from : Math.max(r.from, r.to);
+      const to = r.to == null ? r.from : Math.max(r.from, r.to);
       for (let i = r.from; i <= to; i++) {
         if (values.includes(i)) {
           values.splice(values.indexOf(i), 1);
@@ -184,12 +184,12 @@ export class EditableTable {
       }
     });
 
-    let chunks: number[][] = [];
+    const chunks: number[][] = [];
     values.forEach((v) => {
       if (chunks.length === 0) {
         chunks.push([v]);
       } else {
-        let last = chunks[chunks.length - 1];
+        const last = chunks[chunks.length - 1];
         if (last[last.length - 1] === v - 1) {
           last.push(v);
         } else {
@@ -201,14 +201,14 @@ export class EditableTable {
     chunks.forEach((c) => {
       let existingRow = undefined;
       if (c[c.length - 1] < 20) {
-        let temp = this.rows.filter((r) => r.from === c[c.length - 1] + 1);
+        const temp = this.rows.filter((r) => r.from === c[c.length - 1] + 1);
         if (temp.length) {
           existingRow = temp[0];
         }
       }
 
       if (existingRow != null && !existingRow.edited) {
-        let index = this.rows.indexOf(existingRow);
+        const index = this.rows.indexOf(existingRow);
         this.rows[index] = new EditableTableRow(
           existingRow.result,
           c[0],
@@ -233,17 +233,17 @@ export class EditableTable {
     [...this.rows]
       .filter((r1) => r1.edited)
       .forEach((r1) => {
-        let overlaps = this.rows.filter(
+        const overlaps = this.rows.filter(
           (r2) => !r2.edited && r1.overlapsRangeOf(r2),
         );
         overlaps.forEach((r2) => {
           if (r1.containsRangeOf(r2)) {
             this.rows.splice(this.rows.indexOf(r2), 1);
           } else {
-            let from =
+            const from =
               r2.from >= r1.from && r2.from <= r1.to ? r1.to + 1 : r2.from;
-            let to = r2.to >= r1.from && r2.to <= r1.to ? r1.from - 1 : r2.to;
-            let index = this.rows.indexOf(r2);
+            const to = r2.to >= r1.from && r2.to <= r1.to ? r1.from - 1 : r2.to;
+            const index = this.rows.indexOf(r2);
             this.rows[index] = new EditableTableRow(r2.result, from, to);
           }
         });
@@ -260,7 +260,7 @@ export class EditableTableCollection {
   category?: string;
 
   static from(tableCollection?: TableCollection) {
-    let result = new EditableTableCollection();
+    const result = new EditableTableCollection();
     if (tableCollection != null) {
       result.description = tableCollection.description;
       result.category = tableCollection.category;

--- a/WebTools/src/table/model/table.ts
+++ b/WebTools/src/table/model/table.ts
@@ -40,7 +40,7 @@ export class Table {
   }
 
   public resolveRoll(roll: number) {
-    let results = this.rows.filter((r) =>
+    const results = this.rows.filter((r) =>
       r.to == null ? r.from === roll : r.from <= roll && roll <= r.to,
     );
     return results.length > 0 ? results[0] : undefined;
@@ -71,7 +71,7 @@ export class TableCollection {
 
   public roll: TableRoll<ValueResult[]> = () => {
     const dice = D20.roll();
-    let row = this.mainTable.resolveRoll(dice);
+    const row = this.mainTable.resolveRoll(dice);
     if (row != null) {
       return [row.result];
     } else {

--- a/WebTools/src/table/model/tableMarshaller.ts
+++ b/WebTools/src/table/model/tableMarshaller.ts
@@ -13,7 +13,7 @@ class TableMarshaller {
   }
 
   marshall(tableCollection: TableCollection) {
-    let json = { mainTable: this.marshallTable(tableCollection.mainTable) };
+    const json = { mainTable: this.marshallTable(tableCollection.mainTable) };
     if (tableCollection.uuid) {
       json['uuid'] = tableCollection.uuid;
     }
@@ -27,7 +27,7 @@ class TableMarshaller {
   }
 
   unmarshall(encodedCollection: string) {
-    let json = this.decode(encodedCollection);
+    const json = this.decode(encodedCollection);
 
     if (json['mainTable']) {
       const mainTable = this.unmarshallTable(json['mainTable']);
@@ -48,7 +48,7 @@ class TableMarshaller {
 
   private unmarshallTable(json: any) {
     const name = json['name'];
-    let rows = [];
+    const rows = [];
     if (json['rows']) {
       json.rows
         ?.map((r) => {
@@ -69,8 +69,8 @@ class TableMarshaller {
   decode(s: string) {
     if (s) {
       try {
-        let encoded = Base64.toUint8Array(s);
-        let text = new TextDecoder().decode(pako.inflate(encoded));
+        const encoded = Base64.toUint8Array(s);
+        const text = new TextDecoder().decode(pako.inflate(encoded));
         return JSON.parse(text);
       } catch (e) {
         return undefined;
@@ -81,7 +81,7 @@ class TableMarshaller {
   }
 
   private marshallTable(table: Table) {
-    let json = {};
+    const json = {};
     if (table.name) {
       json['name'] = table.name;
     }
@@ -101,9 +101,9 @@ class TableMarshaller {
   }
 
   private encode(json: any) {
-    let text = JSON.stringify(json);
-    let encoded = pako.deflate(new TextEncoder().encode(text));
-    let result = Base64.fromUint8Array(encoded, true);
+    const text = JSON.stringify(json);
+    const encoded = pako.deflate(new TextEncoder().encode(text));
+    const result = Base64.fromUint8Array(encoded, true);
     return result;
   }
 }

--- a/WebTools/src/table/page/editTablePage.tsx
+++ b/WebTools/src/table/page/editTablePage.tsx
@@ -47,7 +47,7 @@ const EditTablePage: React.FC<IEditTablePageProperties> = ({
   );
 
   const categoryItems = () => {
-    let sorted = categories.sort().map((v, i) => new DropDownElement(i, v));
+    const sorted = categories.sort().map((v, i) => new DropDownElement(i, v));
     sorted.push(new DropDownElement(OTHER, 'Other'));
     sorted.unshift(new DropDownElement(NO_SELECTION, ''));
     return sorted;
@@ -67,19 +67,19 @@ const EditTablePage: React.FC<IEditTablePageProperties> = ({
   };
 
   const selectCategoryValue = (category: string) => {
-    let collection = tableCollection.copy();
+    const collection = tableCollection.copy();
     collection.category = category;
     setTableCollection(collection);
   };
 
   const selectTableName = (name: string) => {
-    let collection = tableCollection.copy();
+    const collection = tableCollection.copy();
     collection.mainTable.name = name;
     setTableCollection(collection);
   };
 
   const selectTableDescription = (description: string) => {
-    let collection = tableCollection.copy();
+    const collection = tableCollection.copy();
     collection.description = description;
     setTableCollection(collection);
   };
@@ -170,7 +170,7 @@ const EditTablePage: React.FC<IEditTablePageProperties> = ({
 
   const isErrorPresent = () => {
     let error = false;
-    let rows = tableCollection.mainTable.rows;
+    const rows = tableCollection.mainTable.rows;
     rows.forEach(
       (r) =>
         (error =

--- a/WebTools/src/table/page/importTablePage.tsx
+++ b/WebTools/src/table/page/importTablePage.tsx
@@ -14,11 +14,11 @@ import {
 const ImportTablePage = () => {
   const navigate = useNavigate();
 
-  let url = new URL(window.location.href);
-  let query = new URLSearchParams(url.search);
-  let encodedTable = query.get('table');
+  const url = new URL(window.location.href);
+  const query = new URLSearchParams(url.search);
+  const encodedTable = query.get('table');
 
-  let collection = TableMarshaller.instance.unmarshall(encodedTable);
+  const collection = TableMarshaller.instance.unmarshall(encodedTable);
 
   if (isTableCollectionAlreadyImported(collection.uuid, encodedTable)) {
     setTimeout(() => {

--- a/WebTools/src/token/model/baseTngEraUniformPack.ts
+++ b/WebTools/src/token/model/baseTngEraUniformPack.ts
@@ -523,7 +523,7 @@ export abstract class BaseTngEraUniformPack extends BaseNeckProvider {
   }
 
   getRankSwatches() {
-    let result = [
+    const result = [
       new Swatch(
         Rank.None,
         'None',

--- a/WebTools/src/token/model/bynarUniformPack.ts
+++ b/WebTools/src/token/model/bynarUniformPack.ts
@@ -88,8 +88,8 @@ export class BynarUniformPack extends BaseNeckProvider implements IUniformPack {
   }
 
   getUniformAndVariantBody(token: TokenModel) {
-    let result = BynarBody;
-    let neck = this.getNeck(
+    const result = BynarBody;
+    const neck = this.getNeck(
       BodyType.AverageFemale,
       token.skinColor,
       token.species,

--- a/WebTools/src/token/model/civilianOutfitUniformPack.ts
+++ b/WebTools/src/token/model/civilianOutfitUniformPack.ts
@@ -1451,7 +1451,7 @@ export class CivilianOutfitUniformPack
   }
 
   getUniformVariantSwatches(token: TokenModel) {
-    let swatches = [];
+    const swatches = [];
     if (token.bodyType === BodyType.AverageMale) {
       swatches.push(
         new Swatch(UniformVariantType.Base, 'Default Outfit', (token) =>

--- a/WebTools/src/token/model/discovery23UniformPack.ts
+++ b/WebTools/src/token/model/discovery23UniformPack.ts
@@ -152,7 +152,7 @@ export class Discovery23UniformPack
   }
 
   getUniformAndVariantBody(token: TokenModel) {
-    let base = this.getUniformAndVariantByBodyType(
+    const base = this.getUniformAndVariantByBodyType(
       token,
       token.variant,
       token.bodyType,
@@ -275,7 +275,7 @@ export class Discovery23UniformPack
   getBorderLogo(token: TokenModel): string {
     let base = borderInsignia.base;
 
-    let division = DivisionColors.getDivision(this.era, token.divisionColor);
+    const division = DivisionColors.getDivision(this.era, token.divisionColor);
     if (division === 'Medical') {
       base = base.replace(DefaultRed, SILVER);
     } else {
@@ -296,7 +296,7 @@ export class Discovery23UniformPack
   }
 
   getBorderColor(token: TokenModel): string {
-    let division = DivisionColors.getDivision(this.era, token.divisionColor);
+    const division = DivisionColors.getDivision(this.era, token.divisionColor);
     if (division === 'Medical') {
       return token.divisionColor;
     } else {
@@ -307,7 +307,7 @@ export class Discovery23UniformPack
   getRankBorderIndicator(token: TokenModel): string {
     let divisionColour = token.divisionColor;
 
-    let division = DivisionColors.getDivision(this.era, token.divisionColor);
+    const division = DivisionColors.getDivision(this.era, token.divisionColor);
     if (division === 'Medical') {
       divisionColour = '#aba7a8';
     }

--- a/WebTools/src/token/model/discovery32UniformPack.ts
+++ b/WebTools/src/token/model/discovery32UniformPack.ts
@@ -271,7 +271,7 @@ export class Discovery32UniformPack
     bodyType: BodyType,
   ) {
     let base = '';
-    let divisionColour = token.divisionColor;
+    const divisionColour = token.divisionColor;
     if (bodyType === BodyType.AverageMale) {
       base = Discovery32CenturyUniform.maleBody;
     } else {
@@ -332,7 +332,7 @@ export class Discovery32UniformPack
   }
 
   getBorderLogo(token: TokenModel): string {
-    let base = borderInsignia.base;
+    const base = borderInsignia.base;
     return base + borderInsignia.shine;
   }
 

--- a/WebTools/src/token/model/divisionColors.ts
+++ b/WebTools/src/token/model/divisionColors.ts
@@ -45,7 +45,7 @@ export class DivisionColors {
     } else if (
       [UniformEra.Discovery32, UniformEra.StarfleetAcademy].includes(era)
     ) {
-      let result = [
+      const result = [
         new NamedColor(i18next.t('Division.command'), '#821217'),
         new NamedColor(i18next.t('Division.science'), '#174b89'),
         new NamedColor(i18next.t('Division.operations'), '#d8a91e'),
@@ -140,11 +140,11 @@ export class DivisionColors {
   }
 
   static getDivision(era: UniformEra, color: string) {
-    let index = this.indexOf(era, color);
+    const index = this.indexOf(era, color);
     if (!this.isDivisionColorsSupported(era)) {
       return null;
     } else if (era === UniformEra.MonsterMaroon) {
-      let colours = [
+      const colours = [
         'Command',
         'Science',
         'HelmEngineering',
@@ -155,13 +155,13 @@ export class DivisionColors {
       ];
       return index >= 0 ? colours[index] : null;
     } else if (era === UniformEra.Discovery23) {
-      let colours = ['Command', 'Science', 'Operations', 'Medical'];
+      const colours = ['Command', 'Science', 'Operations', 'Medical'];
       return index >= 0 ? colours[index] : null;
     } else if (era === UniformEra.Discovery32) {
-      let colours = ['Command', 'Science', 'Operations', 'Medical'];
+      const colours = ['Command', 'Science', 'Operations', 'Medical'];
       return index >= 0 ? colours[index] : null;
     } else if (era === UniformEra.StarfleetAcademy) {
-      let colours = [
+      const colours = [
         'Command',
         'Science',
         'Operations',
@@ -170,7 +170,13 @@ export class DivisionColors {
       ];
       return index >= 0 ? colours[index] : null;
     } else if (era === UniformEra.StrangeNewWorlds) {
-      let colours = ['Command', 'Science', 'Medical', 'Nursing', 'Operations'];
+      const colours = [
+        'Command',
+        'Science',
+        'Medical',
+        'Nursing',
+        'Operations',
+      ];
       return index >= 0 ? colours[index] : null;
     } else {
       return index >= 0 ? Division[index] : null;

--- a/WebTools/src/token/model/enterpriseUniformPack.ts
+++ b/WebTools/src/token/model/enterpriseUniformPack.ts
@@ -738,7 +738,7 @@ export class EnterpriseUniformPack
 
   getUniformAndVariantBody(token: TokenModel) {
     let result = '';
-    let neck = this.getNeck(
+    const neck = this.getNeck(
       token.bodyType,
       token.skinColor,
       token.species,

--- a/WebTools/src/token/model/eyeBrowCatalog.ts
+++ b/WebTools/src/token/model/eyeBrowCatalog.ts
@@ -680,7 +680,7 @@ class EyeBrowCatalog {
   }
 
   getEyeBrows(token: TokenModel) {
-    let result = this.getBrow(
+    const result = this.getBrow(
       token.eyeType,
       token.species,
       token.skinColor,

--- a/WebTools/src/token/model/eyeCatalog.ts
+++ b/WebTools/src/token/model/eyeCatalog.ts
@@ -218,7 +218,7 @@ class EyeCatalog {
   }
 
   getEyes(token: TokenModel) {
-    let result = this.getEyeAndNoseEdge(
+    const result = this.getEyeAndNoseEdge(
       token.eyeType,
       token.species,
       token.skinColor,
@@ -370,7 +370,7 @@ class EyeCatalog {
   }
 
   private static decorateSwatch(eyeType: EyeType, token: TokenModel) {
-    let result =
+    const result =
       `<svg viewBox="0 0 110 110" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <defs>
                     <clipPath id="eyeType` +

--- a/WebTools/src/token/model/facialHairCatalog.ts
+++ b/WebTools/src/token/model/facialHairCatalog.ts
@@ -241,8 +241,8 @@ class FacialHairCatalog {
         let svg = i.svg;
 
         if (i.id === FacialHairType.FiveOclockShadow) {
-          let key = 'Head' + (token.headType + 1);
-          let temp = FiveOclockShadow[key];
+          const key = 'Head' + (token.headType + 1);
+          const temp = FiveOclockShadow[key];
           if (temp) {
             svg = temp;
           }
@@ -285,7 +285,7 @@ class FacialHairCatalog {
   }
 
   getCategoryForType(type: FacialHairType) {
-    let types = this.items.filter((i) => i.id === type);
+    const types = this.items.filter((i) => i.id === type);
     return types?.length
       ? types[0].category
       : FacialHairCategory.MoustacheAndBeard;
@@ -293,7 +293,7 @@ class FacialHairCatalog {
 
   private static decorateSwatch(item: FacialHairItem, token: TokenModel) {
     if (item.category === FacialHairCategory.Moustache) {
-      let result =
+      const result =
         `<svg viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                     <g transform="translate(-255, -140)">` +
         DefaultLip.replace(
@@ -308,7 +308,7 @@ class FacialHairCatalog {
                 </svg>`;
       return result;
     } else if (item.category === FacialHairCategory.Shadow) {
-      let result =
+      const result =
         `<svg viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <g>
                     <g transform="translate(-255, -150)">` +
@@ -325,7 +325,7 @@ class FacialHairCatalog {
                 </svg>`;
       return result;
     } else {
-      let result =
+      const result =
         `<svg viewBox="0 0 150 150" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <defs>
                     <clipPath id="facialHairClipPath` +

--- a/WebTools/src/token/model/ferengiUniformPack.ts
+++ b/WebTools/src/token/model/ferengiUniformPack.ts
@@ -501,8 +501,8 @@ export class FerengiUniformPack
   }
 
   getUniformAndVariantBody(token: TokenModel) {
-    let result = FerengiBody;
-    let neck = this.getNeck(
+    const result = FerengiBody;
+    const neck = this.getNeck(
       BodyType.AverageFemale,
       token.skinColor,
       token.species,

--- a/WebTools/src/token/model/hairCatalog.ts
+++ b/WebTools/src/token/model/hairCatalog.ts
@@ -1087,7 +1087,7 @@ class HairCatalog {
   }
 
   getHair(token: TokenModel, element: HairElement) {
-    let hair = this.items.filter((i) => i.id === token.hairType)[0];
+    const hair = this.items.filter((i) => i.id === token.hairType)[0];
 
     if (
       token.extras.indexOf(ExtraType.SecurityHelmet) >= 0 ||
@@ -1103,7 +1103,7 @@ class HairCatalog {
   }
 
   getSwatches(token: TokenModel) {
-    let hairTypes = SpeciesRestrictions.getHairTypes(token.species);
+    const hairTypes = SpeciesRestrictions.getHairTypes(token.species);
     return this.items
       .filter((i) => hairTypes.indexOf(i.id) >= 0)
       .map(
@@ -1118,7 +1118,7 @@ class HairCatalog {
   }
 
   private static decorateSwatch(hair: HairItem, token: TokenModel) {
-    let result =
+    const result =
       `<svg viewBox="0 0 280 280" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <defs>
                     <clipPath id="hairClipPath` +

--- a/WebTools/src/token/model/headCatalog.ts
+++ b/WebTools/src/token/model/headCatalog.ts
@@ -793,7 +793,7 @@ class HeadCatalog {
   }
 
   static decorateSwatch(svg: string, skinColor: string) {
-    let result =
+    const result =
       `<svg viewBox="0 0 275 275" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <g transform="translate(-135, 10)">` +
       SimpleNeck.replace(

--- a/WebTools/src/token/model/jemHadarUniformPack.ts
+++ b/WebTools/src/token/model/jemHadarUniformPack.ts
@@ -180,7 +180,7 @@ export class JemHadarUniformPack
 
   getUniformAndVariantBody(token: TokenModel) {
     let result = '';
-    let neck = this.getNeck(
+    const neck = this.getNeck(
       BodyType.AverageMale,
       token.skinColor,
       token.species,

--- a/WebTools/src/token/model/klingonArmorUniformPack.ts
+++ b/WebTools/src/token/model/klingonArmorUniformPack.ts
@@ -1319,7 +1319,7 @@ export class KlingonArmorUniformPack
   implements IUniformPack
 {
   getRankIndicator(token: TokenModel) {
-    let borderRank = this.getRankBorderIndicator(token);
+    const borderRank = this.getRankBorderIndicator(token);
     if (
       token.bodyType === BodyType.AverageMale &&
       UniformVariantType.Variant3 === token.variant
@@ -1414,7 +1414,7 @@ export class KlingonArmorUniformPack
 
   getUniformAndVariantBody(token: TokenModel) {
     let result = '';
-    let seam = '';
+    const seam = '';
     let neck = '';
     switch (token.bodyType) {
       case BodyType.AverageMale:

--- a/WebTools/src/token/model/macoUniformPack.ts
+++ b/WebTools/src/token/model/macoUniformPack.ts
@@ -493,7 +493,7 @@ export class MacoUniformPack extends BaseNeckProvider implements IUniformPack {
     if (token.rankIndicator === Rank.None) {
       return '';
     } else {
-      let rank = this.getRankBorderIndicator(token);
+      const rank = this.getRankBorderIndicator(token);
       if (token.bodyType === BodyType.AverageFemale) {
         return (
           MacoUniforms.averageFemaleRankBelowShadow +

--- a/WebTools/src/token/model/monsterMaroonUniformPack.ts
+++ b/WebTools/src/token/model/monsterMaroonUniformPack.ts
@@ -1112,7 +1112,7 @@ export class MonsterMaroonUniformPack
 
   getUniformAndVariantBody(token: TokenModel) {
     let result = '';
-    let neck = this.getNeck(
+    const neck = this.getNeck(
       token.bodyType,
       token.skinColor,
       token.species,
@@ -1156,7 +1156,7 @@ export class MonsterMaroonUniformPack
             : MonsterMaroon.averageFemaleBody;
       }
     }
-    let finalResult = (neck + result)
+    const finalResult = (neck + result)
       .replace(DefaultRed, token.divisionColor)
       .replace(SpeciesRestrictions.DEFAULT_SKIN_COLOR_REGEX, token.skinColor);
     return DivisionColors.getDivision(
@@ -1169,7 +1169,7 @@ export class MonsterMaroonUniformPack
 
   getUniformVariantSwatches(token: TokenModel) {
     if (token.bodyType === BodyType.AverageFemale) {
-      let result = [
+      const result = [
         new Swatch(UniformVariantType.Base, 'Base', (token) =>
           UniformCatalog.decorateSwatch(
             this.getNeck(
@@ -1243,7 +1243,7 @@ export class MonsterMaroonUniformPack
       );
       return result;
     } else if (token.bodyType === BodyType.AverageMale) {
-      let result = [
+      const result = [
         new Swatch(UniformVariantType.Base, 'Base', (token) =>
           UniformCatalog.decorateSwatch(
             this.getNeck(
@@ -1325,7 +1325,7 @@ export class MonsterMaroonUniformPack
       divisionSvg = divisionSvg.replace(/#2d2d2d/g, token.divisionColor);
     }
 
-    let result =
+    const result =
       `<svg viewBox="0 0 300 300" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <defs>
                     <clipPath id="clipPath` +
@@ -1355,7 +1355,7 @@ export class MonsterMaroonUniformPack
     token: TokenModel,
     gradient: string = '',
   ) {
-    let gradientKey = 'rank' + Rank[rankIndicator] + 'Gradient';
+    const gradientKey = 'rank' + Rank[rankIndicator] + 'Gradient';
     return (
       `<svg viewBox="0 0 130 130" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
             <defs>` +

--- a/WebTools/src/token/model/mouthCatalog.ts
+++ b/WebTools/src/token/model/mouthCatalog.ts
@@ -627,7 +627,7 @@ class MouthCatalog {
   }
 
   private static decorateSwatch(mouthType: MouthType, token: TokenModel) {
-    let result =
+    const result =
       `<svg viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <g transform="translate(-255, -140)">` +
       this.getMouthSvg(mouthType, token.species)

--- a/WebTools/src/token/model/nasoLabialFoldCatalog.ts
+++ b/WebTools/src/token/model/nasoLabialFoldCatalog.ts
@@ -102,7 +102,7 @@ class NasoLabialFoldCatalog {
   }
 
   private static decorateSwatch(svg: string) {
-    let result =
+    const result =
       `<svg viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <g transform="translate(-255, -140)">` +
       svg +

--- a/WebTools/src/token/model/noseCatalog.ts
+++ b/WebTools/src/token/model/noseCatalog.ts
@@ -471,7 +471,7 @@ class NoseCatalog {
   }
 
   private static decorateSwatch(svg: string, token: TokenModel) {
-    let result =
+    const result =
       `<svg viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <g transform="translate(-260, -100)">` +
       svg +

--- a/WebTools/src/token/model/picard25thCenturyUniformPack.ts
+++ b/WebTools/src/token/model/picard25thCenturyUniformPack.ts
@@ -278,12 +278,12 @@ export class Picard25thCenturyUniformPack
   }
 
   getRankIndicator(token: TokenModel): string {
-    let result = super.getRankIndicator(token);
+    const result = super.getRankIndicator(token);
     return result.replace(/#fbb03b/g, '#fddfb1');
   }
 
   getRankBorderIndicator(token: TokenModel): string {
-    let result = super.getRankBorderIndicator(token);
+    const result = super.getRankBorderIndicator(token);
     return result.replace(/#fbb03b/g, '#fddfb1');
   }
 }

--- a/WebTools/src/token/model/picardRomulanEvacuationUniformPack.ts
+++ b/WebTools/src/token/model/picardRomulanEvacuationUniformPack.ts
@@ -114,7 +114,7 @@ export class PicardRomulanEvacuationUniformPack
     bodyType: BodyType,
   ) {
     let base = '';
-    let divisionColour = token.divisionColor;
+    const divisionColour = token.divisionColor;
     if (bodyType === BodyType.AverageMale) {
       base = Discovery32CenturyUniform.maleBody;
     } else {
@@ -140,7 +140,7 @@ export class PicardRomulanEvacuationUniformPack
   }
 
   getRankBorderIndicator(token: TokenModel): string {
-    let result = super.getRankBorderIndicator(token);
+    const result = super.getRankBorderIndicator(token);
     return result.replace(/#fbb03b/g, '#fddfb1');
   }
 }

--- a/WebTools/src/token/model/romulanNemesisUniformPack.ts
+++ b/WebTools/src/token/model/romulanNemesisUniformPack.ts
@@ -1581,7 +1581,7 @@ export class RomulanNemesisUniformPack
 
   getUniformAndVariantBody(token: TokenModel) {
     let result = '';
-    let neck = this.getNeck(
+    const neck = this.getNeck(
       token.bodyType,
       token.skinColor,
       token.species,

--- a/WebTools/src/token/model/romulanUniformPack.ts
+++ b/WebTools/src/token/model/romulanUniformPack.ts
@@ -315,7 +315,7 @@ export class RomulanUniformPack
 
   getUniformAndVariantBody(token: TokenModel) {
     let result = '';
-    let neck = this.getNeck(
+    const neck = this.getNeck(
       token.bodyType,
       token.skinColor,
       token.species,

--- a/WebTools/src/token/model/speciesRestrictions.ts
+++ b/WebTools/src/token/model/speciesRestrictions.ts
@@ -299,7 +299,7 @@ class SpeciesRestrictions {
   }
 
   static getDefaultEyeColor(species: Species) {
-    let colours = SpeciesRestrictions.getEyeColors(species);
+    const colours = SpeciesRestrictions.getEyeColors(species);
     return colours[Math.floor(colours.length / 2)];
   }
 
@@ -625,8 +625,8 @@ class SpeciesRestrictions {
   }
 
   static isHumanLikeSkinColouring(species: Species) {
-    let colours = SpeciesRestrictions.getSkinColors(species);
-    let humanSkinColours = SpeciesRestrictions.getSkinColors(Species.Human);
+    const colours = SpeciesRestrictions.getSkinColors(species);
+    const humanSkinColours = SpeciesRestrictions.getSkinColors(Species.Human);
     let result = colours.length === humanSkinColours.length;
     if (result) {
       colours.forEach((c, i) => (result = result && c === humanSkinColours[i]));
@@ -636,8 +636,8 @@ class SpeciesRestrictions {
 
   static isDarkSkinned(species: Species, skinColor: string) {
     if (this.isHumanLikeSkinColouring(species)) {
-      let skinColours = SpeciesRestrictions.getSkinColors(species);
-      let index = skinColours.indexOf(skinColor);
+      const skinColours = SpeciesRestrictions.getSkinColors(species);
+      const index = skinColours.indexOf(skinColor);
       return index >= Math.floor(skinColours.length / 2);
     } else {
       return false;

--- a/WebTools/src/token/model/starfleetAcademyUniformPack.ts
+++ b/WebTools/src/token/model/starfleetAcademyUniformPack.ts
@@ -508,7 +508,7 @@ export class StarfleetAcademyUniformPack
     if (isCadetRank(token.rankIndicator)) {
       return [];
     } else {
-      let variants = [
+      const variants = [
         new Swatch(UniformVariantType.Base, 'Base', (token) =>
           UniformCatalog.decorateSwatch(
             this.getUniformAndVariantByBodyType(
@@ -564,7 +564,7 @@ export class StarfleetAcademyUniformPack
     bodyType: BodyType,
   ) {
     let base = '';
-    let divisionColour = token.divisionColor;
+    const divisionColour = token.divisionColor;
     if (isCadetRank(token.rankIndicator)) {
       if (bodyType === BodyType.AverageMale) {
         base = StarfleetAcademyUniform.maleBodyCadetVariant;

--- a/WebTools/src/token/model/stoUniformPack.ts
+++ b/WebTools/src/token/model/stoUniformPack.ts
@@ -629,7 +629,7 @@ export class StoUniformPack
   }
 
   getUniformAndVariantBody(token: TokenModel) {
-    let division = DivisionColors.getDivision(
+    const division = DivisionColors.getDivision(
       token.uniformEra,
       token.divisionColor,
     );
@@ -822,7 +822,7 @@ export class StoUniformPack
   }
 
   getRankSwatches() {
-    let result = [
+    const result = [
       new Swatch(
         Rank.None,
         'None',
@@ -968,7 +968,7 @@ export class StoUniformPack
   }
 
   getBorderLogo(token: TokenModel): string {
-    let division = DivisionColors.getDivision(
+    const division = DivisionColors.getDivision(
       token.uniformEra,
       token.divisionColor,
     );

--- a/WebTools/src/token/model/strangeNewWorldsUniformPack.ts
+++ b/WebTools/src/token/model/strangeNewWorldsUniformPack.ts
@@ -338,7 +338,7 @@ export class StrangeNewWorldsUniformPack
   }
 
   getUniformAndVariantBody(token: TokenModel) {
-    let division = DivisionColors.getDivision(
+    const division = DivisionColors.getDivision(
       token.uniformEra,
       token.divisionColor,
     );
@@ -478,7 +478,7 @@ export class StrangeNewWorldsUniformPack
       default:
     }
 
-    let finalResult =
+    const finalResult =
       this.getNeck(
         token.bodyType,
         token.skinColor,
@@ -771,12 +771,12 @@ export class StrangeNewWorldsUniformPack
   }
 
   static getRankIndicatorColor(divisionColor: string) {
-    let base = SimpleColor.from(divisionColor);
+    const base = SimpleColor.from(divisionColor);
     return base.isDark ? base.lighten(0.4).asHex() : base.darken(0.25).asHex();
   }
 
   getBorderLogo(token: TokenModel): string {
-    let division = DivisionColors.getDivision(
+    const division = DivisionColors.getDivision(
       token.uniformEra,
       token.divisionColor,
     );

--- a/WebTools/src/token/model/sulibanUniformPack.ts
+++ b/WebTools/src/token/model/sulibanUniformPack.ts
@@ -442,7 +442,7 @@ export class SulibanUniformPack
 
   getUniformAndVariantBody(token: TokenModel) {
     let result = '';
-    let neck = this.getNeck(
+    const neck = this.getNeck(
       token.bodyType,
       token.skinColor,
       token.species,

--- a/WebTools/src/token/model/swatch.ts
+++ b/WebTools/src/token/model/swatch.ts
@@ -23,7 +23,7 @@ class Swatch {
     if (this.localizationKey == null) {
       return this.name;
     } else {
-      let result = i18next.t(this.localizationKey);
+      const result = i18next.t(this.localizationKey);
       return result === this.localizationKey
         ? this.name
         : i18next.t(this.localizationKey);

--- a/WebTools/src/token/model/tokenModel.ts
+++ b/WebTools/src/token/model/tokenModel.ts
@@ -74,7 +74,7 @@ export class TokenModel {
   }
 
   static from(token: Token): TokenModel {
-    let result = new TokenModel();
+    const result = new TokenModel();
     result.primarySpecies = token.species;
     result.secondarySpecies = token.secondarySpecies;
     result.speciesOption = token.speciesOption;
@@ -101,7 +101,7 @@ export class TokenModel {
   }
 
   copy() {
-    let result = new TokenModel();
+    const result = new TokenModel();
 
     result.primarySpecies = this.primarySpecies;
     result.secondarySpecies = this.secondarySpecies;

--- a/WebTools/src/token/model/tosKlingonUniformPack.ts
+++ b/WebTools/src/token/model/tosKlingonUniformPack.ts
@@ -202,7 +202,7 @@ export class TosKlingonUniformPack
 
   getUniformAndVariantBody(token: TokenModel) {
     let result = '';
-    let neck = this.getNeck(
+    const neck = this.getNeck(
       token.bodyType,
       token.skinColor,
       token.species,
@@ -264,7 +264,7 @@ export class TosKlingonUniformPack
   }
 
   getRankIndicator(token: TokenModel) {
-    let borderRank = this.getRankBorderIndicator(token);
+    const borderRank = this.getRankBorderIndicator(token);
     if (token.bodyType === BodyType.AverageMale) {
       if (token.variant === UniformVariantType.Variant1) {
         return (

--- a/WebTools/src/token/model/tosUniformPack.ts
+++ b/WebTools/src/token/model/tosUniformPack.ts
@@ -388,7 +388,7 @@ export class TosUniformPack extends BaseNeckProvider implements IUniformPack {
   }
 
   getUniformAndVariantBody(token: TokenModel) {
-    let division = DivisionColors.getDivision(
+    const division = DivisionColors.getDivision(
       token.uniformEra,
       token.divisionColor,
     );
@@ -485,7 +485,7 @@ export class TosUniformPack extends BaseNeckProvider implements IUniformPack {
   }
 
   getUniformVariantSwatches(token: TokenModel) {
-    let swatches = [];
+    const swatches = [];
     if (token.bodyType === BodyType.AverageMale) {
       swatches.push(
         new Swatch(UniformVariantType.Base, 'Standard Uniform', (token) =>
@@ -752,7 +752,7 @@ export class TosUniformPack extends BaseNeckProvider implements IUniformPack {
   }
 
   getBorderLogo(token: TokenModel): string {
-    let division = DivisionColors.getDivision(
+    const division = DivisionColors.getDivision(
       token.uniformEra,
       token.divisionColor,
     );

--- a/WebTools/src/token/model/uniformCatalog.ts
+++ b/WebTools/src/token/model/uniformCatalog.ts
@@ -27,7 +27,7 @@ class UniformCatalog {
   }
 
   getUniformVariantSwatches(token: TokenModel) {
-    let uniformPack = this.getUniformPack(token.uniformEra);
+    const uniformPack = this.getUniformPack(token.uniformEra);
     if (uniformPack != null) {
       return uniformPack.getUniformVariantSwatches(token);
     } else {
@@ -40,7 +40,7 @@ class UniformCatalog {
   }
 
   static decorateSwatch(svg: string, clipPathId: number, token: TokenModel) {
-    let result =
+    const result =
       `<svg viewBox="0 0 300 300" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <defs>
                     <clipPath id="clipPath` +

--- a/WebTools/src/token/model/uniformEra.ts
+++ b/WebTools/src/token/model/uniformEra.ts
@@ -51,8 +51,8 @@ export class UniformEraModel {
   }
 
   get localizedName() {
-    let key = makeKey('UniformEra.', UniformEra[this.id]);
-    let result = i18next.t(makeKey('UniformEra.', UniformEra[this.id]));
+    const key = makeKey('UniformEra.', UniformEra[this.id]);
+    const result = i18next.t(makeKey('UniformEra.', UniformEra[this.id]));
     return result === key ? this.name : result;
   }
 }

--- a/WebTools/src/token/model/uniformVariantRestrictions.ts
+++ b/WebTools/src/token/model/uniformVariantRestrictions.ts
@@ -18,7 +18,7 @@ export default class UniformVariantRestrictions {
     divisionColor: string,
     rank: Rank,
   ) {
-    let result = [UniformVariantType.Base];
+    const result = [UniformVariantType.Base];
 
     if (uniformEra === UniformEra.MonsterMaroon) {
       if ('Medical' === DivisionColors.getDivision(uniformEra, divisionColor)) {

--- a/WebTools/src/token/tokenCreationPage.tsx
+++ b/WebTools/src/token/tokenCreationPage.tsx
@@ -179,13 +179,13 @@ const TokenCreationPage: React.FC<ITokenCreationPageProperties> = ({
       height: 400,
       svg: TokenSvgBuilder.createSvg(token, rounded, bordered && rounded),
     }).then((png) => {
-      let division = DivisionColors.getDivision(
+      const division = DivisionColors.getDivision(
         token.uniformEra,
         token.divisionColor,
       );
-      let species = SpeciesHelper.getSpeciesByType(token.species);
-      let speciesName = species.name.replace(/[ ()’']/g, '');
-      let name =
+      const species = SpeciesHelper.getSpeciesByType(token.species);
+      const speciesName = species.name.replace(/[ ()’']/g, '');
+      const name =
         'token-' +
         speciesName +
         '-' +
@@ -202,8 +202,8 @@ const TokenCreationPage: React.FC<ITokenCreationPageProperties> = ({
   };
 
   const returnToViewPage = () => {
-    let json = marshaller.decode(marshalledCharacter);
-    let c = marshaller.decodeCharacter(json);
+    const json = marshaller.decode(marshalledCharacter);
+    const c = marshaller.decodeCharacter(json);
     c.token = new TokenConfig(token, rounded, bordered);
     store.dispatch(saveCharacterToLocalStorage(c, replacementHash));
     const value = marshaller.encodeMainCharacter(c);

--- a/WebTools/src/token/view/extrasSelectionView.tsx
+++ b/WebTools/src/token/view/extrasSelectionView.tsx
@@ -24,7 +24,9 @@ const ExtraSelectionView: React.FC<ITokenPageProperties> = ({ token }) => {
   };
 
   const addExtra = (extraType: ExtraType, category: ExtraCategory) => {
-    let current = token.extras.filter((e) => getExtraCategory(e) !== category);
+    const current = token.extras.filter(
+      (e) => getExtraCategory(e) !== category,
+    );
     if (extraType !== ExtraType.None) {
       current.push(extraType);
     }

--- a/WebTools/src/token/view/mouthSelectionView.tsx
+++ b/WebTools/src/token/view/mouthSelectionView.tsx
@@ -86,13 +86,13 @@ const MouthSelectionView: React.FC<ITokenPageProperties> = ({ token }) => {
     type: FacialHairType,
     category: FacialHairCategory,
   ) => {
-    let newTypes = [];
+    const newTypes = [];
     if (type !== FacialHairType.None) {
       category = FacialHairCatalog.instance.getCategoryForType(type);
     }
     token.facialHairType
       .filter((t) => {
-        let p = FacialHairCatalog.instance.getCategoryForType(t);
+        const p = FacialHairCatalog.instance.getCategoryForType(t);
         if (category === FacialHairCategory.MoustacheAndBeard) {
           return p === FacialHairCategory.Shadow;
         } else {
@@ -108,7 +108,7 @@ const MouthSelectionView: React.FC<ITokenPageProperties> = ({ token }) => {
   };
 
   const getShadowType = () => {
-    let type = token.facialHairType.filter(
+    const type = token.facialHairType.filter(
       (f) =>
         FacialHairCatalog.instance.getCategoryForType(f) ===
         FacialHairCategory.Shadow,
@@ -117,7 +117,7 @@ const MouthSelectionView: React.FC<ITokenPageProperties> = ({ token }) => {
   };
 
   const getMoustacheType = () => {
-    let type = token.facialHairType.filter(
+    const type = token.facialHairType.filter(
       (f) =>
         FacialHairCatalog.instance.getCategoryForType(f) ===
         FacialHairCategory.Moustache,
@@ -126,7 +126,7 @@ const MouthSelectionView: React.FC<ITokenPageProperties> = ({ token }) => {
   };
 
   const getBeardTypes = () => {
-    let types = token.facialHairType.filter(
+    const types = token.facialHairType.filter(
       (f) =>
         FacialHairCatalog.instance.getCategoryForType(f) ===
           FacialHairCategory.Beard ||

--- a/WebTools/src/token/view/swatchButton.tsx
+++ b/WebTools/src/token/view/swatchButton.tsx
@@ -21,7 +21,7 @@ class SwatchButton extends React.Component<ISwatchButtonProperties, {}> {
     if (svg instanceof String || typeof svg === 'string') {
       svgContents = svg as string;
     } else {
-      let s = svg as (token: TokenModel) => string;
+      const s = svg as (token: TokenModel) => string;
       svgContents = s(token);
     }
     return (

--- a/WebTools/src/token/view/uniformSelectionView.tsx
+++ b/WebTools/src/token/view/uniformSelectionView.tsx
@@ -71,7 +71,7 @@ const UniformSelectionView: React.FC<IUniformSelectionViewProperties> = ({
   };
 
   const uniformErasList = () => {
-    let uniformTypes = SpeciesRestrictions.getUniformTypes(token.species);
+    const uniformTypes = SpeciesRestrictions.getUniformTypes(token.species);
     return UniformEraHelper.instance.types
       .filter((u) => uniformTypes.indexOf(u.id) >= 0)
       .map((u) => new DropDownElement(u.id, u.localizedName));

--- a/WebTools/src/tracker/addCharacterView.tsx
+++ b/WebTools/src/tracker/addCharacterView.tsx
@@ -61,11 +61,11 @@ class AddCharacterView extends React.Component<
     if (urlString) {
       const { t } = this.props;
       try {
-        let url = new URL(urlString);
-        let query = new URLSearchParams(url.search);
-        let encodedSheet = query.get('s');
+        const url = new URL(urlString);
+        const query = new URLSearchParams(url.search);
+        const encodedSheet = query.get('s');
 
-        let json = marshaller.decode(encodedSheet);
+        const json = marshaller.decode(encodedSheet);
         if (json == null) {
           this.setState((state) => ({
             ...state,
@@ -85,7 +85,7 @@ class AddCharacterView extends React.Component<
             characterString: undefined,
           }));
         } else {
-          let character = marshaller.decodeCharacter(json);
+          const character = marshaller.decodeCharacter(json);
           this.setState((state) => ({
             ...state,
             enabled: true,
@@ -113,9 +113,9 @@ class AddCharacterView extends React.Component<
   }
 
   addCharacter() {
-    let json = marshaller.decode(this.state.characterString);
+    const json = marshaller.decode(this.state.characterString);
     if (json) {
-      let character = marshaller.decodeCharacter(json);
+      const character = marshaller.decodeCharacter(json);
       store.dispatch(addGMTrackedCharacter(character));
       this.props.onDone();
     } else {

--- a/WebTools/src/tracker/gmCharacterView.tsx
+++ b/WebTools/src/tracker/gmCharacterView.tsx
@@ -23,7 +23,7 @@ const GMCharacterView: React.FC<IGMCharacterViewProperties> = ({
   tracking,
 }) => {
   const { t } = useTranslation();
-  let character = tracking.character;
+  const character = tracking.character;
 
   const renderJob = () => {
     let result = '';
@@ -34,9 +34,9 @@ const GMCharacterView: React.FC<IGMCharacterViewProperties> = ({
   };
 
   const renderStress = () => {
-    let stress = tracking?.character?.stress;
+    const stress = tracking?.character?.stress;
     if (character.isStressTrackPresent && stress) {
-      let iterator = [];
+      const iterator = [];
       for (let i = 1; i <= stress; i++) {
         iterator.push(i);
       }
@@ -64,7 +64,7 @@ const GMCharacterView: React.FC<IGMCharacterViewProperties> = ({
         </div>
       );
     } else if (character.isPersonalThreatTrackPresent) {
-      let iterator = [];
+      const iterator = [];
       for (let i = 1; i <= character.personalThreat; i++) {
         iterator.push(i);
       }

--- a/WebTools/src/view/focusBlockView.tsx
+++ b/WebTools/src/view/focusBlockView.tsx
@@ -3,7 +3,7 @@ import { localizedFocus } from '../components/focusHelper';
 
 const FocusBlockView: React.FC<ICharacterPageProperties> = ({ character }) => {
   if (character.focuses) {
-    let result = character.focuses.map((f, i) => (
+    const result = character.focuses.map((f, i) => (
       <div className="text-white view-border-bottom py-2" key={'focus-' + i}>
         {localizedFocus(f)}
       </div>

--- a/WebTools/src/view/mainCharacterView.tsx
+++ b/WebTools/src/view/mainCharacterView.tsx
@@ -231,7 +231,7 @@ const MainCharacterView: React.FC<ICharacterViewProperties> = ({
 
   function renderPastimes() {
     if (character.pastime) {
-      let result = character.pastime.map((p, i) => (
+      const result = character.pastime.map((p, i) => (
         <div
           className="text-white view-border-bottom py-2"
           key={'pastime-' + i}

--- a/WebTools/src/view/originalEncodedSheet.ts
+++ b/WebTools/src/view/originalEncodedSheet.ts
@@ -1,6 +1,6 @@
 export const originalEncodedSheet = () => {
-  let url = new URL(window.location.href);
-  let query = new URLSearchParams(url.search);
-  let encodedSheet = query.get('s');
+  const url = new URL(window.location.href);
+  const query = new URLSearchParams(url.search);
+  const encodedSheet = query.get('s');
   return encodedSheet;
 };

--- a/WebTools/src/view/starshipView.tsx
+++ b/WebTools/src/view/starshipView.tsx
@@ -41,12 +41,12 @@ const StarshipView: React.FC<IStarshipViewProperties> = ({ starship }) => {
   });
 
   const refitAsString = () => {
-    let refitString = starship.refitsAsString();
+    const refitString = starship.refitsAsString();
     return refitString === '' ? NBSP : refitString;
   };
 
   const getAllTraits = () => {
-    let traits = starship.getAllTraits();
+    const traits = starship.getAllTraits();
     return traits === '' ? NBSP : traits;
   };
 
@@ -55,10 +55,10 @@ const StarshipView: React.FC<IStarshipViewProperties> = ({ starship }) => {
   };
 
   const renderShields = () => {
-    let shield = starship.shields;
+    const shield = starship.shields;
     if (shield) {
-      let iterator = [];
-      let iterator2 = [];
+      const iterator = [];
+      const iterator2 = [];
       for (let i = 1; i <= Math.max(30, Math.ceil(shield / 10) * 10); i++) {
         if (i % 10 > 5 || i % 10 === 0) {
           iterator2.push(i);

--- a/WebTools/src/view/stationView.tsx
+++ b/WebTools/src/view/stationView.tsx
@@ -34,10 +34,10 @@ const StationView: React.FC<IStationViewProperties> = ({ station }) => {
   });
 
   const renderShields = () => {
-    let shield = station.shields;
+    const shield = station.shields;
     if (shield) {
-      let iterator = [];
-      let iterator2 = [];
+      const iterator = [];
+      const iterator2 = [];
       for (let i = 1; i <= Math.max(30, Math.ceil(shield / 10) * 10); i++) {
         if (i % 10 > 5 || i % 10 === 0) {
           iterator2.push(i);

--- a/WebTools/src/view/stressOrShieldsView.tsx
+++ b/WebTools/src/view/stressOrShieldsView.tsx
@@ -8,7 +8,7 @@ const StressOrShieldsView: React.FC<IStressOrShieldsViewProperties> = ({
   rows = 4,
 }) => {
   if (value) {
-    let iterator = [];
+    const iterator = [];
     for (let i = 1; i <= Math.max(rows * 5, Math.ceil(value / 5) * 5); i++) {
       iterator.push(i);
     }

--- a/WebTools/src/view/talentsBlockView.tsx
+++ b/WebTools/src/view/talentsBlockView.tsx
@@ -96,8 +96,8 @@ const TalentsBlockView: React.FC<IConstructPageProperties> = ({
         TALENT_NAME_EXTRAORDINARY_ATTRIBUTE_X,
       ].includes(talent.name)
     ) {
-      let character = construct as Character;
-      let selectedAttributes = character.talents
+      const character = construct as Character;
+      const selectedAttributes = character.talents
         .filter((s) => s.talent === talent.name && s.attribute != null)
         .map((s) => t(makeKey('Construct.attribute.', Attribute[s.attribute])))
         .join(', ');
@@ -115,8 +115,8 @@ const TalentsBlockView: React.FC<IConstructPageProperties> = ({
         TALENT_NAME_IM_A_DOCTOR_NOT_A,
       ].includes(talent.name)
     ) {
-      let character = construct as Character;
-      let selectedAttributes = character.talents
+      const character = construct as Character;
+      const selectedAttributes = character.talents
         .filter((s) => s.talent === talent.name && s.department != null)
         .map((s) =>
           t(makeKey('Construct.discipline.', Department[s.department])),
@@ -131,8 +131,8 @@ const TalentsBlockView: React.FC<IConstructPageProperties> = ({
     } else if (
       [TALENT_NAME_ADDITIONAL_PROPULSION_SYSTEM].includes(talent.name)
     ) {
-      let starship = construct as Starship;
-      let propulsion = starship.talents
+      const starship = construct as Starship;
+      const propulsion = starship.talents
         .filter((s) => s.talent === talent.name && s.selection != null)
         .map(
           (s) =>
@@ -142,8 +142,8 @@ const TalentsBlockView: React.FC<IConstructPageProperties> = ({
         .join(', ');
       return <div className="text-sm px-4">{propulsion}</div>;
     } else if ([TALENT_NAME_EXPANDED_MUNITIONS].includes(talent.name)) {
-      let starship = construct as Starship;
-      let propulsion = starship.talents
+      const starship = construct as Starship;
+      const propulsion = starship.talents
         .filter((s) => s.talent === talent.name && s.weapon != null)
         .map((s) =>
           s.weapon instanceof Weapon
@@ -163,8 +163,8 @@ const TalentsBlockView: React.FC<IConstructPageProperties> = ({
         TALENT_NAME_EXPANSIVE_DEPARTMENT,
       ].includes(talent.name)
     ) {
-      let starship = construct as Starship;
-      let selectedAttributes = starship.talents
+      const starship = construct as Starship;
+      const selectedAttributes = starship.talents
         .filter((s) => s.talent === talent.name && s.department != null)
         .map((s) =>
           t(makeKey('Construct.department.', Department[s.department])),
@@ -177,8 +177,8 @@ const TalentsBlockView: React.FC<IConstructPageProperties> = ({
         </div>
       );
     } else if ([TALENT_NAME_REDUNDANT_SYSTEMS].includes(talent.name)) {
-      let starship = construct as Starship;
-      let selectedAttributes = starship.talents
+      const starship = construct as Starship;
+      const selectedAttributes = starship.talents
         .filter((s) => s.talent === talent.name && s.system != null)
         .map((s) => t(makeKey('Construct.system.', System[s.system])))
         .join(', ');
@@ -195,8 +195,8 @@ const TalentsBlockView: React.FC<IConstructPageProperties> = ({
         'Upgraded Systems (Service Record)',
       ].includes(talent.name)
     ) {
-      let starship = construct as Starship;
-      let selectedAttributes = starship.talents
+      const starship = construct as Starship;
+      const selectedAttributes = starship.talents
         .filter((s) => s.talent === talent.name && s.system != null)
         .map((s) => t(makeKey('Construct.system.', System[s.system])))
         .join(', ');
@@ -213,8 +213,8 @@ const TalentsBlockView: React.FC<IConstructPageProperties> = ({
 
   const renderStarshipTalents = (construct: Station | Starship) => {
     const talents = construct?.rankedTalents.map((selectedTalent, i) => {
-      let t = selectedTalent.talentModel;
-      let name = selectedTalent.displayNameWithMultiple;
+      const t = selectedTalent.talentModel;
+      const name = selectedTalent.displayNameWithMultiple;
       let description = undefined;
       if (selectedTalent.isCustom) {
         description = selectedTalent.customTalentDescription;
@@ -252,14 +252,14 @@ const TalentsBlockView: React.FC<IConstructPageProperties> = ({
     const specialRules = construct
       ?.getDistinctTalentNameList()
       .map((tName, i) => {
-        let t = TalentsHelper.getTalent(tName);
+        const t = TalentsHelper.getTalent(tName);
         let name = t.localizedName;
-        let starship = construct as Starship;
-        let qualifier = starship.getQualifierForTalent(tName);
+        const starship = construct as Starship;
+        const qualifier = starship.getQualifierForTalent(tName);
         if (qualifier?.length) {
           name += ' [' + qualifier + ']';
         }
-        let talentName =
+        const talentName =
           name +
           (t.maxRank > 1
             ? ' [x' + construct.getRankForTalent(t.name) + ']'
@@ -326,11 +326,11 @@ const TalentsBlockView: React.FC<IConstructPageProperties> = ({
         </Header>
         {(construct as Character)?.rankedTalents.map((s, i) => {
           let x = undefined;
-          let t = s.talentModel;
+          const t = s.talentModel;
           if (t.isXQualified) {
             x = s.x;
           }
-          let talentName = s.displayNameWithMultiple;
+          const talentName = s.displayNameWithMultiple;
           return (
             <div
               className="text-white view-border-bottom py-2"

--- a/WebTools/src/view/viewSheetPage.tsx
+++ b/WebTools/src/view/viewSheetPage.tsx
@@ -50,14 +50,14 @@ const ViewSheetPage = () => {
 
   const renderContents = () => {
     const encodedSheet = originalEncodedSheet();
-    let json = marshaller.decode(encodedSheet);
+    const json = marshaller.decode(encodedSheet);
 
     if (!json) {
       return (
         <div className="page text-white">{t('ViewPage.errorMessage')}</div>
       );
     } else if (json.stereotype === 'asset') {
-      let asset = marshaller.decodeAsset(encodedSheet);
+      const asset = marshaller.decodeAsset(encodedSheet);
       modifyTitleForAsset(asset);
       return (
         <div className="page container ms-0">
@@ -77,7 +77,7 @@ const ViewSheetPage = () => {
         </div>
       );
     } else if (json.stereotype === 'creature') {
-      let creature = marshaller.decodeCreature(json);
+      const creature = marshaller.decodeCreature(json);
       modifyTitle(creature);
       return (
         <div className="page container ms-0">
@@ -97,7 +97,7 @@ const ViewSheetPage = () => {
         </div>
       );
     } else if (json.stereotype === 'starship' || json.stereotype === 'simple') {
-      let starship = marshaller.decodeStarship(encodedSheet);
+      const starship = marshaller.decodeStarship(encodedSheet);
       modifyTitle(starship);
       return (
         <div className="page container ms-0">
@@ -117,7 +117,7 @@ const ViewSheetPage = () => {
         </div>
       );
     } else if (json.stereotype === 'supportingCharacter') {
-      let character = marshaller.decodeCharacter(json);
+      const character = marshaller.decodeCharacter(json);
       modifyTitle(character);
       return (
         <div className="page container ms-0">
@@ -137,7 +137,7 @@ const ViewSheetPage = () => {
         </div>
       );
     } else if (json.stereotype === 'npc') {
-      let character = marshaller.decodeCharacter(json);
+      const character = marshaller.decodeCharacter(json);
       modifyTitle(character);
       return (
         <div className="page container ms-0">
@@ -155,7 +155,7 @@ const ViewSheetPage = () => {
         </div>
       );
     } else if (json.stereotype === 'mainCharacter') {
-      let character = marshaller.decodeCharacter(json);
+      const character = marshaller.decodeCharacter(json);
       modifyTitle(character);
       return (
         <div className="page container ms-0">
@@ -173,7 +173,7 @@ const ViewSheetPage = () => {
         </div>
       );
     } else if (json.stereotype === 'station') {
-      let station = marshaller.decodeStation(json);
+      const station = marshaller.decodeStation(json);
       modifyTitle(station);
       return (
         <div className="page container ms-0">
@@ -191,7 +191,7 @@ const ViewSheetPage = () => {
         </div>
       );
     } else if (json.stereotype === 'soloCharacter') {
-      let character = marshaller.decodeCharacter(json);
+      const character = marshaller.decodeCharacter(json);
       modifyTitle(character);
       return (
         <div className="page container ms-0">

--- a/WebTools/src/view/weaponBlockView.tsx
+++ b/WebTools/src/view/weaponBlockView.tsx
@@ -13,8 +13,8 @@ const WeaponBlockView: React.FC<IWeaponBlockViewProperties> = ({
   const { t } = useTranslation();
 
   if (construct.determineWeapons().length) {
-    let weapons = construct.determineWeapons().map((w, i) => {
-      let dice = construct.getDiceForWeapon(w);
+    const weapons = construct.determineWeapons().map((w, i) => {
+      const dice = construct.getDiceForWeapon(w);
       return (
         <WeaponView
           key={'weapon-' + i}

--- a/WebTools/src/vtt/fantasyGroundsVttExport.ts
+++ b/WebTools/src/vtt/fantasyGroundsVttExport.ts
@@ -26,7 +26,7 @@ export class FantasyGroupsVttExporter {
   }
 
   private exportNpc(character: Character) {
-    let characterNode = {
+    const characterNode = {
       type: 'element',
       name: 'npc',
       elements: [
@@ -157,7 +157,7 @@ export class FantasyGroupsVttExporter {
   }
 
   private exportMainCharacter(character: Character) {
-    let characterNode = {
+    const characterNode = {
       type: 'element',
       name: 'character',
       elements: [
@@ -458,7 +458,7 @@ export class FantasyGroupsVttExporter {
   nodesToXml(characterNode: any) {
     characterNode.elements = characterNode.elements.filter((e) => e != null);
 
-    let result = {
+    const result = {
       declaration: { attributes: { version: '1.0', encoding: 'utf-8' } },
       elements: [
         {
@@ -479,7 +479,7 @@ export class FantasyGroupsVttExporter {
 
   convertCharacterDescription(character: Character) {
     if (character.description?.length) {
-      let paragraphs = character.description
+      const paragraphs = character.description
         .split('\n')
         .filter((s) => s?.length)
         .map((s) => {
@@ -508,7 +508,7 @@ export class FantasyGroupsVttExporter {
   }
 
   convertUpbringingLink(character: Character) {
-    let implementedUpbringings = [
+    const implementedUpbringings = [
       EarlyOutlook.MilitaryOrExploration,
       EarlyOutlook.BusinessOrTrade,
       EarlyOutlook.AgricultureOrRural,
@@ -613,15 +613,15 @@ export class FantasyGroupsVttExporter {
   }
 
   convertWeaponsAndEquipment(character: Character) {
-    let equipment = this.convertEquipment(character);
-    let weapons = this.convertWeapons(character, equipment.length);
+    const equipment = this.convertEquipment(character);
+    const weapons = this.convertWeapons(character, equipment.length);
     return equipment.concat(weapons);
   }
 
   convertNpcWeapons(character: Character, start: number = 0) {
-    let result = [];
+    const result = [];
     character.determineWeapons().forEach((w, i) => {
-      let weapon = {
+      const weapon = {
         name: this.createNumberedId(start + i + 1),
         type: 'element',
         elements: [
@@ -761,9 +761,9 @@ export class FantasyGroupsVttExporter {
   }
 
   convertWeapons(character: Character, start: number = 0) {
-    let result = [];
+    const result = [];
     character.determineWeapons().forEach((w, i) => {
-      let weapon = {
+      const weapon = {
         name: this.createNumberedId(start + i + 1),
         type: 'element',
         elements: [
@@ -971,7 +971,7 @@ export class FantasyGroupsVttExporter {
 
   convertWeaponAttributes(tagName: string, attributes: WeaponQuality[]) {
     let index = 1;
-    let result = {
+    const result = {
       name: tagName,
       type: 'element',
       elements: [],
@@ -1016,15 +1016,15 @@ export class FantasyGroupsVttExporter {
   }
 
   convertDisciplines(character: Character) {
-    let result = {
+    const result = {
       name: 'disciplines',
       type: 'element',
       elements: [],
     };
 
     DepartmentsHelper.instance.getDepartments().forEach((d) => {
-      let name = Department[d].toLowerCase();
-      let discipline = {
+      const name = Department[d].toLowerCase();
+      const discipline = {
         name: name,
         type: 'element',
         elements: [
@@ -1141,7 +1141,7 @@ export class FantasyGroupsVttExporter {
   }
 
   convertCareer(character: Character) {
-    let career =
+    const career =
       character.careerStep?.career != null
         ? CareersHelper.instance.getCareer(
             character.careerStep.career,
@@ -1169,7 +1169,7 @@ export class FantasyGroupsVttExporter {
   }
 
   convertUpbringing(character: Character) {
-    let upbringing = character.upbringingStep?.upbringing;
+    const upbringing = character.upbringingStep?.upbringing;
     if (upbringing) {
       return {
         name: 'upbringing',
@@ -1190,7 +1190,7 @@ export class FantasyGroupsVttExporter {
   }
 
   convertTraining(character: Character) {
-    let training = character.educationStep?.track
+    const training = character.educationStep?.track
       ? TracksHelper.instance.getTrack(
           character.educationStep?.track,
           character.type,
@@ -1217,7 +1217,7 @@ export class FantasyGroupsVttExporter {
   }
 
   convertEnvironment(character: Character) {
-    let environment = character.environmentStep
+    const environment = character.environmentStep
       ? CharacterSerializer.serializeEnvironment(
           character.environmentStep.environment,
           character.environmentStep.otherSpecies,
@@ -1245,7 +1245,7 @@ export class FantasyGroupsVttExporter {
 
   convertRank(character: Character) {
     if (character.rank != null && character.type === CharacterType.Starfleet) {
-      let rank = RanksHelper.instance().getRankByName(character.rank.name);
+      const rank = RanksHelper.instance().getRankByName(character.rank.name);
       if (rank) {
         let rankNumber = undefined;
         switch (rank.id) {
@@ -1302,15 +1302,15 @@ export class FantasyGroupsVttExporter {
   }
 
   convertAttributes(character: Character) {
-    let result = {
+    const result = {
       name: 'attributes',
       type: 'element',
       elements: [],
     };
 
     AttributesHelper.getAllAttributes().forEach((a) => {
-      let name = Attribute[a].toLowerCase();
-      let attribute = {
+      const name = Attribute[a].toLowerCase();
+      const attribute = {
         name: name,
         type: 'element',
         elements: [
@@ -1490,7 +1490,7 @@ export class FantasyGroupsVttExporter {
 
   convertNotes(character: Character) {
     let index = 1;
-    let result = {
+    const result = {
       name: 'notes',
       type: 'element',
       elements: [],
@@ -1641,7 +1641,7 @@ export class FantasyGroupsVttExporter {
 
   convertCareerEvents(character: Character) {
     if (character.careerEvents?.length) {
-      let result = {
+      const result = {
         name: 'careerevent',
         type: 'element',
         elements: [],
@@ -1649,13 +1649,13 @@ export class FantasyGroupsVttExporter {
 
       let index = 1;
       character.careerEvents.forEach((e) => {
-        let event = CareerEventsHelper.getCareerEvent(
+        const event = CareerEventsHelper.getCareerEvent(
           e.id,
           character.type,
           character.version,
         );
         if (event) {
-          let key = this.createNumberedId(index++);
+          const key = this.createNumberedId(index++);
           result.elements.push({
             name: key,
             type: 'element',
@@ -1827,7 +1827,7 @@ export class FantasyGroupsVttExporter {
   }
 
   convertEquipment(character: Character, start: number = 0) {
-    let result = [];
+    const result = [];
 
     character.equipmentAndImplants?.forEach((e, i) => {
       result.push({
@@ -1959,7 +1959,7 @@ export class FantasyGroupsVttExporter {
   }
 
   convertToFormattedText(tagName: string, header: string, paragraphs: string) {
-    let result = {
+    const result = {
       name: tagName,
       attributes: {
         type: 'formattedtext',
@@ -1982,8 +1982,8 @@ export class FantasyGroupsVttExporter {
     }
 
     paragraphs?.split('\n')?.forEach((p) => {
-      let tokens = textTokenizer(p);
-      let parents = [
+      const tokens = textTokenizer(p);
+      const parents = [
         {
           type: 'element',
           name: 'p',
@@ -1997,8 +1997,8 @@ export class FantasyGroupsVttExporter {
           if (parents.length && parents[parents.length - 1].name === 'b') {
             parents.pop();
           } else {
-            let parent = parents[parents.length - 1];
-            let element = {
+            const parent = parents[parents.length - 1];
+            const element = {
               type: 'element',
               name: 'b',
               elements: [],
@@ -2010,8 +2010,8 @@ export class FantasyGroupsVttExporter {
           if (parents.length && parents[parents.length - 1].name === 'i') {
             parents.pop();
           } else {
-            let parent = parents[parents.length - 1];
-            let element = {
+            const parent = parents[parents.length - 1];
+            const element = {
               type: 'element',
               name: 'i',
               elements: [],
@@ -2020,7 +2020,7 @@ export class FantasyGroupsVttExporter {
             parents.push(element);
           }
         } else {
-          let parent = parents[parents.length - 1];
+          const parent = parents[parents.length - 1];
           parent.elements.push({
             type: 'text',
             text: t,
@@ -2034,14 +2034,14 @@ export class FantasyGroupsVttExporter {
 
   convertNpcTalents(character: Character) {
     let index = 1;
-    let result = {
+    const result = {
       name: 'specialrules',
       type: 'element',
       elements: [],
     };
 
     character.rankedTalents.forEach((selectedTalent) => {
-      let talent = selectedTalent.talentModel;
+      const talent = selectedTalent.talentModel;
       if (talent) {
         let name = selectedTalent.displayName;
         if (talent.maxRank > 1) {
@@ -2089,14 +2089,14 @@ export class FantasyGroupsVttExporter {
 
   convertTalents(character: Character) {
     let index = 1;
-    let result = {
+    const result = {
       name: 'talent',
       type: 'element',
       elements: [],
     };
 
     character.rankedTalents.forEach((s) => {
-      let talent = s.talentModel;
+      const talent = s.talentModel;
       if (talent) {
         result.elements.push({
           name: this.createNumberedId(index++),

--- a/WebTools/src/vtt/foundryVttExporter.ts
+++ b/WebTools/src/vtt/foundryVttExporter.ts
@@ -54,9 +54,9 @@ export class FoundryVttExporter {
   }
 
   exportStarship(starship: Starship, type: FoundryPluginType) {
-    let now = Date.now();
+    const now = Date.now();
 
-    let result = {
+    const result = {
       name: starship.name || 'Unnamed Starship',
       type:
         type === FoundryPluginType.Standard && starship.isSmallCraft
@@ -109,7 +109,7 @@ export class FoundryVttExporter {
     };
 
     DepartmentsHelper.instance.getDepartments().forEach((d) => {
-      let name = Department[d].toLowerCase();
+      const name = Department[d].toLowerCase();
       result.system.departments[name] = {
         label: 'sta.actor.starship.department.' + name,
         value: '' + starship.departments[d],
@@ -262,9 +262,9 @@ export class FoundryVttExporter {
   }
 
   exportStation(station: Station, type: FoundryPluginType) {
-    let now = Date.now();
+    const now = Date.now();
 
-    let result = {
+    const result = {
       name: station.name || 'Unnamed Station',
       type: 'starship',
       img: 'systems/sta/assets/icons/VoyagerCombadgeIcon.png',
@@ -314,7 +314,7 @@ export class FoundryVttExporter {
     };
 
     DepartmentsHelper.instance.getDepartments().forEach((d) => {
-      let name = Department[d].toLowerCase();
+      const name = Department[d].toLowerCase();
       result.system.departments[name] = {
         label: 'sta.actor.starship.department.' + name,
         value: '' + station.departments[d],
@@ -571,8 +571,8 @@ export class FoundryVttExporter {
   }
 
   exportCharacter(character: Character, type: FoundryPluginType) {
-    let now = Date.now();
-    let result = {
+    const now = Date.now();
+    const result = {
       name: character.name || 'Unnamed Character',
       type: 'character',
       img: 'icons/svg/mystery-man.svg',
@@ -638,7 +638,7 @@ export class FoundryVttExporter {
     };
 
     DepartmentsHelper.instance.getDepartments().forEach((d) => {
-      let name = Department[d].toLowerCase();
+      const name = Department[d].toLowerCase();
       result.system.disciplines[name] = {
         label: 'sta.actor.character.discipline.' + name,
         value: '' + character.departments[d],
@@ -647,7 +647,7 @@ export class FoundryVttExporter {
     });
 
     AttributesHelper.getAllAttributes().forEach((a) => {
-      let name = Attribute[a].toLowerCase();
+      const name = Attribute[a].toLowerCase();
       result.system.attributes[name] = {
         label: 'sta.actor.character.attribute.' + name,
         value: '' + character.attributes[a],
@@ -766,7 +766,7 @@ export class FoundryVttExporter {
     }
 
     character.equipmentAndImplants?.forEach((e) => {
-      let item = {
+      const item = {
         name: e.name,
         type: e instanceof EquipmentModel && e.isArmour ? 'armor' : 'item',
         img: this.determineItemIcon(e.name),
@@ -801,7 +801,7 @@ export class FoundryVttExporter {
     });
 
     if (character.role != null) {
-      let role = RolesHelper.instance.getRoleModelByName(
+      const role = RolesHelper.instance.getRoleModelByName(
         character.role,
         character.type,
       );
@@ -838,9 +838,9 @@ export class FoundryVttExporter {
       }
     }
 
-    let talents = character.rankedTalents;
+    const talents = character.rankedTalents;
     talents.forEach((s) => {
-      let talent = s.talentModel;
+      const talent = s.talentModel;
       if (talent) {
         result.items.push({
           name: s.displayNameWithMultiple,
@@ -971,7 +971,7 @@ export class FoundryVttExporter {
   convertCharacterDescription(character: Character) {
     let result = '';
     if (character.description?.length) {
-      let paragraphs = character.description
+      const paragraphs = character.description
         .split('\n')
         .filter((s) => s?.length);
       paragraphs.forEach((p) => {
@@ -1263,7 +1263,8 @@ export class FoundryVttExporter {
             );
     }
 
-    let prerequisites = talent instanceof TalentModel ? talent.requirement : '';
+    const prerequisites =
+      talent instanceof TalentModel ? talent.requirement : '';
     return (
       markupToHtml(description) +
       (prerequisites ? '<p><strong>' + prerequisites + '</strong></p>' : '')

--- a/WebTools/src/vtt/markupToHtml.ts
+++ b/WebTools/src/vtt/markupToHtml.ts
@@ -6,7 +6,7 @@ export const markupToHtml = (description: string) => {
     : description
         .split('\n')
         .map((d) => {
-          let parts = textTokenizer(d);
+          const parts = textTokenizer(d);
           let result = '<p>';
           let style = '';
           parts.forEach((p) => {

--- a/WebTools/src/vtt/roll20VttExporter.ts
+++ b/WebTools/src/vtt/roll20VttExporter.ts
@@ -71,10 +71,10 @@ class IdHelper {
   }
 
   private incrementId(id: string) {
-    let base = id.substring(0, id.length - 1);
-    let lastDigit = id.substring(id.length - 1).toLocaleLowerCase();
+    const base = id.substring(0, id.length - 1);
+    const lastDigit = id.substring(id.length - 1).toLocaleLowerCase();
 
-    let index = IdHelper.ID_PARTS.indexOf(lastDigit);
+    const index = IdHelper.ID_PARTS.indexOf(lastDigit);
     if (index >= IdHelper.ID_PARTS.length - 1) {
       return this.incrementId(base) + IdHelper.ID_PARTS[0];
     } else {
@@ -94,9 +94,9 @@ export class Roll20VttExporter {
   }
 
   exportStarship(starship: Starship) {
-    let id = new IdHelper();
-    let name = starship.name || 'Unnamed Starship';
-    let result: IRoll20Json = {
+    const id = new IdHelper();
+    const name = starship.name || 'Unnamed Starship';
+    const result: IRoll20Json = {
       schema_version: 3,
       type: 'character',
       character: {
@@ -263,7 +263,7 @@ export class Roll20VttExporter {
   }
 
   exportStarshipAsHandout(starship: Starship) {
-    let starshipClass = starship.className ?? '';
+    const starshipClass = starship.className ?? '';
     let name =
       starship.name?.length > 0
         ? starship.name
@@ -275,7 +275,7 @@ export class Roll20VttExporter {
       name += ', ' + starship.registry;
     }
 
-    let result = {
+    const result = {
       schema_version: 3,
       type: 'handout',
       handout: {
@@ -296,7 +296,7 @@ export class Roll20VttExporter {
   createStarshipNotes(starship: Starship) {
     let result = '';
 
-    let description = starship.spaceframeModel?.localizedDescription;
+    const description = starship.spaceframeModel?.localizedDescription;
     if (description) {
       description
         .split('\n')
@@ -395,7 +395,7 @@ export class Roll20VttExporter {
 
       result += '</ul>\n';
     }
-    let talents = starship
+    const talents = starship
       .getDistinctTalentNameList()
       .map((t) => TalentsHelper.getTalent(t))
       .filter((t) => t != null && !t.isSpecialRule(starship.version));
@@ -406,7 +406,7 @@ export class Roll20VttExporter {
         '</strong></p>\n<ul>\n';
 
       talents.forEach((t) => {
-        let qualifier = starship.getQualifierForTalent(t.name);
+        const qualifier = starship.getQualifierForTalent(t.name);
         result +=
           '<li><p><b>' +
           t.localizedName +
@@ -422,7 +422,7 @@ export class Roll20VttExporter {
       result += '</ul>\n';
     }
 
-    let specialRules = starship
+    const specialRules = starship
       .getDistinctTalentNameList()
       .map((t) => TalentsHelper.getTalent(t))
       .filter((t) => t != null && t.isSpecialRule(starship.version));
@@ -433,7 +433,7 @@ export class Roll20VttExporter {
         '</strong></p>\n<ul>\n';
 
       specialRules.forEach((t) => {
-        let qualifier = starship.getQualifierForTalent(t.name);
+        const qualifier = starship.getQualifierForTalent(t.name);
         result +=
           '<li><p><b>' +
           t.localizedName +
@@ -452,12 +452,12 @@ export class Roll20VttExporter {
   }
 
   exportCharacter(character: Character) {
-    let id = new IdHelper();
+    const id = new IdHelper();
     let name = character.name || 'Unnamed Character';
     if (character.pronouns) {
       name += ' (' + character.pronouns + ')';
     }
-    let result: IRoll20Json = {
+    const result: IRoll20Json = {
       schema_version: 3,
       type: 'character',
       character: {
@@ -612,7 +612,7 @@ export class Roll20VttExporter {
       ),
     );
     character.implants.forEach((e) => {
-      let implant = BorgImplants.instance.getImplantByType(e);
+      const implant = BorgImplants.instance.getImplantByType(e);
       Array.prototype.push.apply(
         result.character.attribs,
         this.convertEquipment(character, implant, id),
@@ -623,7 +623,7 @@ export class Roll20VttExporter {
       result.character.attribs.push(...this.convertTalent(character, t, id));
     });
 
-    let traits = [...character.baseTraits];
+    const traits = [...character.baseTraits];
     character.additionalTraits
       .split(',')
       .map((t) => t.trim())
@@ -635,7 +635,7 @@ export class Roll20VttExporter {
       if (i === 0) {
         // species trait
         if (character.speciesStep?.species !== Species.Custom) {
-          let species = SpeciesHelper.getSpeciesByType(
+          const species = SpeciesHelper.getSpeciesByType(
             character?.speciesStep?.species,
           );
           description = species.localizedTraitDescription;
@@ -915,7 +915,7 @@ export class Roll20VttExporter {
     id: IdHelper,
   ) {
     const rowId = id.nextId();
-    let result = [
+    const result = [
       {
         name: 'repeating_equipmentks_' + rowId + '_equipment_name',
         current: equipment.name,
@@ -957,12 +957,12 @@ export class Roll20VttExporter {
   ) {
     const rowId = id.nextId();
 
-    let talent = selectedTalent.talentModel;
-    let category = this.determineCategoryType(talent);
+    const talent = selectedTalent.talentModel;
+    const category = this.determineCategoryType(talent);
 
     let name = selectedTalent.displayNameWithMultiple;
 
-    let qualifier = starship.getQualifierForTalent(talent.name);
+    const qualifier = starship.getQualifierForTalent(talent.name);
     if (qualifier?.length) {
       name += ': ' + qualifier;
     }
@@ -1012,10 +1012,10 @@ export class Roll20VttExporter {
   ) {
     const rowId = id.nextId();
 
-    let talent = selectedTalent.talentModel;
-    let category = this.determineCategoryType(talent);
+    const talent = selectedTalent.talentModel;
+    const category = this.determineCategoryType(talent);
 
-    let name = selectedTalent.displayNameWithMultiple;
+    const name = selectedTalent.displayNameWithMultiple;
 
     return [
       {
@@ -1168,7 +1168,7 @@ export class Roll20VttExporter {
     description?: string,
   ) {
     const rowId = id.nextId();
-    let result = [
+    const result = [
       {
         name: 'repeating_traits_' + rowId + '_trait_name',
         current: trait,
@@ -1195,7 +1195,7 @@ export class Roll20VttExporter {
 
   convertStarshipTrait(starship: Starship, trait: string, id: IdHelper) {
     const rowId = id.nextId();
-    let result = [
+    const result = [
       {
         name: 'repeating_straits_' + rowId + '_strait_name',
         current: trait,

--- a/WebTools/src/vtt/view/VttSelectionDialog.tsx
+++ b/WebTools/src/vtt/view/VttSelectionDialog.tsx
@@ -35,7 +35,7 @@ export const VttSelectionModal: React.FC<IVttSelectionModalProperties> = ({
   );
 
   useEffect(() => {
-    let dataJson = window.localStorage.getItem('settings.vttOptions');
+    const dataJson = window.localStorage.getItem('settings.vttOptions');
     let data = {};
     try {
       data = dataJson ? JSON.parse(dataJson) : {};
@@ -43,11 +43,11 @@ export const VttSelectionModal: React.FC<IVttSelectionModalProperties> = ({
       // ignore
     }
 
-    let type = VttTypes.instance.getTypeByTypeName(data['vttType'])?.type;
+    const type = VttTypes.instance.getTypeByTypeName(data['vttType'])?.type;
     if (type != null) {
       setVttType(type);
     }
-    let pluginType = data['foundryPluginType'] ?? FoundryPluginType.Standard;
+    const pluginType = data['foundryPluginType'] ?? FoundryPluginType.Standard;
     setFoundryPluginType(pluginType);
   }, []);
 
@@ -105,7 +105,7 @@ export const VttSelectionModal: React.FC<IVttSelectionModalProperties> = ({
     if (p == null) {
       p = foundryPluginType;
     }
-    let newState = {
+    const newState = {
       vttType: t,
       foundryPluginType: p,
     };
@@ -208,7 +208,7 @@ export const VttSelectionModal: React.FC<IVttSelectionModalProperties> = ({
   };
 
   const persistVtt = (state: IVttSelectionState) => {
-    let data = {
+    const data = {
       vttType: VttType[state.vttType],
     };
     if (state.foundryPluginType != null) {

--- a/WebTools/src/vtt/vttType.ts
+++ b/WebTools/src/vtt/vttType.ts
@@ -35,7 +35,7 @@ export class VttTypes {
   }
 
   getTypeByTypeName(name: string) {
-    let results = this.types.filter((t) => VttType[t.type] === name);
+    const results = this.types.filter((t) => VttType[t.type] === name);
     return results.length === 1 ? results[0] : null;
   }
 }

--- a/WebTools/tests/creature/model/creatureNameGenerator.test.ts
+++ b/WebTools/tests/creature/model/creatureNameGenerator.test.ts
@@ -3,7 +3,7 @@ import { creatureNameGenerator } from '../../../src/creature/model/creatureNameG
 
 describe('test name generation', () => {
   test('should generate a name', () => {
-    let name = creatureNameGenerator();
+    const name = creatureNameGenerator();
 
     expect(name?.length).toBeGreaterThan(0);
   });

--- a/WebTools/tests/exportpdf/paragraph.test.ts
+++ b/WebTools/tests/exportpdf/paragraph.test.ts
@@ -11,7 +11,7 @@ describe('testing line functions', () => {
   test('should append block', async () => {
     const pdf = await PDFDocument.create();
     const helvetica = await pdf.embedFont(StandardFonts.Helvetica);
-    let line = new Line(
+    const line = new Line(
       new XYLocation(0, 0),
       pdf.getPage(0),
       new Column(0, 0, 500, 100),
@@ -30,7 +30,7 @@ describe('testing line functions', () => {
   test('should not append different block (colour)', async () => {
     const pdf = await PDFDocument.create();
     const helvetica = await pdf.embedFont(StandardFonts.Helvetica);
-    let line = new Line(
+    const line = new Line(
       new XYLocation(0, 0),
       pdf.getPage(0),
       new Column(0, 0, 500, 100),
@@ -54,7 +54,7 @@ describe('testing line functions', () => {
   test('should not append different block (font size)', async () => {
     const pdf = await PDFDocument.create();
     const helvetica = await pdf.embedFont(StandardFonts.Helvetica);
-    let line = new Line(
+    const line = new Line(
       new XYLocation(0, 0),
       pdf.getPage(0),
       new Column(0, 0, 500, 100),

--- a/WebTools/tests/exportpdf/textTokenizer.test.ts
+++ b/WebTools/tests/exportpdf/textTokenizer.test.ts
@@ -3,7 +3,7 @@ import { textTokenizer } from '../../src/exportpdf/textTokenizer';
 
 describe('test text tokenization', () => {
   test('should handle standard case', () => {
-    let tokens = textTokenizer('very basic case');
+    const tokens = textTokenizer('very basic case');
     expect(tokens.length).toEqual(1);
   });
 
@@ -19,17 +19,17 @@ describe('test text tokenization', () => {
   });
 
   test('should find bold markup', () => {
-    let tokens = textTokenizer('very basic **case**');
+    const tokens = textTokenizer('very basic **case**');
     expect(tokens.length).toEqual(4);
   });
 
   test('should find italic markup', () => {
-    let tokens = textTokenizer('very basic _case_ here');
+    const tokens = textTokenizer('very basic _case_ here');
     expect(tokens.length).toEqual(5);
   });
 
   test('should find mixed markup', () => {
-    let tokens = textTokenizer(
+    const tokens = textTokenizer(
       'very basic _case_ here, but also with **some** bolding going on',
     );
     expect(tokens.length).toEqual(9);

--- a/WebTools/tests/helpers/eras.test.ts
+++ b/WebTools/tests/helpers/eras.test.ts
@@ -4,10 +4,10 @@ import { Era } from '../../src/helpers/erasEnum';
 
 describe('testing era helper', () => {
   test('should find era by name', () => {
-    let era = Eras.instance.getEraByName('NextGeneration');
+    const era = Eras.instance.getEraByName('NextGeneration');
     expect(era).toBe(Era.NextGeneration);
 
-    let era2 = Eras.instance.getEraByName('Enterprise');
+    const era2 = Eras.instance.getEraByName('Enterprise');
     expect(era2).toBe(Era.Enterprise);
   });
 });

--- a/WebTools/tests/helpers/weapons.test.ts
+++ b/WebTools/tests/helpers/weapons.test.ts
@@ -8,31 +8,31 @@ import {
 
 describe('testing weapons', () => {
   test('should find 1e weapons', () => {
-    let strike = PersonalWeapons.instance(1).unarmedStrike;
+    const strike = PersonalWeapons.instance(1).unarmedStrike;
     expect(strike.dice).toBe(1);
 
-    let phaser1 = PersonalWeapons.instance(1).phaser1;
+    const phaser1 = PersonalWeapons.instance(1).phaser1;
     expect(phaser1.dice).toBe(2);
   });
 
   test('should find 2e weapons', () => {
-    let strike = PersonalWeapons.instance(2).unarmedStrike;
+    const strike = PersonalWeapons.instance(2).unarmedStrike;
     expect(strike.dice).toBe(2);
 
-    let phaser1 = PersonalWeapons.instance(2).phaser1;
+    const phaser1 = PersonalWeapons.instance(2).phaser1;
     expect(phaser1.dice).toBe(3);
   });
 
   test('ushaan-tor has correct base damage per edition', () => {
-    let v1 = PersonalWeapons.instance(1).ushaanTor;
+    const v1 = PersonalWeapons.instance(1).ushaanTor;
     expect(v1.dice).toBe(2);
 
-    let v2 = PersonalWeapons.instance(2).ushaanTor;
+    const v2 = PersonalWeapons.instance(2).ushaanTor;
     expect(v2.dice).toBe(3);
   });
 
   test('2e quantum torpedo has Intense instead of Vicious (#303)', () => {
-    let v1 = TorpedoLoadTypeModel.getTorpedoLoadTypeModelByType(
+    const v1 = TorpedoLoadTypeModel.getTorpedoLoadTypeModelByType(
       TorpedoLoadType.Quantum,
       1,
     );
@@ -40,7 +40,7 @@ describe('testing weapons', () => {
       v1.effectAndQualities.some((q) => q.quality === Quality.Vicious),
     ).toBeTruthy();
 
-    let v2 = TorpedoLoadTypeModel.getTorpedoLoadTypeModelByType(
+    const v2 = TorpedoLoadTypeModel.getTorpedoLoadTypeModelByType(
       TorpedoLoadType.Quantum,
       2,
     );

--- a/WebTools/tests/starship/model/randomStarshipEvent.test.ts
+++ b/WebTools/tests/starship/model/randomStarshipEvent.test.ts
@@ -8,10 +8,10 @@ class MockSpaceframe implements IServiceYearProvider {
 
 describe('testing event selector', () => {
   test('should produce event', () => {
-    let model = new MockSpaceframe();
+    const model = new MockSpaceframe();
 
     for (let i = 0; i < 20; i++) {
-      let event = randomStarshipEvent(model, 2385);
+      const event = randomStarshipEvent(model, 2385);
       expect(event).toBeDefined();
     }
   });

--- a/WebTools/tests/starship/model/starshipNameTable.test.ts
+++ b/WebTools/tests/starship/model/starshipNameTable.test.ts
@@ -8,7 +8,7 @@ import { Spaceframe } from '../../../src/helpers/spaceframeEnum';
 describe('testing name generator', () => {
   test('should produce name', () => {
     for (let i = 0; i < 100; i++) {
-      let name = StarshipRandomNameTable(
+      const name = StarshipRandomNameTable(
         Era.NextGeneration,
         RandomStarshipCharacterType.Starfleet,
         CharacterType.Starfleet,

--- a/WebTools/tests/table/model/editableTable.test.ts
+++ b/WebTools/tests/table/model/editableTable.test.ts
@@ -7,7 +7,7 @@ import { ValueResult } from '../../../src/table/model/table';
 
 describe('testing tables', () => {
   test('should sort rows (standard)', () => {
-    let table = new EditableTable();
+    const table = new EditableTable();
     table.rows.push(new EditableTableRow(new ValueResult('a', 'b'), 5, 6));
     table.rows.push(new EditableTableRow(new ValueResult('c', 'd'), 1, 2));
     table.rows.push(new EditableTableRow(new ValueResult('e', 'f'), 3, 3));
@@ -21,19 +21,19 @@ describe('testing tables', () => {
   });
 
   test('detect contained rows', () => {
-    let row1 = new EditableTableRow(new ValueResult('', ''), 1, 8);
-    let row2 = new EditableTableRow(new ValueResult('', ''), 4, 8);
-    let row3 = new EditableTableRow(new ValueResult('', ''), 9, 15);
+    const row1 = new EditableTableRow(new ValueResult('', ''), 1, 8);
+    const row2 = new EditableTableRow(new ValueResult('', ''), 4, 8);
+    const row3 = new EditableTableRow(new ValueResult('', ''), 9, 15);
 
     expect(row1.containsRangeOf(row2)).toBeTruthy();
     expect(row1.containsRangeOf(row3)).toBeFalsy();
   });
 
   test('detect overlapped rows', () => {
-    let row1 = new EditableTableRow(new ValueResult('', ''), 2, 8);
-    let row2 = new EditableTableRow(new ValueResult('', ''), 4, 10);
-    let row3 = new EditableTableRow(new ValueResult('', ''), 1, 3);
-    let row4 = new EditableTableRow(new ValueResult('', ''), 4, 8);
+    const row1 = new EditableTableRow(new ValueResult('', ''), 2, 8);
+    const row2 = new EditableTableRow(new ValueResult('', ''), 4, 10);
+    const row3 = new EditableTableRow(new ValueResult('', ''), 1, 3);
+    const row4 = new EditableTableRow(new ValueResult('', ''), 4, 8);
 
     expect(row1.overlapsRangeOf(row2)).toBeTruthy();
     expect(row1.overlapsRangeOf(row3)).toBeTruthy();
@@ -42,10 +42,10 @@ describe('testing tables', () => {
   });
 
   test('detect overlapped starts', () => {
-    let row1 = new EditableTableRow(new ValueResult('', ''), 2, 8);
-    let row2 = new EditableTableRow(new ValueResult('', ''), 4, 10);
-    let row3 = new EditableTableRow(new ValueResult('', ''), 1, 3);
-    let row4 = new EditableTableRow(new ValueResult('', ''), 4, 8);
+    const row1 = new EditableTableRow(new ValueResult('', ''), 2, 8);
+    const row2 = new EditableTableRow(new ValueResult('', ''), 4, 10);
+    const row3 = new EditableTableRow(new ValueResult('', ''), 1, 3);
+    const row4 = new EditableTableRow(new ValueResult('', ''), 4, 8);
 
     expect(row1.overlapsStartOf(row2)).toBeTruthy();
     expect(row1.overlapsStartOf(row3)).toBeFalsy();
@@ -54,10 +54,10 @@ describe('testing tables', () => {
   });
 
   test('detect overlapped ends', () => {
-    let row1 = new EditableTableRow(new ValueResult('', ''), 2, 8);
-    let row2 = new EditableTableRow(new ValueResult('', ''), 4, 10);
-    let row3 = new EditableTableRow(new ValueResult('', ''), 1, 3);
-    let row4 = new EditableTableRow(new ValueResult('', ''), 4, 8);
+    const row1 = new EditableTableRow(new ValueResult('', ''), 2, 8);
+    const row2 = new EditableTableRow(new ValueResult('', ''), 4, 10);
+    const row3 = new EditableTableRow(new ValueResult('', ''), 1, 3);
+    const row4 = new EditableTableRow(new ValueResult('', ''), 4, 8);
 
     expect(row1.overlapsEndOf(row2)).toBeFalsy();
     expect(row1.overlapsEndOf(row3)).toBeTruthy();
@@ -66,7 +66,7 @@ describe('testing tables', () => {
   });
 
   test('should fill gaps in table', () => {
-    let table = EditableTable.from();
+    const table = EditableTable.from();
     expect(table.rows.length).toBe(4);
 
     const row1 = table.rows[0];
@@ -80,7 +80,7 @@ describe('testing tables', () => {
   });
 
   test('should remove overlapped row', () => {
-    let table = EditableTable.from();
+    const table = EditableTable.from();
     expect(table.rows.length).toBe(4);
 
     const row1 = table.rows[0];


### PR DESCRIPTION
Convert all var declarations to let/const via ESLint autofix and enforce the no-var and prefer-const rules (part of #438).

- Adds no-var and prefer-const as errors to eslintConfig
- Converts all remaining var declarations to let/const
- Converts let declarations never reassigned to const
- Loop-closure sites reviewed: no for loops capture the loop variable, so the conversion is behavior-preserving
- Re-runs Prettier on the 25 files the autofix left unformatted

Verification: full_check.sh passes (58 suites / 322 tests, tsc --noEmit, eslint on src and tests, prettier:check).