### PR TITLE
Rename non-component functions to camelCase (part of #438)

### DIFF
--- a/WebTools/src/common/extensions.ts
+++ b/WebTools/src/common/extensions.ts
@@ -1,6 +1,6 @@
-export function CopyObject(target: {}, ...sources: Array<{}>) {
+export function copyObject(target: {}, ...sources: Array<{}>) {
   if (target === undefined || target === null) {
-    throw new TypeError('CopyObject failed due to inconsistent cast.');
+    throw new TypeError('copyObject failed due to inconsistent cast.');
   }
 
   const to = Object(target);

--- a/WebTools/src/components/focusSelectionView.tsx
+++ b/WebTools/src/components/focusSelectionView.tsx
@@ -5,8 +5,8 @@ import { Department } from '../helpers/department';
 import D20IconButton from '../solo/component/d20IconButton';
 import { localizedFocus } from './focusHelper';
 import {
-  FocusRandomTable,
-  FocusRandomTableWithHints,
+  focusRandomTable,
+  focusRandomTableWithHints,
 } from '../solo/table/focusRandomTable';
 import { useTranslation } from 'react-i18next';
 
@@ -41,9 +41,9 @@ export const FocusSelectionView: React.FC<IFocusSelectionProperties> = ({
       const focus =
         hints != null
           ? localizedFocus(
-              FocusRandomTableWithHints(randomFocusDepartment, hints),
+              focusRandomTableWithHints(randomFocusDepartment, hints),
             )
-          : localizedFocus(FocusRandomTable(randomFocusDepartment));
+          : localizedFocus(focusRandomTable(randomFocusDepartment));
       if (character.focuses.indexOf(focus) < 0) {
         done = true;
         addFocus(focus);

--- a/WebTools/src/components/speciesAbilityView.tsx
+++ b/WebTools/src/components/speciesAbilityView.tsx
@@ -7,7 +7,7 @@ import { InputFieldAndLabel } from '../common/inputFieldAndLabel';
 import store from '../state/store';
 import D20IconButton from '../solo/component/d20IconButton';
 import { localizedFocus } from './focusHelper';
-import { FocusRandomTableWithHints } from '../solo/table/focusRandomTable';
+import { focusRandomTableWithHints } from '../solo/table/focusRandomTable';
 import { setCharacterSpeciesAbilityFocus } from '../state/characterActions';
 import { Department } from '../helpers/department';
 import { hasSource } from '../state/contextFunctions';
@@ -31,7 +31,7 @@ export const SpeciesAbilityView: React.FC<ISpeciesAbilityProperties> = ({
   const selectRandomFocus = (index: number) => {
     let done = false;
     while (!done) {
-      const focus = localizedFocus(FocusRandomTableWithHints(skill));
+      const focus = localizedFocus(focusRandomTableWithHints(skill));
       if (character.focuses.indexOf(focus) < 0) {
         done = true;
         store.dispatch(setCharacterSpeciesAbilityFocus(focus, index));

--- a/WebTools/src/creature/model/creatureGenerator.ts
+++ b/WebTools/src/creature/model/creatureGenerator.ts
@@ -33,7 +33,7 @@ import { generateRandomLocomotionType } from './locomotion';
 import { generateRandomNaturalAttacks } from './naturalAttacks';
 import { Attribute } from '../../helpers/attributes';
 
-export const CreatureGenerator = async (
+export const creatureGenerator = async (
   era: Era,
   habitat?: Habitat,
   creatureType?: CreatureType,

--- a/WebTools/src/creature/page/randomCreatureConfigurationPage.tsx
+++ b/WebTools/src/creature/page/randomCreatureConfigurationPage.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../components/dropDownInput';
 import { Habitat, HabitatHelper } from '../model/habitat';
 import { useEffect, useState } from 'react';
-import { CreatureGenerator } from '../model/creatureGenerator';
+import { creatureGenerator } from '../model/creatureGenerator';
 import { connect } from 'react-redux';
 import { Era } from '../../helpers/erasEnum';
 import { marshaller } from '../../helpers/marshaller';
@@ -78,7 +78,7 @@ const RandomCreatureConfigurationPage: React.FC<
 
   const createCreature = async () => {
     setLoading(true);
-    const creature = await CreatureGenerator(
+    const creature = await creatureGenerator(
       era,
       habitat,
       creatureType,

--- a/WebTools/src/pages/careerLengthPage.tsx
+++ b/WebTools/src/pages/careerLengthPage.tsx
@@ -15,7 +15,7 @@ import { Window } from '../common/window';
 import SoloCharacterBreadcrumbs from '../solo/component/soloCharacterBreadcrumbs';
 import { Header } from '../components/header';
 import InstructionText from '../components/instructionText';
-import { CareerLengthRandomTable } from '../solo/table/careerLengthRandomTable';
+import { careerLengthRandomTable } from '../solo/table/careerLengthRandomTable';
 import { Stereotype } from '../common/construct';
 import CharacterCreationBreadcrumbs from '../components/characterCreationBreadcrumbs';
 import { CharacterType } from '../common/characterType';
@@ -68,7 +68,7 @@ const CareerLengthPage: React.FC<ICharacterProperties> = ({ character }) => {
     if (character.hasTalent(ADVANCED_TEAM_DYNAMICS)) {
       return D20.roll() <= 10 ? Career.Experienced : Career.Veteran;
     } else {
-      return CareerLengthRandomTable();
+      return careerLengthRandomTable();
     }
   };
 

--- a/WebTools/src/pages/earlyOutlookPage.tsx
+++ b/WebTools/src/pages/earlyOutlookPage.tsx
@@ -22,9 +22,9 @@ import { Department } from '../helpers/department';
 import { Window } from '../common/window';
 import { AttributesHelper } from '../helpers/attributes';
 import {
-  EarlyOutlookAspirationRandomTable,
-  EarlyOutlookCasteRandomTable,
-  EarlyOutlookUpbringingRandomTable,
+  earlyOutlookAspirationRandomTable,
+  earlyOutlookCasteRandomTable,
+  earlyOutlookUpbringingRandomTable,
 } from '../solo/table/earlyOutlookRandomTable';
 import { connect } from 'react-redux';
 import { Stereotype } from '../common/construct';
@@ -230,7 +230,7 @@ const EarlyOutlookPage: React.FC<ICharacterProperties> = ({ character }) => {
             size="sm"
             className="me-3"
             onClick={() =>
-              setRandomUpbringing(EarlyOutlookUpbringingRandomTable())
+              setRandomUpbringing(earlyOutlookUpbringingRandomTable())
             }
           >
             <>
@@ -288,7 +288,7 @@ const EarlyOutlookPage: React.FC<ICharacterProperties> = ({ character }) => {
         <div className="my-4">
           <Button
             className="btn btn-primary btn-sm me-3"
-            onClick={() => setRandomCaste(EarlyOutlookCasteRandomTable())}
+            onClick={() => setRandomCaste(earlyOutlookCasteRandomTable())}
           >
             <>
               <img
@@ -346,7 +346,7 @@ const EarlyOutlookPage: React.FC<ICharacterProperties> = ({ character }) => {
             size="sm"
             className="me-3"
             onClick={() =>
-              setRandomAsperation(EarlyOutlookAspirationRandomTable())
+              setRandomAsperation(earlyOutlookAspirationRandomTable())
             }
           >
             <>

--- a/WebTools/src/pages/educationDetailsPage.tsx
+++ b/WebTools/src/pages/educationDetailsPage.tsx
@@ -39,7 +39,7 @@ import DisciplineListComponent from '../components/disciplineListComponent';
 import { PageIdentity } from './pageIdentity';
 import { Stereotype } from '../common/construct';
 import D20IconButton from '../solo/component/d20IconButton';
-import { FocusRandomTableWithHints } from '../solo/table/focusRandomTable';
+import { focusRandomTableWithHints } from '../solo/table/focusRandomTable';
 import { localizedFocus } from '../components/focusHelper';
 import { SelectedTalent } from '../common/selectedTalent';
 import { determineSelectedTalentExtraErrors } from '../common/selectedTalentExtraCheck';
@@ -84,7 +84,7 @@ const EducationDetailsPage: React.FC<ICharacterProperties> = ({
     let done = false;
     while (!done) {
       const focus = localizedFocus(
-        FocusRandomTableWithHints(
+        focusRandomTableWithHints(
           character.educationStep?.primaryDiscipline,
           track.focuses.focusSuggestions,
         ),

--- a/WebTools/src/solo/page/soloCareerEventDetailPage.tsx
+++ b/WebTools/src/solo/page/soloCareerEventDetailPage.tsx
@@ -25,7 +25,7 @@ import AttributeListComponent from '../../components/attributeListComponent';
 import SoloCharacterBreadcrumbs from '../component/soloCharacterBreadcrumbs';
 import { Dialog } from '../../components/dialog';
 import D20IconButton from '../component/d20IconButton';
-import { FocusRandomTable } from '../table/focusRandomTable';
+import { focusRandomTable } from '../table/focusRandomTable';
 import {
   CareerEventAttributeController,
   CareerEventDisciplineController,
@@ -74,7 +74,7 @@ const SoloCareerEventDetailsPage: React.FC<ISoloCareerEventProperties> = ({
     let done = false;
     while (!done) {
       const focus = localizedFocus(
-        FocusRandomTable(careerEventStep.discipline),
+        focusRandomTable(careerEventStep.discipline),
       );
       if (character.focuses.indexOf(focus) < 0) {
         done = true;

--- a/WebTools/src/solo/page/soloEarlyOutlookDetailsPage.tsx
+++ b/WebTools/src/solo/page/soloEarlyOutlookDetailsPage.tsx
@@ -21,7 +21,7 @@ import Button from 'react-bootstrap/Button';
 import { Dialog } from '../../components/dialog';
 import SoloCharacterBreadcrumbs from '../component/soloCharacterBreadcrumbs';
 import D20IconButton from '../component/d20IconButton';
-import { FocusRandomTable } from '../table/focusRandomTable';
+import { focusRandomTable } from '../table/focusRandomTable';
 import { EarlyOutlookDiscplineController } from '../../components/earlyOutlookControllers';
 import { localizedFocus } from '../../components/focusHelper';
 
@@ -53,7 +53,7 @@ const SoloEarlyOutlookDetailsPage: React.FC<ICharacterProperties> = ({
     let done = false;
     while (!done) {
       const focus = localizedFocus(
-        FocusRandomTable(character.upbringingStep?.discipline),
+        focusRandomTable(character.upbringingStep?.discipline),
       );
       if (character.focuses.indexOf(focus) < 0) {
         done = true;

--- a/WebTools/src/solo/page/soloEarlyOutlookPage.tsx
+++ b/WebTools/src/solo/page/soloEarlyOutlookPage.tsx
@@ -16,9 +16,9 @@ import {
   UpbringingsHelper,
 } from '../../helpers/upbringings';
 import {
-  EarlyOutlookAspirationRandomTable,
-  EarlyOutlookCasteRandomTable,
-  EarlyOutlookUpbringingRandomTable,
+  earlyOutlookAspirationRandomTable,
+  earlyOutlookCasteRandomTable,
+  earlyOutlookUpbringingRandomTable,
 } from '../table/earlyOutlookRandomTable';
 import { setCharacterEarlyOutlook } from '../../state/characterActions';
 import store from '../../state/store';
@@ -170,7 +170,7 @@ const SoloEarlyOutlookPage: React.FC<ICharacterProperties> = ({
             size="sm"
             className="me-3"
             onClick={() =>
-              setRandomUpbringing(EarlyOutlookUpbringingRandomTable())
+              setRandomUpbringing(earlyOutlookUpbringingRandomTable())
             }
           >
             <>
@@ -226,7 +226,7 @@ const SoloEarlyOutlookPage: React.FC<ICharacterProperties> = ({
           <Button
             size="sm"
             className="me-3"
-            onClick={() => setRandomCaste(EarlyOutlookCasteRandomTable())}
+            onClick={() => setRandomCaste(earlyOutlookCasteRandomTable())}
           >
             <>
               <img
@@ -282,7 +282,7 @@ const SoloEarlyOutlookPage: React.FC<ICharacterProperties> = ({
             size="sm"
             className="me-3"
             onClick={() =>
-              setRandomAsperation(EarlyOutlookAspirationRandomTable())
+              setRandomAsperation(earlyOutlookAspirationRandomTable())
             }
           >
             <>

--- a/WebTools/src/solo/page/soloEducationDetailsPage.tsx
+++ b/WebTools/src/solo/page/soloEducationDetailsPage.tsx
@@ -25,7 +25,7 @@ import { Dialog } from '../../components/dialog';
 import SoloCharacterBreadcrumbs from '../component/soloCharacterBreadcrumbs';
 import D20IconButton from '../component/d20IconButton';
 import { randomUniqueValue } from '../table/valueRandomTable';
-import { FocusRandomTable } from '../table/focusRandomTable';
+import { focusRandomTable } from '../table/focusRandomTable';
 import {
   EducationAttributeController,
   EducationPrimaryDisciplineController,
@@ -80,7 +80,7 @@ const SoloEducationDetailsPage: React.FC<ICharacterProperties> = ({
     let done = false;
     while (!done) {
       const focus = localizedFocus(
-        FocusRandomTable(character.educationStep?.primaryDiscipline),
+        focusRandomTable(character.educationStep?.primaryDiscipline),
       );
       if (character.focuses.indexOf(focus) < 0) {
         done = true;

--- a/WebTools/src/solo/page/soloEducationPage.tsx
+++ b/WebTools/src/solo/page/soloEducationPage.tsx
@@ -10,7 +10,7 @@ import { makeKey } from '../../common/translationKey';
 import { TrackModel, TracksHelper } from '../../helpers/tracks';
 import Button from 'react-bootstrap/Button';
 import { Window } from '../../common/window';
-import { EducationTrackRandomTable } from '../table/educationRandomTable';
+import { educationTrackRandomTable } from '../table/educationRandomTable';
 import store from '../../state/store';
 import { setCharacterEducation } from '../../state/characterActions';
 import SoloCharacterBreadcrumbs from '../component/soloCharacterBreadcrumbs';
@@ -76,7 +76,7 @@ const SoloEducationPage: React.FC<ICharacterProperties> = ({ character }) => {
           size="sm"
           className="me-3"
           onClick={() =>
-            setRandomTrack(EducationTrackRandomTable(character.type))
+            setRandomTrack(educationTrackRandomTable(character.type))
           }
         >
           <>

--- a/WebTools/src/solo/page/soloEducationTypePage.tsx
+++ b/WebTools/src/solo/page/soloEducationTypePage.tsx
@@ -7,7 +7,7 @@ import { Window } from '../../common/window';
 import Button from 'react-bootstrap/Button';
 import { Navigation } from '../../common/navigator';
 import { PageIdentity } from '../../pages/pageIdentity';
-import { EducationCategoryRandomTable } from '../table/educationRandomTable';
+import { educationCategoryRandomTable } from '../table/educationRandomTable';
 import { connect } from 'react-redux';
 import { Header } from '../../components/header';
 import { setCharacterType } from '../../state/characterActions';
@@ -65,7 +65,7 @@ const SoloEducationTypePage: React.FC<ICharacterProperties> = ({
         <Button
           size="sm"
           className="me-3"
-          onClick={() => setRandomType(EducationCategoryRandomTable())}
+          onClick={() => setRandomType(educationCategoryRandomTable())}
         >
           <>
             <img

--- a/WebTools/src/solo/page/soloSpeciesPage.tsx
+++ b/WebTools/src/solo/page/soloSpeciesPage.tsx
@@ -11,7 +11,7 @@ import { Attribute } from '../../helpers/attributes';
 import { Window } from '../../common/window';
 import Button from 'react-bootstrap/Button';
 import { useState } from 'react';
-import { SpeciesRandomTable } from '../table/speciesRandomTable';
+import { speciesRandomTable } from '../table/speciesRandomTable';
 import store from '../../state/store';
 import { setCharacterSpecies } from '../../state/characterActions';
 import SoloCharacterBreadcrumbs from '../component/soloCharacterBreadcrumbs';
@@ -103,7 +103,7 @@ const SoloSpeciesPage: React.FC<ISoloSpeciesPageProperties> = ({
         <Button
           size="sm"
           className="me-3"
-          onClick={() => setRandomSpecies(SpeciesRandomTable(era))}
+          onClick={() => setRandomSpecies(speciesRandomTable(era))}
         >
           <>
             <img

--- a/WebTools/src/solo/page/soloStarshipSpaceframePage.tsx
+++ b/WebTools/src/solo/page/soloStarshipSpaceframePage.tsx
@@ -13,7 +13,7 @@ import { SpaceframeHelper } from '../../helpers/spaceframes';
 import { Department } from '../../helpers/department';
 import { SpaceframeModel } from '../../helpers/spaceframeModel';
 import { setStarshipSpaceframe } from '../../state/starshipActions';
-import { SpaceframeRandomTable } from '../table/starshipRandomTable';
+import { spaceframeRandomTable } from '../table/starshipRandomTable';
 import { StatView } from '../../components/StatView';
 import { System } from '../../helpers/systems';
 import SoloStarshipBreadcrumbs from '../component/soloStarshipBreadcrumbs';
@@ -200,7 +200,7 @@ const SoloStarshipSpaceframePage: React.FC<
         <Button
           size="sm"
           className="me-3"
-          onClick={() => setRandomSpaceframe(SpaceframeRandomTable(era))}
+          onClick={() => setRandomSpaceframe(spaceframeRandomTable(era))}
         >
           <>
             <img

--- a/WebTools/src/solo/table/careerLengthRandomTable.ts
+++ b/WebTools/src/solo/table/careerLengthRandomTable.ts
@@ -1,7 +1,7 @@
 import { D20 } from '../../common/die';
 import { Career } from '../../helpers/careerEnum';
 
-export const CareerLengthRandomTable = () => {
+export const careerLengthRandomTable = () => {
   const roll = D20.roll();
   switch (roll) {
     case 1:

--- a/WebTools/src/solo/table/earlyOutlookRandomTable.ts
+++ b/WebTools/src/solo/table/earlyOutlookRandomTable.ts
@@ -1,7 +1,7 @@
 import { D20 } from '../../common/die';
 import { EarlyOutlook } from '../../helpers/upbringings';
 
-export const EarlyOutlookUpbringingRandomTable = () => {
+export const earlyOutlookUpbringingRandomTable = () => {
   let roll = D20.roll();
   while (true) {
     switch (roll) {
@@ -35,7 +35,7 @@ export const EarlyOutlookUpbringingRandomTable = () => {
   }
 };
 
-export const EarlyOutlookCasteRandomTable = () => {
+export const earlyOutlookCasteRandomTable = () => {
   let roll = D20.roll();
   while (true) {
     switch (roll) {
@@ -69,7 +69,7 @@ export const EarlyOutlookCasteRandomTable = () => {
   }
 };
 
-export const EarlyOutlookAspirationRandomTable = () => {
+export const earlyOutlookAspirationRandomTable = () => {
   let roll = D20.roll();
   while (true) {
     switch (roll) {

--- a/WebTools/src/solo/table/educationRandomTable.ts
+++ b/WebTools/src/solo/table/educationRandomTable.ts
@@ -2,7 +2,7 @@ import { CharacterType } from '../../common/characterType';
 import { D20 } from '../../common/die';
 import { Track } from '../../helpers/trackEnum';
 
-export const EducationCategoryRandomTable = () => {
+export const educationCategoryRandomTable = () => {
   const roll = D20.roll();
   switch (roll) {
     case 1:
@@ -33,7 +33,7 @@ export const EducationCategoryRandomTable = () => {
   }
 };
 
-export const EducationTrackRandomTable = (type: CharacterType) => {
+export const educationTrackRandomTable = (type: CharacterType) => {
   let roll = D20.roll();
   switch (type) {
     case CharacterType.Starfleet: {

--- a/WebTools/src/solo/table/environmentRandomTable.ts
+++ b/WebTools/src/solo/table/environmentRandomTable.ts
@@ -1,7 +1,7 @@
 import { D20 } from '../../common/die';
 import { Environment } from '../../helpers/environments';
 
-export const EnvironmentSettingRandomTable = () => {
+export const environmentSettingRandomTable = () => {
   const roll = D20.roll();
   switch (roll) {
     case 1:
@@ -32,7 +32,7 @@ export const EnvironmentSettingRandomTable = () => {
   }
 };
 
-export const EnvironmentConditionRandomTable = () => {
+export const environmentConditionRandomTable = () => {
   const roll = D20.roll();
   switch (roll) {
     case 1:

--- a/WebTools/src/solo/table/focusRandomTable.ts
+++ b/WebTools/src/solo/table/focusRandomTable.ts
@@ -1,7 +1,7 @@
 import { D20 } from '../../common/die';
 import { Department } from '../../helpers/department';
 
-const FocusCommandRandomTable = () => {
+const focusCommandRandomTable = () => {
   const tableRoll = D20.roll();
   const roll = D20.roll();
 
@@ -96,7 +96,7 @@ const FocusCommandRandomTable = () => {
   }
 };
 
-const FocusConnRandomTable = () => {
+const focusConnRandomTable = () => {
   const tableRoll = D20.roll();
   const roll = D20.roll();
 
@@ -191,7 +191,7 @@ const FocusConnRandomTable = () => {
   }
 };
 
-const FocusSecurityRandomTable = () => {
+const focusSecurityRandomTable = () => {
   const tableRoll = D20.roll();
   const roll = D20.roll();
 
@@ -286,7 +286,7 @@ const FocusSecurityRandomTable = () => {
   }
 };
 
-const FocusEngineeringRandomTable = () => {
+const focusEngineeringRandomTable = () => {
   const tableRoll = D20.roll();
   const roll = D20.roll();
 
@@ -381,7 +381,7 @@ const FocusEngineeringRandomTable = () => {
   }
 };
 
-const FocusScienceRandomTable = () => {
+const focusScienceRandomTable = () => {
   const tableRoll = D20.roll();
   const roll = D20.roll();
 
@@ -476,7 +476,7 @@ const FocusScienceRandomTable = () => {
   }
 };
 
-const FocusMedicineRandomTable = () => {
+const focusMedicineRandomTable = () => {
   const tableRoll = D20.roll();
   const roll = D20.roll();
 
@@ -571,7 +571,7 @@ const FocusMedicineRandomTable = () => {
   }
 };
 
-export const FocusRandomTableWithHints = (
+export const focusRandomTableWithHints = (
   skill?: Department,
   hints: string[] = [],
 ) => {
@@ -579,32 +579,32 @@ export const FocusRandomTableWithHints = (
     const i = Math.floor(hints.length * Math.random());
     return hints[i];
   } else {
-    return FocusRandomTable(skill);
+    return focusRandomTable(skill);
   }
 };
 
-export const FocusRandomTable = (skill?: Department) => {
+export const focusRandomTable = (skill?: Department) => {
   if (skill == null) {
-    skill = FocusDivisionRandomTable();
+    skill = focusDivisionRandomTable();
   }
 
   if (skill === Department.Command) {
-    return FocusCommandRandomTable();
+    return focusCommandRandomTable();
   } else if (skill === Department.Conn) {
-    return FocusConnRandomTable();
+    return focusConnRandomTable();
   } else if (skill === Department.Security) {
-    return FocusSecurityRandomTable();
+    return focusSecurityRandomTable();
   } else if (skill === Department.Engineering) {
-    return FocusEngineeringRandomTable();
+    return focusEngineeringRandomTable();
   } else if (skill === Department.Science) {
-    return FocusScienceRandomTable();
+    return focusScienceRandomTable();
   } else {
     // Medicine
-    return FocusMedicineRandomTable();
+    return focusMedicineRandomTable();
   }
 };
 
-export const FocusDivisionRandomTable = () => {
+export const focusDivisionRandomTable = () => {
   let roll = D20.roll();
 
   while (true) {

--- a/WebTools/src/solo/table/speciesRandomTable.ts
+++ b/WebTools/src/solo/table/speciesRandomTable.ts
@@ -2,11 +2,11 @@ import { D20 } from '../../common/die';
 import { Era } from '../../helpers/erasEnum';
 import { Species } from '../../helpers/speciesEnum';
 
-export const SpeciesRandomTable = (era: Era) => {
+export const speciesRandomTable = (era: Era) => {
   const tables = [
-    EnterpriseSpeciesRandomTable,
-    OriginalSeriesSpeciesRandomTable,
-    NextGenerationSpeciesRandomTable,
+    enterpriseSpeciesRandomTable,
+    originalSeriesSpeciesRandomTable,
+    nextGenerationSpeciesRandomTable,
   ];
   const table =
     tables[Math.min(tables.length - 1, Math.floor(Math.random() * (era + 1)))];
@@ -14,7 +14,7 @@ export const SpeciesRandomTable = (era: Era) => {
   return table();
 };
 
-const EnterpriseSpeciesRandomTable = () => {
+const enterpriseSpeciesRandomTable = () => {
   const roll = D20.roll();
 
   switch (roll) {
@@ -61,7 +61,7 @@ const EnterpriseSpeciesRandomTable = () => {
   }
 };
 
-const OriginalSeriesSpeciesRandomTable = () => {
+const originalSeriesSpeciesRandomTable = () => {
   const roll = D20.roll();
 
   switch (roll) {
@@ -108,7 +108,7 @@ const OriginalSeriesSpeciesRandomTable = () => {
   }
 };
 
-const NextGenerationSpeciesRandomTable = () => {
+const nextGenerationSpeciesRandomTable = () => {
   const roll = D20.roll();
 
   switch (roll) {

--- a/WebTools/src/solo/table/starshipRandomTable.ts
+++ b/WebTools/src/solo/table/starshipRandomTable.ts
@@ -3,19 +3,19 @@ import { TableRoll } from '../../common/tableRoll';
 import { Era } from '../../helpers/erasEnum';
 import { Spaceframe } from '../../helpers/spaceframeEnum';
 
-export const SpaceframeRandomTable = (era: Era) => {
+export const spaceframeRandomTable = (era: Era) => {
   const tables = [
-    EnterpriseSpaceframeRandomTable,
-    OriginalSeriesSpaceframeRandomTable,
-    NextGenerationSpaceframeRandomTable,
-    PicardProdigySpaceframeRandomTable,
-    Discovery32SpaceframeRandomTable,
+    enterpriseSpaceframeRandomTable,
+    originalSeriesSpaceframeRandomTable,
+    nextGenerationSpaceframeRandomTable,
+    picardProdigySpaceframeRandomTable,
+    discovery32SpaceframeRandomTable,
   ];
 
   return tables[era]();
 };
 
-const EnterpriseSpaceframeRandomTable: TableRoll<Spaceframe> = () => {
+const enterpriseSpaceframeRandomTable: TableRoll<Spaceframe> = () => {
   const roll = D20.roll();
 
   switch (roll) {
@@ -48,7 +48,7 @@ const EnterpriseSpaceframeRandomTable: TableRoll<Spaceframe> = () => {
   }
 };
 
-const OriginalSeriesSpaceframeRandomTable: TableRoll<Spaceframe> = () => {
+const originalSeriesSpaceframeRandomTable: TableRoll<Spaceframe> = () => {
   const roll = D20.roll();
 
   switch (roll) {
@@ -96,7 +96,7 @@ const OriginalSeriesSpaceframeRandomTable: TableRoll<Spaceframe> = () => {
   }
 };
 
-const NextGenerationSpaceframeRandomTable: TableRoll<Spaceframe> = () => {
+const nextGenerationSpaceframeRandomTable: TableRoll<Spaceframe> = () => {
   const roll = D20.roll();
 
   switch (roll) {
@@ -141,7 +141,7 @@ const NextGenerationSpaceframeRandomTable: TableRoll<Spaceframe> = () => {
   }
 };
 
-const PicardProdigySpaceframeRandomTable: TableRoll<Spaceframe> = () => {
+const picardProdigySpaceframeRandomTable: TableRoll<Spaceframe> = () => {
   const roll = D20.roll();
 
   switch (roll) {
@@ -178,7 +178,7 @@ const PicardProdigySpaceframeRandomTable: TableRoll<Spaceframe> = () => {
   }
 };
 
-const Discovery32SpaceframeRandomTable: TableRoll<Spaceframe> = () => {
+const discovery32SpaceframeRandomTable: TableRoll<Spaceframe> = () => {
   const roll = D20.roll();
 
   switch (roll) {

--- a/WebTools/src/solo/table/valueRandomTable.ts
+++ b/WebTools/src/solo/table/valueRandomTable.ts
@@ -4,7 +4,7 @@ import { Source } from '../../helpers/sources';
 import { Species } from '../../helpers/speciesEnum';
 import { hasSource } from '../../state/contextFunctions';
 
-export const ValueRandomTable = (species?: Species, skill?: Department) => {
+export const valueRandomTable = (species?: Species, skill?: Department) => {
   const roll = D20.roll();
   if (roll <= 15 && hasSource(Source.ContinuingMissions)) {
     const subRoll = D20.roll();
@@ -42,9 +42,9 @@ export const randomUniqueValue = (
   species?: Species,
   skill?: Department,
 ) => {
-  let value = ValueRandomTable(species, skill);
+  let value = valueRandomTable(species, skill);
   while (existingValues.includes(value)) {
-    value = ValueRandomTable(species, skill);
+    value = valueRandomTable(species, skill);
   }
   return value;
 };

--- a/WebTools/src/starship/model/starshipTalentMatrix.ts
+++ b/WebTools/src/starship/model/starshipTalentMatrix.ts
@@ -1,6 +1,6 @@
 import { TalentsHelper } from '../../helpers/talents';
 
-export const StarshipTalentMatrix = (roll: number) => {
+export const starshipTalentMatrix = (roll: number) => {
   switch (roll) {
     case 3:
       return TalentsHelper.getTalent('Ablative Armor');

--- a/WebTools/src/supportingcharacters/modify/modifySupportCharacterPage.tsx
+++ b/WebTools/src/supportingcharacters/modify/modifySupportCharacterPage.tsx
@@ -25,7 +25,7 @@ import { Attribute } from '../../helpers/attributes';
 import { SimpleAttributeSelector } from '../../components/simpleAttributeSelector';
 import { InputFieldAndLabel } from '../../common/inputFieldAndLabel';
 import D20IconButton from '../../solo/component/d20IconButton';
-import { FocusRandomTable } from '../../solo/table/focusRandomTable';
+import { focusRandomTable } from '../../solo/table/focusRandomTable';
 import { TalentDescription } from '../../components/talentDescription';
 import { ModalControl } from '../../components/modal';
 import { Promotion, CharacterAdvancementStep } from '../../common/character';
@@ -250,7 +250,7 @@ const ModifySupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
   const randomFocus = () => {
     let done = false;
     while (!done) {
-      const f = FocusRandomTable();
+      const f = focusRandomTable();
       if (!character?.focuses?.includes(f)) {
         done = true;
         setFocusSelection(f);

--- a/WebTools/src/supportingcharacters/supportingCharacterPage.tsx
+++ b/WebTools/src/supportingcharacters/supportingCharacterPage.tsx
@@ -32,7 +32,7 @@ import {
   setSupportingCharacterSupervisory,
 } from '../state/characterActions';
 import { localizedFocus } from '../components/focusHelper';
-import { FocusRandomTableWithHints } from '../solo/table/focusRandomTable';
+import { focusRandomTableWithHints } from '../solo/table/focusRandomTable';
 import D20IconButton from '../solo/component/d20IconButton';
 import { CheckBox } from '../components/checkBox';
 import ReactMarkdown from 'react-markdown';
@@ -175,7 +175,7 @@ const SupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
     let done = false;
     while (!done) {
       const focus = localizedFocus(
-        FocusRandomTableWithHints(character.supportingStep?.disciplines[0]),
+        focusRandomTableWithHints(character.supportingStep?.disciplines[0]),
       );
       if (character.focuses.indexOf(focus) < 0) {
         done = true;

--- a/WebTools/tests/solo/table/valueRandomTable.test.ts
+++ b/WebTools/tests/solo/table/valueRandomTable.test.ts
@@ -1,21 +1,21 @@
 import { test, expect, describe, jest } from '@jest/globals';
 import {
-  ValueRandomTable,
+  valueRandomTable,
   randomUniqueValue,
 } from '../../../src/solo/table/valueRandomTable';
 
-describe('ValueRandomTable', () => {
+describe('valueRandomTable', () => {
   test('returns a string', () => {
     const spy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
-    const result = ValueRandomTable();
+    const result = valueRandomTable();
     expect(typeof result).toBe('string');
     spy.mockRestore();
   });
 
   test('can return the same value on successive rolls', () => {
     const spy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
-    const first = ValueRandomTable();
-    const second = ValueRandomTable();
+    const first = valueRandomTable();
+    const second = valueRandomTable();
     expect(first).toBe(second);
     spy.mockRestore();
   });
@@ -30,12 +30,12 @@ describe('randomUniqueValue', () => {
   });
 
   test('rerolls when the rolled value is already assigned', () => {
-    // With the default store, ValueRandomTable uses StandardValuesTable.
+    // With the default store, valueRandomTable uses StandardValuesTable.
     // Math.random 0.5 rolls an 11, and 0.6 rolls a 13.
     const assigned = 'Push me too far and you’ll see my ugly side';
     const rerolled = 'Seeking to find myself far from home';
 
-    // ValueRandomTable consumes two random values per attempt
+    // valueRandomTable consumes two random values per attempt
     // (an unused outer roll and the StandardValuesTable roll).
     const randomValues = [0.5, 0.5, 0.5, 0.6];
     const spy = jest


### PR DESCRIPTION
Rename PascalCase non-component functions to camelCase, per the Google TypeScript style guide and the TypeScript conventions plan (#438). This is part of #438.

Renamed:
- CopyObject to copyObject
- StarshipTalentMatrix to starshipTalentMatrix
- CreatureGenerator to creatureGenerator
- All *RandomTable functions in src/solo/table (focus, careerLength, education, earlyOutlook, environment, species, starship spaceframe, and value random tables) to camelCase

Kept PascalCase for React component consts and classes. Updated all call sites and the valueRandomTable test. Formatting verified with prettier; full_check.sh passes (58 suites, 322 tests, tsc, eslint, prettier).