### PR TITLE
Remove leading-underscore identifiers (part of #438)

### DIFF
--- a/WebTools/src/asset/assetType.ts
+++ b/WebTools/src/asset/assetType.ts
@@ -15,7 +15,7 @@ export class AssetTypeModel {
 }
 
 export class AssetTypes {
-  private static _instance: AssetTypes;
+  private static singleton: AssetTypes;
 
   private readonly types: AssetTypeModel[] = [
     new AssetTypeModel(AssetType.Ship, 'Ship'),
@@ -24,10 +24,10 @@ export class AssetTypes {
   ];
 
   static get instance() {
-    if (AssetTypes._instance == null) {
-      AssetTypes._instance = new AssetTypes();
+    if (AssetTypes.singleton == null) {
+      AssetTypes.singleton = new AssetTypes();
     }
-    return AssetTypes._instance;
+    return AssetTypes.singleton;
   }
 
   public getTypes() {

--- a/WebTools/src/common/character.ts
+++ b/WebTools/src/common/character.ts
@@ -75,11 +75,11 @@ export class OtherDetails {
 
 export class AlliedMilitaryDetails {
   readonly alliedMilitary: AlliedMilitary;
-  readonly _name: string;
+  readonly nameValue: string;
 
   constructor(alliedMilitary: AlliedMilitary, name: string) {
     this.alliedMilitary = alliedMilitary;
-    this._name = name;
+    this.nameValue = name;
   }
 
   get type() {
@@ -90,9 +90,9 @@ export class AlliedMilitaryDetails {
     if (
       this.alliedMilitary &&
       this.alliedMilitary.type === AlliedMilitaryType.Other &&
-      this._name
+      this.nameValue
     ) {
-      return this._name;
+      return this.nameValue;
     } else if (this.alliedMilitary) {
       return this.alliedMilitary.name;
     } else {
@@ -103,20 +103,20 @@ export class AlliedMilitaryDetails {
 
 export class GovernmentDetails {
   readonly government: Government;
-  readonly _name: string;
+  readonly nameValue: string;
 
   constructor(government: Government, name: string) {
     this.government = government;
-    this._name = name;
+    this.nameValue = name;
   }
 
   get name() {
     if (
       this.government &&
       this.government.type === Polity.Other &&
-      this._name
+      this.nameValue
     ) {
-      return this._name;
+      return this.nameValue;
     } else if (this.government) {
       return this.government.name;
     } else {
@@ -514,23 +514,23 @@ export class Character extends Construct implements IWeaponDiceProvider {
   public static ABSOLUTE_MAX_ATTRIBUTE = 12;
   public static ABSOLUTE_MAX_DEPARTMENT = 5;
 
-  private _attributeInitialValue: number = 7;
+  private attributeInitialValue: number = 7;
 
   public reprimands = 0;
-  public _attributes: number[] = [];
-  public _skills: number[] = [];
+  public attributeValues: number[] = [];
+  public skills: number[] = [];
   public traits: string[];
   public additionalTraits: string;
   public age: Age;
   public lineage?: string;
   public house?: string;
   public careerEvents: CareerEventStep[];
-  public _rank?: CharacterRank;
+  public rankValue?: CharacterRank;
   public role?: Role;
   public jobAssignment?: string;
   public assignedShip?: string;
   public secondaryRole?: Role;
-  public _focuses: string[];
+  public focusValues: string[];
   public typeDetails: AlliedMilitaryDetails | GovernmentDetails | OtherDetails;
   public pronouns: string = '';
   public pastime: string[];
@@ -555,21 +555,21 @@ export class Character extends Construct implements IWeaponDiceProvider {
 
   constructor() {
     super(Stereotype.MainCharacter);
-    this._attributes = [
-      this._attributeInitialValue,
-      this._attributeInitialValue,
-      this._attributeInitialValue,
-      this._attributeInitialValue,
-      this._attributeInitialValue,
-      this._attributeInitialValue,
+    this.attributeValues = [
+      this.attributeInitialValue,
+      this.attributeInitialValue,
+      this.attributeInitialValue,
+      this.attributeInitialValue,
+      this.attributeInitialValue,
+      this.attributeInitialValue,
     ];
 
     for (let i = 0; i <= Department.Medicine; i++) {
-      this._skills.push(0);
+      this.skills.push(0);
     }
 
     this.traits = [];
-    this._focuses = [];
+    this.focusValues = [];
     this.careerEvents = [];
     this.age = AgeHelper.getAdultAge();
   }
@@ -832,7 +832,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
       });
       return result;
     } else {
-      result = [...this._attributes];
+      result = [...this.attributeValues];
     }
 
     this.improvements?.forEach((i) => {
@@ -901,7 +901,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
       result =
         this.stereotype === Stereotype.Npc
           ? [...this.npcGenerationStep?.departments]
-          : [...this._skills];
+          : [...this.skills];
       if (this.hasTalent('Intensive Training (Special Rule)')) {
         result = result.map((d) => (d === 0 ? 1 : d));
       }
@@ -1765,7 +1765,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
   }
 
   addFocus(focus: string) {
-    this._focuses.push(focus);
+    this.focusValues.push(focus);
   }
 
   get focuses() {
@@ -1811,7 +1811,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
       });
 
       if (this.legacyMode) {
-        result = this._focuses.map(
+        result = this.focusValues.map(
           (f, i) => new FocusAssembly(f, AssemblyContext.Legacy, i),
         );
       } else {
@@ -1856,7 +1856,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
         }
       });
     } else {
-      result = this._focuses.map(
+      result = this.focusValues.map(
         (f, i) => new FocusAssembly(f, AssemblyContext.Legacy, i),
       );
     }
@@ -1962,7 +1962,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
       const promotion = promotions[promotions.length - 1] as Promotion;
       return promotion.rank;
     } else {
-      return this._rank;
+      return this.rankValue;
     }
   }
 
@@ -2127,8 +2127,8 @@ export class Character extends Construct implements IWeaponDiceProvider {
     character.stereotype = this.stereotype;
     character.typeDetails = this.typeDetails;
     character.version = this.version;
-    character._attributes = [...this._attributes];
-    character._skills = [...this._skills];
+    character.attributeValues = [...this.attributeValues];
+    character.skills = [...this.skills];
     this.traits.forEach((t) => {
       character.traits.push(t);
     });
@@ -2143,7 +2143,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
     });
     character.jobAssignment = this.jobAssignment;
     character.assignedShip = this.assignedShip;
-    character._rank = this._rank;
+    character.rankValue = this.rankValue;
     character.role = this.role;
     character.secondaryRole = this.secondaryRole;
     if (this.speciesStep) {
@@ -2195,8 +2195,8 @@ export class Character extends Construct implements IWeaponDiceProvider {
     character.finishingStep = this.finishingStep?.copy();
     character.npcGenerationStep = this.npcGenerationStep?.copy();
     character.supportingStep = this.supportingStep?.copy();
-    this._focuses.forEach((f) => {
-      character._focuses.push(f);
+    this.focusValues.forEach((f) => {
+      character.focusValues.push(f);
     });
     character.improvements = this.improvements?.map((i) => i.copy());
     character.pronouns = this.pronouns;
@@ -2293,7 +2293,7 @@ export class Character extends Construct implements IWeaponDiceProvider {
 
     result.supportingStep = new SupportingStep();
     const rank = RanksHelper.instance().getRank(Rank.Ensign);
-    result._rank = new CharacterRank(rank.localizedName, rank.id);
+    result.rankValue = new CharacterRank(rank.localizedName, rank.id);
     return result;
   }
 

--- a/WebTools/src/components/characterSheetDialog.tsx
+++ b/WebTools/src/components/characterSheetDialog.tsx
@@ -18,11 +18,9 @@ interface ICharacterSheetDialogProperties {
   construct: Construct;
 }
 
-const _CharacterSheetDialog: React.FC<ICharacterSheetDialogProperties> = ({
-  sheets,
-  suffix,
-  construct,
-}) => {
+const CharacterSheetDialogContent: React.FC<
+  ICharacterSheetDialogProperties
+> = ({ sheets, suffix, construct }) => {
   const [selection, setSelection] = useState(sheets[0]);
   const [tags, setTags] = useState([]);
   const { t } = useTranslation();
@@ -177,7 +175,7 @@ class CharacterSheetDialogControl {
     ModalControl.show(
       'xl',
       () => {},
-      React.createElement(_CharacterSheetDialog, {
+      React.createElement(CharacterSheetDialogContent, {
         sheets: filteredSheets,
         suffix: suffix,
         construct: c,

--- a/WebTools/src/components/dialog.tsx
+++ b/WebTools/src/components/dialog.tsx
@@ -8,7 +8,7 @@ interface IDialogProperties {
   message: string;
 }
 
-const _Dialog: React.FC<IDialogProperties> = ({ message }) => {
+const DialogContent: React.FC<IDialogProperties> = ({ message }) => {
   const { t } = useTranslation();
 
   return (
@@ -24,19 +24,19 @@ const _Dialog: React.FC<IDialogProperties> = ({ message }) => {
 };
 
 class DialogControl {
-  static _root;
+  static rootElement;
 
-  private _message: string;
+  private message: string;
 
   static get root() {
-    if (DialogControl._root == null) {
-      DialogControl._root = createRoot(document.getElementById('dialog'));
+    if (DialogControl.rootElement == null) {
+      DialogControl.rootElement = createRoot(document.getElementById('dialog'));
     }
-    return DialogControl._root;
+    return DialogControl.rootElement;
   }
 
   show(message: string) {
-    this._message = message;
+    this.message = message;
     this.render(true);
   }
 
@@ -47,13 +47,13 @@ class DialogControl {
   private render(visible: boolean) {
     if (visible) {
       DialogControl.root.render(
-        React.createElement(_Dialog, {
-          message: this._message,
+        React.createElement(DialogContent, {
+          message: this.message,
         }),
       );
     } else {
       DialogControl.root.unmount();
-      DialogControl._root = null;
+      DialogControl.rootElement = null;
     }
   }
 }

--- a/WebTools/src/components/dieRoll.tsx
+++ b/WebTools/src/components/dieRoll.tsx
@@ -8,20 +8,20 @@ interface IDieRollProperties {
 }
 
 export class DieRoll extends React.Component<IDieRollProperties, {}> {
-  private _isSelected: boolean;
+  private isSelected: boolean;
 
   constructor(props: IDieRollProperties) {
     super(props);
 
-    this._isSelected = this.props.isSelected;
+    this.isSelected = this.props.isSelected;
   }
 
   componentDidUpdate(prevProps: IDieRollProperties) {
-    this._isSelected = this.props.isSelected;
+    this.isSelected = this.props.isSelected;
   }
 
   render() {
-    const className = this._isSelected ? 'die die-selected' : 'die';
+    const className = this.isSelected ? 'die die-selected' : 'die';
 
     return (
       <div className={className} onClick={() => this.toggleSelection()}>
@@ -31,8 +31,8 @@ export class DieRoll extends React.Component<IDieRollProperties, {}> {
   }
 
   private toggleSelection() {
-    this._isSelected = !this._isSelected;
-    this.props.onSelect(this._isSelected ? this.props.index : -1);
+    this.isSelected = !this.isSelected;
+    this.props.onSelect(this.isSelected ? this.props.index : -1);
     this.forceUpdate();
   }
 }

--- a/WebTools/src/components/modal.tsx
+++ b/WebTools/src/components/modal.tsx
@@ -32,7 +32,7 @@ const ModalBox: React.FC<IModalProperties> = ({
 export default ModalBox;
 
 class ModalDialogControl {
-  static _root;
+  static rootElement;
 
   size?: 'xl' | 'lg' | 'sm';
   onClose?: () => void;
@@ -40,10 +40,12 @@ class ModalDialogControl {
   header: string;
 
   static get root() {
-    if (ModalDialogControl._root == null) {
-      ModalDialogControl._root = createRoot(document.getElementById('dialog'));
+    if (ModalDialogControl.rootElement == null) {
+      ModalDialogControl.rootElement = createRoot(
+        document.getElementById('dialog'),
+      );
     }
-    return ModalDialogControl._root;
+    return ModalDialogControl.rootElement;
   }
 
   show(
@@ -79,7 +81,7 @@ class ModalDialogControl {
       );
     } else {
       ModalDialogControl.root.unmount();
-      ModalDialogControl._root = null;
+      ModalDialogControl.rootElement = null;
     }
   }
 }

--- a/WebTools/src/components/refitsView.tsx
+++ b/WebTools/src/components/refitsView.tsx
@@ -71,7 +71,7 @@ interface IRefitsViewProperties extends WithTranslation {
 }
 
 export class RefitsView extends React.Component<IRefitsViewProperties, {}> {
-  private _absoluteMax: number = 12;
+  private absoluteMax: number = 12;
 
   render() {
     const { t } = this.props;

--- a/WebTools/src/creature/model/creatureSize.ts
+++ b/WebTools/src/creature/model/creatureSize.ts
@@ -24,7 +24,7 @@ export class CreatureSizeModel {
 }
 
 export class CreatureSizeHelper {
-  private static _instance: CreatureSizeHelper;
+  private static singleton: CreatureSizeHelper;
 
   private items = [
     new CreatureSizeModel(CreatureSize.Swarm, 'Swarm'),
@@ -36,10 +36,10 @@ export class CreatureSizeHelper {
   ];
 
   static get instance() {
-    if (CreatureSizeHelper._instance == null) {
-      CreatureSizeHelper._instance = new CreatureSizeHelper();
+    if (CreatureSizeHelper.singleton == null) {
+      CreatureSizeHelper.singleton = new CreatureSizeHelper();
     }
-    return CreatureSizeHelper._instance;
+    return CreatureSizeHelper.singleton;
   }
 
   getTypes() {

--- a/WebTools/src/creature/model/creatureType.ts
+++ b/WebTools/src/creature/model/creatureType.ts
@@ -27,7 +27,7 @@ export class CreatureTypeModel {
 }
 
 export class CreatureTypeHelper {
-  private static _instance: CreatureTypeHelper;
+  private static singleton: CreatureTypeHelper;
 
   private items = [
     new CreatureTypeModel(CreatureType.Amphibian, 'Amphibian'),
@@ -41,10 +41,10 @@ export class CreatureTypeHelper {
   ];
 
   static get instance() {
-    if (CreatureTypeHelper._instance == null) {
-      CreatureTypeHelper._instance = new CreatureTypeHelper();
+    if (CreatureTypeHelper.singleton == null) {
+      CreatureTypeHelper.singleton = new CreatureTypeHelper();
     }
-    return CreatureTypeHelper._instance;
+    return CreatureTypeHelper.singleton;
   }
 
   getTypes() {

--- a/WebTools/src/creature/model/diet.ts
+++ b/WebTools/src/creature/model/diet.ts
@@ -24,7 +24,7 @@ export class DietTypeModel {
 }
 
 export class DietTypeHelper {
-  private static _instance: DietTypeHelper;
+  private static singleton: DietTypeHelper;
 
   private items = [
     new DietTypeModel(DietType.Herbivore, 'Herbivore'),
@@ -36,10 +36,10 @@ export class DietTypeHelper {
   ];
 
   static get instance() {
-    if (DietTypeHelper._instance == null) {
-      DietTypeHelper._instance = new DietTypeHelper();
+    if (DietTypeHelper.singleton == null) {
+      DietTypeHelper.singleton = new DietTypeHelper();
     }
-    return DietTypeHelper._instance;
+    return DietTypeHelper.singleton;
   }
 
   getTypes() {

--- a/WebTools/src/creature/model/habitat.ts
+++ b/WebTools/src/creature/model/habitat.ts
@@ -30,7 +30,7 @@ export class HabitatModel {
 }
 
 export class HabitatHelper {
-  private static _instance: HabitatHelper;
+  private static singleton: HabitatHelper;
 
   private items = [
     new HabitatModel(Habitat.Caves, 'Caves'),
@@ -48,10 +48,10 @@ export class HabitatHelper {
   ];
 
   static get instance() {
-    if (HabitatHelper._instance == null) {
-      HabitatHelper._instance = new HabitatHelper();
+    if (HabitatHelper.singleton == null) {
+      HabitatHelper.singleton = new HabitatHelper();
     }
-    return HabitatHelper._instance;
+    return HabitatHelper.singleton;
   }
 
   getTypes() {

--- a/WebTools/src/creature/model/locomotion.ts
+++ b/WebTools/src/creature/model/locomotion.ts
@@ -43,7 +43,7 @@ export class LocomotionModel {
 }
 
 export class LocomotionTypeHelper {
-  private static _instance: LocomotionTypeHelper;
+  private static singleton: LocomotionTypeHelper;
 
   private items = [
     new LocomotionTypeModel(LocomotionType.Legs, 'Legs'),
@@ -56,10 +56,10 @@ export class LocomotionTypeHelper {
   ];
 
   static get instance() {
-    if (LocomotionTypeHelper._instance == null) {
-      LocomotionTypeHelper._instance = new LocomotionTypeHelper();
+    if (LocomotionTypeHelper.singleton == null) {
+      LocomotionTypeHelper.singleton = new LocomotionTypeHelper();
     }
-    return LocomotionTypeHelper._instance;
+    return LocomotionTypeHelper.singleton;
   }
 
   getTypes() {

--- a/WebTools/src/creature/model/naturalAttacks.ts
+++ b/WebTools/src/creature/model/naturalAttacks.ts
@@ -20,13 +20,13 @@ export enum NaturalAttacks {
 }
 
 export class NaturalAttacksHelper {
-  private static _instance: NaturalAttacksHelper;
+  private static singleton: NaturalAttacksHelper;
 
   static get instance() {
-    if (NaturalAttacksHelper._instance == null) {
-      NaturalAttacksHelper._instance = new NaturalAttacksHelper();
+    if (NaturalAttacksHelper.singleton == null) {
+      NaturalAttacksHelper.singleton = new NaturalAttacksHelper();
     }
-    return NaturalAttacksHelper._instance;
+    return NaturalAttacksHelper.singleton;
   }
 
   allAttackTypes(): NaturalAttacks[] {

--- a/WebTools/src/creature/page/randomCreatureConfigurationPage.tsx
+++ b/WebTools/src/creature/page/randomCreatureConfigurationPage.tsx
@@ -171,7 +171,7 @@ const RandomCreatureConfigurationPage: React.FC<
                     isChecked={includeDescription}
                     value={'includeDescription'}
                     text={t('NpcConfigurationPage.includeDescription')}
-                    onChanged={(_inc) =>
+                    onChanged={() =>
                       updateIncludeDescription(!includeDescription)
                     }
                   />

--- a/WebTools/src/exportpdf/landscape2eCharacterSheet.ts
+++ b/WebTools/src/exportpdf/landscape2eCharacterSheet.ts
@@ -252,7 +252,7 @@ export class Landscape2eCharacterSheet extends BaseFormFillingSheet {
       const image = await pdf.embedPng(tokenBytes);
       try {
         pdf.getForm().getButton('Image35_af_image').setImage(image);
-      } catch (_e) {
+      } catch {
         // name changed...? ignore it.
         console.log('Image button not found in PDF');
       }

--- a/WebTools/src/exportpdf/standard2eCharacterSheet.ts
+++ b/WebTools/src/exportpdf/standard2eCharacterSheet.ts
@@ -138,7 +138,7 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
       const image = await pdf.embedPng(tokenBytes);
       try {
         pdf.getForm().getButton('Image2_af_image').setImage(image);
-      } catch (_e) {
+      } catch {
         // name changed...? ignore it.
         console.log('Image button not found in PDF');
       }

--- a/WebTools/src/helpers/age.ts
+++ b/WebTools/src/helpers/age.ts
@@ -58,7 +58,7 @@ export class Age {
   }
 }
 
-class _AgeHelper {
+class AgeRepository {
   private ages: Age[] = [
     new Age('Adult', [10, 9, 9, 8, 8, 7], [4, 3, 2, 2, 1, 1], 56, 16),
     new Age(
@@ -114,6 +114,6 @@ class _AgeHelper {
   }
 }
 
-const AgeHelper = new _AgeHelper();
+const AgeHelper = new AgeRepository();
 
 export default AgeHelper;

--- a/WebTools/src/helpers/alliedMilitary.ts
+++ b/WebTools/src/helpers/alliedMilitary.ts
@@ -55,13 +55,13 @@ export class AlliedMilitary {
 }
 
 class AllyHelper {
-  static _instance: AllyHelper;
+  static singleton: AllyHelper;
 
   static get instance() {
-    if (AllyHelper._instance == null) {
-      AllyHelper._instance = new AllyHelper();
+    if (AllyHelper.singleton == null) {
+      AllyHelper.singleton = new AllyHelper();
     }
-    return AllyHelper._instance;
+    return AllyHelper.singleton;
   }
 
   options: AlliedMilitary[] = [

--- a/WebTools/src/helpers/borgImplant.ts
+++ b/WebTools/src/helpers/borgImplant.ts
@@ -54,13 +54,13 @@ export class Implant {
 }
 
 export class BorgImplants {
-  static _instance: BorgImplants;
+  static singleton: BorgImplants;
 
   static get instance() {
-    if (BorgImplants._instance == null) {
-      BorgImplants._instance = new BorgImplants();
+    if (BorgImplants.singleton == null) {
+      BorgImplants.singleton = new BorgImplants();
     }
-    return BorgImplants._instance;
+    return BorgImplants.singleton;
   }
 
   readonly implants: Implant[] = [

--- a/WebTools/src/helpers/careerEvents.ts
+++ b/WebTools/src/helpers/careerEvents.ts
@@ -102,7 +102,7 @@ export class CareerEventModel {
 }
 
 class CareerEvents {
-  private _events: CareerEventModel[] = [
+  private events: CareerEventModel[] = [
     new CareerEventModel(
       'Ship Destroyed',
       'The ship the character was serving on was lost, destroyed during a mission, and the character was one of the few who survived.\n\n- What was the ship’s mission? Was it something routine that went horribly wrong, or was it something perilous? What destroyed the ship?\n- How many survivors were there? How long did it take before they were recovered?',
@@ -909,7 +909,7 @@ class CareerEvents {
     ),
   ];
 
-  private _klingonEvents: CareerEventModel[] = [
+  private klingonEvents: CareerEventModel[] = [
     new CareerEventModel(
       'Ship Destroyed',
       'The ship you were serving on was lost, destroyed during a mission, and you were one of the few who survived. What was the ship’s mission? Was it something routine that went horribly wrong, or was it something perilous? What destroyed the ship? How many survivors were there? How long did it take before they were recovered?',
@@ -1145,7 +1145,7 @@ class CareerEvents {
     ),
   ];
 
-  private _unofficialEvents: CareerEventModel[] = [
+  private unofficialEvents: CareerEventModel[] = [
     new CareerEventModel(
       'Advanced Tactical Training',
       'The character took a specialized course in advanced tactical and intelligence techniques.\n\n- Where was the course taught? Who recommended the character for the course?\n- Did the character pass the course? How did the character rank in the various subjects?',
@@ -1541,15 +1541,15 @@ class CareerEvents {
   getSoloCareerEvents() {
     const result = [];
     for (let i = 0; i < 20; i++) {
-      result.push(this._events[i]);
+      result.push(this.events[i]);
     }
     return result;
   }
 
   getCareerEvents(character: Character) {
     let list = isKlingonWarrior1e(character.type, character.version)
-      ? this._klingonEvents
-      : this._events;
+      ? this.klingonEvents
+      : this.events;
     list = list.filter((e) => e.isPrerequisiteFulfilled(character));
     return [...list].sort((e1, e2) => {
       return e1.localizedName.localeCompare(e2.localizedName);
@@ -1558,7 +1558,7 @@ class CareerEvents {
 
   getCareerEventsIncludingUnofficial(character: Character) {
     const list = this.getCareerEvents(character);
-    this._unofficialEvents.forEach((e) => list.push(e));
+    this.unofficialEvents.forEach((e) => list.push(e));
     return list.sort((e1, e2) => {
       return e1.localizedName.localeCompare(e2.localizedName);
     });
@@ -1572,8 +1572,8 @@ class CareerEvents {
     let event = undefined;
 
     const list = isKlingonWarrior1e(type, version)
-      ? this._klingonEvents
-      : this._events;
+      ? this.klingonEvents
+      : this.events;
     list.forEach((ev) => {
       if (ev.roll === id) {
         event = ev;
@@ -1581,7 +1581,7 @@ class CareerEvents {
     });
 
     if (event == null) {
-      const items = this._unofficialEvents.filter((e) => e.roll === id);
+      const items = this.unofficialEvents.filter((e) => e.roll === id);
       if (items.length === 1) {
         event = items[0];
       }
@@ -1596,8 +1596,8 @@ class CareerEvents {
       let event = undefined;
 
       const list = isKlingonWarrior1e(character.type, character.version)
-        ? this._klingonEvents
-        : this._events;
+        ? this.klingonEvents
+        : this.events;
       list.forEach((ev) => {
         if (ev.roll === roll) {
           event = ev;

--- a/WebTools/src/helpers/careers.ts
+++ b/WebTools/src/helpers/careers.ts
@@ -45,16 +45,16 @@ export class CareerModel {
 }
 
 export class CareersHelper {
-  private static _instance: CareersHelper;
+  private static singleton: CareersHelper;
 
   static get instance() {
-    if (CareersHelper._instance == null) {
-      CareersHelper._instance = new CareersHelper();
+    if (CareersHelper.singleton == null) {
+      CareersHelper.singleton = new CareersHelper();
     }
-    return CareersHelper._instance;
+    return CareersHelper.singleton;
   }
 
-  private _careers: CareerModel[] = [
+  private careers: CareerModel[] = [
     new CareerModel(
       Career.Young,
       'core',
@@ -70,7 +70,7 @@ export class CareersHelper {
     ),
   ];
 
-  private _civilianCareers: CareerModel[] = [
+  private civilianCareers: CareerModel[] = [
     new CareerModel(
       Career.Young,
       'civilian',
@@ -86,7 +86,7 @@ export class CareersHelper {
     ),
   ];
 
-  private _klingonCareers: CareerModel[] = [
+  private klingonCareers: CareerModel[] = [
     new CareerModel(
       Career.Young,
       'klingon',
@@ -102,7 +102,7 @@ export class CareersHelper {
     ),
   ];
 
-  private _soloCareerLengths: CareerModel[] = [
+  private soloCareerLengths: CareerModel[] = [
     new CareerModel(
       Career.Young,
       'solo',
@@ -120,11 +120,11 @@ export class CareersHelper {
 
   private getBaseList(type: CharacterType) {
     if (isKlingonWarriorType(type)) {
-      return this._klingonCareers;
+      return this.klingonCareers;
     } else if (type === CharacterType.Starfleet) {
-      return this._careers;
+      return this.careers;
     } else {
-      return this._civilianCareers; // also allied military
+      return this.civilianCareers; // also allied military
     }
   }
 
@@ -150,12 +150,12 @@ export class CareersHelper {
   }
 
   getSoloCareerLength(careerLength: Career) {
-    const result = this._soloCareerLengths.filter((c) => c.id === careerLength);
+    const result = this.soloCareerLengths.filter((c) => c.id === careerLength);
     return result ? result[0] : undefined;
   }
 
   getSoloCareerLengths() {
-    return this._soloCareerLengths;
+    return this.soloCareerLengths;
   }
 
   getCareer(career: Career, c: Character) {
@@ -186,7 +186,7 @@ export class CareersHelper {
     version: number = 1,
   ) {
     const list =
-      version === 1 ? this.getBaseList(type) : this._soloCareerLengths;
+      version === 1 ? this.getBaseList(type) : this.soloCareerLengths;
     const filtered = list.filter((c) => Career[c.id] === typeName);
     return filtered.length === 0 ? undefined : filtered[0];
   }

--- a/WebTools/src/helpers/characterPrerequisite.ts
+++ b/WebTools/src/helpers/characterPrerequisite.ts
@@ -23,33 +23,33 @@ export class KlingonCharacterPrerequisite implements ICharacterPrerequisite {
 }
 
 export class CareersCharacterPrerequisite implements ICharacterPrerequisite {
-  private _careers: Career[];
+  private careers: Career[];
 
   constructor(...careers: Career[]) {
-    this._careers = careers;
+    this.careers = careers;
   }
 
   isPrerequisiteFulfilled(character: Character) {
     return (
       character.careerStep?.career != null &&
-      this._careers.indexOf(character.careerStep?.career) > -1
+      this.careers.indexOf(character.careerStep?.career) > -1
     );
   }
 }
 
 export class NotRolesCharacterPrerequisite implements ICharacterPrerequisite {
-  private _roles: Role[];
+  private roles: Role[];
 
   constructor(roles: Role[]) {
-    this._roles = roles;
+    this.roles = roles;
   }
 
   isPrerequisiteFulfilled(character: Character) {
     return (
       character.role == null ||
-      (this._roles.indexOf(character.role) < 0 &&
+      (this.roles.indexOf(character.role) < 0 &&
         (character.secondaryRole == null ||
-          this._roles.indexOf(character.secondaryRole) < 0))
+          this.roles.indexOf(character.secondaryRole) < 0))
     );
   }
 }
@@ -101,18 +101,18 @@ export class AllOfCharacterPrerequisite implements ICharacterPrerequisite {
 }
 
 export class AnyOfCharacterPrerequisite implements ICharacterPrerequisite {
-  private _prequisites: ICharacterPrerequisite[];
+  private prequisites: ICharacterPrerequisite[];
 
   constructor(...prequisites: ICharacterPrerequisite[]) {
-    this._prequisites = prequisites;
+    this.prequisites = prequisites;
   }
 
   isPrerequisiteFulfilled(character: Character) {
-    if (this._prequisites.length === 0) {
+    if (this.prequisites.length === 0) {
       return true;
     } else {
       let result = false;
-      this._prequisites.forEach((req) => {
+      this.prequisites.forEach((req) => {
         result = result || req.isPrerequisiteFulfilled(character);
       });
       return result;

--- a/WebTools/src/helpers/department.ts
+++ b/WebTools/src/helpers/department.ts
@@ -8,13 +8,13 @@ export enum Department {
 }
 
 export class DepartmentsHelper {
-  private static _instance: DepartmentsHelper;
+  private static singleton: DepartmentsHelper;
 
   static get instance(): DepartmentsHelper {
-    if (DepartmentsHelper._instance == null) {
-      DepartmentsHelper._instance = new DepartmentsHelper();
+    if (DepartmentsHelper.singleton == null) {
+      DepartmentsHelper.singleton = new DepartmentsHelper();
     }
-    return DepartmentsHelper._instance;
+    return DepartmentsHelper.singleton;
   }
 
   getDepartments() {

--- a/WebTools/src/helpers/environments.ts
+++ b/WebTools/src/helpers/environments.ts
@@ -100,7 +100,7 @@ export class EnvironmentModel {
 }
 
 class Environments {
-  private _environments: { [id: number]: EnvironmentModel } = {
+  private environments: { [id: number]: EnvironmentModel } = {
     [Environment.Homeworld]: new EnvironmentModel(
       Environment.Homeworld,
       'common',
@@ -152,7 +152,7 @@ class Environments {
     ),
   };
 
-  private _century23: { [id: number]: EnvironmentModel } = {
+  private century23: { [id: number]: EnvironmentModel } = {
     [Environment.Andoria23rd]: new EnvironmentModel(
       Environment.Andoria23rd,
       'common',
@@ -270,7 +270,7 @@ class Environments {
     ),
   };
 
-  private _alternateEnvironments: { [id: number]: EnvironmentModel } = {
+  private alternateEnvironments: { [id: number]: EnvironmentModel } = {
     [Environment.UtopianParadise]: new EnvironmentModel(
       Environment.UtopianParadise,
       'alternate',
@@ -322,7 +322,7 @@ class Environments {
     ),
   };
 
-  private _klingonEnvironments: { [id: number]: EnvironmentModel } = {
+  private klingonEnvironments: { [id: number]: EnvironmentModel } = {
     [Environment.Homeworld]: new EnvironmentModel(
       Environment.Homeworld,
       'klingon',
@@ -377,11 +377,11 @@ class Environments {
   getEnvironmentOptions(construct: Construct) {
     const result = [];
     if (construct.stereotype === Stereotype.SoloCharacter) {
-      result.push(...Object.values(this._environments));
+      result.push(...Object.values(this.environments));
     } else {
       const list = isKlingonWarrior1e(construct.type, construct.version)
-        ? this._klingonEnvironments
-        : this._environments;
+        ? this.klingonEnvironments
+        : this.environments;
       for (const environment in list) {
         result.push(list[environment]);
       }
@@ -390,10 +390,10 @@ class Environments {
         construct.version > 1 &&
         hasSource(Source.Century23)
       ) {
-        result.push(...Object.values(this._century23));
+        result.push(...Object.values(this.century23));
       }
       if (hasSource(Source.PlayersGuide)) {
-        result.push(...Object.values(this._alternateEnvironments));
+        result.push(...Object.values(this.alternateEnvironments));
       }
     }
     return result;
@@ -402,8 +402,8 @@ class Environments {
   getEnvironments(type: CharacterType) {
     let environments: EnvironmentModel[] = [];
     const environmentList = isKlingonWarriorType(type)
-      ? this._klingonEnvironments
-      : this._environments;
+      ? this.klingonEnvironments
+      : this.environments;
     for (const environment in environmentList) {
       const env = environmentList[environment];
       if (env.id !== Environment.AnotherSpeciesWorld) {
@@ -447,16 +447,16 @@ class Environments {
     version: number,
   ) {
     const list = isKlingonWarrior1e(type, version)
-      ? Object.values(this._klingonEnvironments)
-      : Object.values(this._environments);
+      ? Object.values(this.klingonEnvironments)
+      : Object.values(this.environments);
     let filtered = list.filter((e) => Environment[e.id] === typeName);
     if (filtered.length === 0) {
-      filtered = Object.values(this._alternateEnvironments).filter(
+      filtered = Object.values(this.alternateEnvironments).filter(
         (e) => Environment[e.id] === typeName,
       );
     }
     if (filtered.length === 0) {
-      filtered = Object.values(this._century23).filter(
+      filtered = Object.values(this.century23).filter(
         (e) => Environment[e.id] === typeName,
       );
     }

--- a/WebTools/src/helpers/equipment.ts
+++ b/WebTools/src/helpers/equipment.ts
@@ -59,13 +59,13 @@ export class EquipmentModel {
 }
 
 export class EquipmentHelper {
-  static _instance: EquipmentHelper;
+  static singleton: EquipmentHelper;
 
   static get instance() {
-    if (EquipmentHelper._instance == null) {
-      EquipmentHelper._instance = new EquipmentHelper();
+    if (EquipmentHelper.singleton == null) {
+      EquipmentHelper.singleton = new EquipmentHelper();
     }
-    return EquipmentHelper._instance;
+    return EquipmentHelper.singleton;
   }
 
   public items = [

--- a/WebTools/src/helpers/eras.ts
+++ b/WebTools/src/helpers/eras.ts
@@ -33,16 +33,16 @@ export const eraDefaultYear = (era: Era) => {
 };
 
 class Eras {
-  private static _instance: Eras;
+  private static singleton: Eras;
 
   static get instance() {
-    if (Eras._instance == null) {
-      Eras._instance = new Eras();
+    if (Eras.singleton == null) {
+      Eras.singleton = new Eras();
     }
-    return Eras._instance;
+    return Eras.singleton;
   }
 
-  private _eras: { [id: number]: EraModel } = {
+  private eras: { [id: number]: EraModel } = {
     [Era.Enterprise]: new EraModel(
       Era.Enterprise,
       'Enterprise (mid-22nd century)',
@@ -68,24 +68,24 @@ class Eras {
   getBasicEras() {
     if (isSecondEdition()) {
       return [
-        this._eras[Era.Enterprise],
-        this._eras[Era.OriginalSeries],
-        this._eras[Era.NextGeneration],
-        this._eras[Era.Discovery32],
+        this.eras[Era.Enterprise],
+        this.eras[Era.OriginalSeries],
+        this.eras[Era.NextGeneration],
+        this.eras[Era.Discovery32],
       ];
     } else {
       return [
-        this._eras[Era.Enterprise],
-        this._eras[Era.OriginalSeries],
-        this._eras[Era.NextGeneration],
+        this.eras[Era.Enterprise],
+        this.eras[Era.OriginalSeries],
+        this.eras[Era.NextGeneration],
       ];
     }
   }
 
   getEras() {
     const eras: EraModel[] = [];
-    for (const era in this._eras) {
-      const er = this._eras[era];
+    for (const era in this.eras) {
+      const er = this.eras[era];
       eras.push(er);
     }
 
@@ -93,11 +93,11 @@ class Eras {
   }
 
   getEra(era: Era) {
-    return this._eras[era];
+    return this.eras[era];
   }
   getEraByName(name: string): Era | null {
-    const results = Object.keys(this._eras)
-      .map((e) => this._eras[e].id)
+    const results = Object.keys(this.eras)
+      .map((e) => this.eras[e].id)
       .filter((e) => Era[e] === name);
     if (results.length === 1) {
       return results[0];

--- a/WebTools/src/helpers/governments.ts
+++ b/WebTools/src/helpers/governments.ts
@@ -31,7 +31,7 @@ export class Government {
   }
 }
 
-class _Governments {
+class GovernmentRepository {
   options: Government[] = [
     new Government('Andorian', Polity.Andorian, Era.Enterprise),
     new Government(
@@ -106,6 +106,6 @@ class _Governments {
   }
 }
 
-const Governments = new _Governments();
+const Governments = new GovernmentRepository();
 
 export default Governments;

--- a/WebTools/src/helpers/marshaller.ts
+++ b/WebTools/src/helpers/marshaller.ts
@@ -399,7 +399,7 @@ class Marshaller {
     sheet['typeDetails'] = this.encodeTypeDetails(character);
 
     if (character.legacyMode) {
-      sheet['attributes'] = this.toAttributeObject(character._attributes);
+      sheet['attributes'] = this.toAttributeObject(character.attributeValues);
     }
 
     if (character.legacyMode) {
@@ -440,10 +440,10 @@ class Marshaller {
       sheet['jobAssignment'] = character.jobAssignment;
     }
 
-    if (character._rank) {
+    if (character.rankValue) {
       sheet['rank'] = {
-        name: character._rank?.name,
-        id: character._rank?.id,
+        name: character.rankValue?.name,
+        id: character.rankValue?.id,
       };
     }
 
@@ -875,7 +875,7 @@ class Marshaller {
       character.legacyMode
     ) {
       sheet['focuses'] = [...character.focuses];
-      sheet['attributes'] = this.toAttributeObject(character._attributes);
+      sheet['attributes'] = this.toAttributeObject(character.attributeValues);
       sheet['disciplines'] = this.getDepartmentByNameObject(
         character.departments,
       );
@@ -926,10 +926,10 @@ class Marshaller {
       });
     }
 
-    if (character._rank) {
+    if (character.rankValue) {
       sheet['rank'] = {
-        name: character._rank?.name,
-        id: character._rank?.id,
+        name: character.rankValue?.name,
+        id: character.rankValue?.id,
       };
     }
 
@@ -1945,9 +1945,9 @@ class Marshaller {
     const rank = json.rank;
     if (rank) {
       if (typeof rank === 'string') {
-        result._rank = new CharacterRank(rank as string);
+        result.rankValue = new CharacterRank(rank as string);
       } else if (rank.name) {
-        result._rank = new CharacterRank(rank.name, rank.id);
+        result.rankValue = new CharacterRank(rank.name, rank.id);
       }
     }
     if (json.version) {
@@ -2277,9 +2277,9 @@ class Marshaller {
       }
     } else {
       const rank =
-        result._rank == null
+        result.rankValue == null
           ? null
-          : RanksHelper.instance().getRankByName(result._rank?.name);
+          : RanksHelper.instance().getRankByName(result.rankValue?.name);
       if (rank && result.stereotype === Stereotype.Npc) {
         if (result.npcGenerationStep == null) {
           result.npcGenerationStep = new NpcGenerationStep();
@@ -2291,7 +2291,7 @@ class Marshaller {
       const focuses = [...json.focuses];
       if (result.stereotype === Stereotype.MainCharacter) {
         result.legacyMode = true;
-        result._focuses = focuses;
+        result.focusValues = focuses;
       } else if (result.stereotype === Stereotype.SupportingCharacter) {
         if (result.supportingStep == null) {
           result.supportingStep = new SupportingStep();
@@ -2308,7 +2308,7 @@ class Marshaller {
       AttributesHelper.getAllAttributes().forEach((a) => {
         const value = json.attributes[Attribute[a]];
         if (value != null) {
-          result._attributes[a] = value;
+          result.attributeValues[a] = value;
         }
       });
     }
@@ -2327,9 +2327,7 @@ class Marshaller {
       } else {
         DepartmentsHelper.instance
           .getDepartments()
-          .forEach(
-            (d) => (result._skills[d] = json.disciplines[Department[d]]),
-          );
+          .forEach((d) => (result.skills[d] = json.disciplines[Department[d]]));
       }
     }
     if (json.environment) {

--- a/WebTools/src/helpers/missionPods.ts
+++ b/WebTools/src/helpers/missionPods.ts
@@ -63,16 +63,16 @@ export class MissionPodModel {
 }
 
 export class MissionPodHelper {
-  private static _instance: MissionPodHelper;
+  private static singleton: MissionPodHelper;
 
   public static instance() {
-    if (MissionPodHelper._instance == null) {
-      MissionPodHelper._instance = new MissionPodHelper();
+    if (MissionPodHelper.singleton == null) {
+      MissionPodHelper.singleton = new MissionPodHelper();
     }
-    return MissionPodHelper._instance;
+    return MissionPodHelper.singleton;
   }
 
-  private _missionPods2e: { [id: number]: MissionPodModel } = {
+  private missionPods2e: { [id: number]: MissionPodModel } = {
     [MissionPod.AstrometricsAndNavigation]: new MissionPodModel(
       MissionPod.AstrometricsAndNavigation,
       'Astrometrics and Navigation',
@@ -197,7 +197,7 @@ export class MissionPodHelper {
     ),
   };
 
-  private _missionPods: { [id: number]: MissionPodModel } = {
+  private missionPods: { [id: number]: MissionPodModel } = {
     [MissionPod.CommandAndControl]: new MissionPodModel(
       MissionPod.CommandAndControl,
       'Command & Control',
@@ -331,7 +331,7 @@ export class MissionPodHelper {
 
   getMissionPodByName(name: string, version: number) {
     let result = undefined;
-    const list = version === 1 ? this._missionPods : this._missionPods2e;
+    const list = version === 1 ? this.missionPods : this.missionPods2e;
     for (const id in list) {
       if (MissionPod[id] === name) {
         result = list[id];
@@ -344,8 +344,7 @@ export class MissionPodHelper {
   getMissionPods(starship: Starship) {
     const missionPods: MissionPodModel[] = [];
 
-    const list =
-      starship.version === 1 ? this._missionPods : this._missionPods2e;
+    const list = starship.version === 1 ? this.missionPods : this.missionPods2e;
     for (const pod in list) {
       const p = list[pod];
       if (p.isPrerequisitesFulfilled(starship)) {

--- a/WebTools/src/helpers/missionProfiles.ts
+++ b/WebTools/src/helpers/missionProfiles.ts
@@ -106,16 +106,16 @@ export class MissionProfileModel {
 }
 
 class MissionProfiles {
-  static _instance: MissionProfiles;
+  static singleton: MissionProfiles;
 
   static get instance() {
-    if (this._instance == null) {
-      this._instance = new MissionProfiles();
+    if (this.singleton == null) {
+      this.singleton = new MissionProfiles();
     }
-    return this._instance;
+    return this.singleton;
   }
 
-  private _profiles2e: { [id: number]: MissionProfileModel } = {
+  private profiles2e: { [id: number]: MissionProfileModel } = {
     [MissionProfile.Battlecruiser]: new MissionProfileModel(
       MissionProfile.Battlecruiser,
       'Battlecruiser',
@@ -361,7 +361,7 @@ class MissionProfiles {
     ),
   };
 
-  private _profiles: { [id: number]: MissionProfileModel } = {
+  private profiles: { [id: number]: MissionProfileModel } = {
     [MissionProfile.StrategicAndDiplomatic]: new MissionProfileModel(
       MissionProfile.StrategicAndDiplomatic,
       'Strategic and Diplomatic Operations',
@@ -617,7 +617,7 @@ class MissionProfiles {
     ),
   };
 
-  private _klingonProfiles: { [id: number]: MissionProfileModel } = {
+  private klingonProfiles: { [id: number]: MissionProfileModel } = {
     [MissionProfile.CrisisAndEmergencyResponse]: new MissionProfileModel(
       MissionProfile.CrisisAndEmergencyResponse,
       'Crisis Response and Interception',
@@ -709,7 +709,7 @@ class MissionProfiles {
     //    []),
   };
 
-  private _klingonProfiles2e: { [id: number]: MissionProfileModel } = {
+  private klingonProfiles2e: { [id: number]: MissionProfileModel } = {
     [MissionProfile.CrisisAndEmergencyResponse]: new MissionProfileModel(
       MissionProfile.CrisisAndEmergencyResponse,
       'Crisis Response and Interception',
@@ -825,7 +825,7 @@ class MissionProfiles {
     ),
   };
 
-  private _stationProfiles: { [id: number]: MissionProfileModel } = {
+  private stationProfiles: { [id: number]: MissionProfileModel } = {
     [MissionProfile.AdministrationAndBureaucracyStation]:
       new MissionProfileModel(
         MissionProfile.AdministrationAndBureaucracyStation,
@@ -954,27 +954,27 @@ class MissionProfiles {
 
   getMissionProfiles(starship: Starship) {
     const profiles: MissionProfileModel[] = [];
-    let list = this._profiles2e;
+    let list = this.profiles2e;
     if (starship.version === 1) {
       list = isKlingonWarrior1e(starship.type, starship.version)
-        ? this._klingonProfiles
-        : this._profiles;
+        ? this.klingonProfiles
+        : this.profiles;
     } else if (isKlingonWarriorType(starship.type)) {
-      list = this._klingonProfiles2e;
+      list = this.klingonProfiles2e;
     } else if (starship.type === CharacterType.Civilian) {
       list = {
         [MissionProfile.CrisisAndEmergencyResponse]:
-          this._profiles2e[MissionProfile.CrisisAndEmergencyResponse],
+          this.profiles2e[MissionProfile.CrisisAndEmergencyResponse],
         [MissionProfile.EntertainmentPleasureShip]:
-          this._profiles2e[MissionProfile.EntertainmentPleasureShip],
+          this.profiles2e[MissionProfile.EntertainmentPleasureShip],
         [MissionProfile.CivilianMerchantMarine]:
-          this._profiles2e[MissionProfile.CivilianMerchantMarine],
+          this.profiles2e[MissionProfile.CivilianMerchantMarine],
         [MissionProfile.ColonySupport]:
-          this._profiles2e[MissionProfile.ColonySupport],
+          this.profiles2e[MissionProfile.ColonySupport],
         [MissionProfile.TechnicalTestBed]:
-          this._profiles2e[MissionProfile.TechnicalTestBed],
+          this.profiles2e[MissionProfile.TechnicalTestBed],
         [MissionProfile.ScientificAndSurvey]:
-          this._profiles2e[MissionProfile.ScientificAndSurvey],
+          this.profiles2e[MissionProfile.ScientificAndSurvey],
       };
     }
     for (const profile of Object.values(list)) {
@@ -991,7 +991,7 @@ class MissionProfiles {
   }
 
   getStationMissionProfiles() {
-    const profiles = [...Object.values(this._stationProfiles)];
+    const profiles = [...Object.values(this.stationProfiles)];
     profiles.sort((p1, p2) => {
       return p1.localizedName.localeCompare(p2.localizedName);
     });
@@ -1005,7 +1005,7 @@ class MissionProfiles {
     if ('PolicalOperationsStation' === name) {
       name = MissionProfile[MissionProfile.PoliticalOperationsStation];
     }
-    const profiles = [...Object.values(this._stationProfiles)].filter(
+    const profiles = [...Object.values(this.stationProfiles)].filter(
       (p) => MissionProfile[p.id] === name,
     );
 
@@ -1015,7 +1015,7 @@ class MissionProfiles {
   getStationMissionProfileByType(
     type: MissionProfile,
   ): MissionProfileModel | undefined {
-    return this._stationProfiles[type];
+    return this.stationProfiles[type];
   }
 
   getMissionProfileByName(
@@ -1023,13 +1023,13 @@ class MissionProfiles {
     type: CharacterType,
     version: number,
   ) {
-    let list = this._profiles2e;
+    let list = this.profiles2e;
     if (version === 1) {
       list = isKlingonWarrior1e(type, version)
-        ? this._klingonProfiles
-        : this._profiles;
+        ? this.klingonProfiles
+        : this.profiles;
     } else if (isKlingonWarriorType(type)) {
-      list = this._klingonProfiles2e;
+      list = this.klingonProfiles2e;
     }
     let result = null;
     for (const id in list) {

--- a/WebTools/src/helpers/prerequisite.ts
+++ b/WebTools/src/helpers/prerequisite.ts
@@ -178,10 +178,10 @@ export class AnyOfPrerequisite
 }
 
 export class CareersPrerequisite implements IConstructPrerequisite {
-  private _careers: Career[];
+  private careers: Career[];
 
   constructor(...careers: Career[]) {
-    this._careers = careers;
+    this.careers = careers;
   }
 
   isPrerequisiteFulfilled(
@@ -190,13 +190,13 @@ export class CareersPrerequisite implements IConstructPrerequisite {
     return (
       character instanceof Character &&
       character.careerStep?.career != null &&
-      this._careers.indexOf(character.careerStep?.career) > -1
+      this.careers.indexOf(character.careerStep?.career) > -1
     );
   }
   describe(): string {
     return (
       'Only available to ' +
-      this._careers.map((c) => Career[c]).join(', ') +
+      this.careers.map((c) => Career[c]).join(', ') +
       ' characters'
     );
   }

--- a/WebTools/src/helpers/ranks.ts
+++ b/WebTools/src/helpers/ranks.ts
@@ -175,26 +175,26 @@ class HasCareerEventsPrerequisite implements ICharacterPrerequisite {
 }
 
 class TrackPrerequisite implements ICharacterPrerequisite {
-  private _track: Track;
+  private track: Track;
 
   constructor(track: Track) {
-    this._track = track;
+    this.track = track;
   }
 
   isPrerequisiteFulfilled(character: Character) {
-    return this._track === character.educationStep?.track;
+    return this.track === character.educationStep?.track;
   }
 }
 
 class NotTrackPrerequisite implements ICharacterPrerequisite {
-  private _track: Track;
+  private track: Track;
 
   constructor(track: Track) {
-    this._track = track;
+    this.track = track;
   }
 
   isPrerequisiteFulfilled(character: Character) {
-    return this._track !== character.educationStep?.track;
+    return this.track !== character.educationStep?.track;
   }
   describe(): string {
     return '';
@@ -202,11 +202,11 @@ class NotTrackPrerequisite implements ICharacterPrerequisite {
 }
 
 class RolesPrerequisite implements ICharacterPrerequisite {
-  private _roles: Role[];
+  private roles: Role[];
   private noRoleAllowed: boolean;
 
   constructor(roles: Role[], noRoleAllowed: boolean = false) {
-    this._roles = roles;
+    this.roles = roles;
     this.noRoleAllowed = noRoleAllowed;
   }
 
@@ -215,23 +215,23 @@ class RolesPrerequisite implements ICharacterPrerequisite {
       return this.noRoleAllowed;
     } else {
       return (
-        this._roles.indexOf(character.role) > -1 ||
+        this.roles.indexOf(character.role) > -1 ||
         (character.secondaryRole != null &&
-          this._roles.indexOf(character.secondaryRole) >= 0)
+          this.roles.indexOf(character.secondaryRole) >= 0)
       );
     }
   }
 }
 
 class NotEraPrerequisite implements ICharacterPrerequisite {
-  private _era: Era;
+  private era: Era;
 
   constructor(era: Era) {
-    this._era = era;
+    this.era = era;
   }
 
   isPrerequisiteFulfilled(character: Character) {
-    return store.getState().context.era !== this._era;
+    return store.getState().context.era !== this.era;
   }
   describe(): string {
     return '';
@@ -289,16 +289,16 @@ export class RankModel {
 }
 
 export class RanksHelper {
-  private static _instance: RanksHelper;
+  private static singleton: RanksHelper;
 
   static instance(): RanksHelper {
-    if (RanksHelper._instance == null) {
-      RanksHelper._instance = new RanksHelper();
+    if (RanksHelper.singleton == null) {
+      RanksHelper.singleton = new RanksHelper();
     }
-    return RanksHelper._instance;
+    return RanksHelper.singleton;
   }
 
-  private _ranks: RankModel[] = [
+  private ranks: RankModel[] = [
     new RankModel(
       Rank.Captain,
       'Captain',
@@ -1371,10 +1371,10 @@ export class RanksHelper {
 
   getRanks(character: Character, ignorePrerequisites?: boolean) {
     return !ignorePrerequisites
-      ? this._ranks.filter((r) =>
+      ? this.ranks.filter((r) =>
           r.prerequisites.every((p) => p.isPrerequisiteFulfilled(character)),
         )
-      : [...this._ranks];
+      : [...this.ranks];
   }
 
   getRanksByType(type: CharacterType, version: number) {
@@ -1537,13 +1537,13 @@ export class RanksHelper {
   }
 
   getRank(rank: Rank) {
-    const ranks = this._ranks.filter((r) => r.id === rank);
+    const ranks = this.ranks.filter((r) => r.id === rank);
     return ranks?.length ? ranks[0] : null;
   }
 
   getRankByName(name: string) {
-    for (const rank in this._ranks) {
-      const r = this._ranks[rank];
+    for (const rank in this.ranks) {
+      const r = this.ranks[rank];
       if (r.name === name) {
         return r;
       }
@@ -1553,8 +1553,8 @@ export class RanksHelper {
   }
 
   getRankByRankName(name: string): Rank | undefined {
-    for (const rank in this._ranks) {
-      const r = this._ranks[rank];
+    for (const rank in this.ranks) {
+      const r = this.ranks[rank];
       if (Rank[r.id] === name) {
         return r.id;
       }

--- a/WebTools/src/helpers/roles.ts
+++ b/WebTools/src/helpers/roles.ts
@@ -265,16 +265,16 @@ export class RoleModel {
 }
 
 export class RolesHelper {
-  private static _instance;
+  private static singleton;
 
   static get instance() {
-    if (RolesHelper._instance == null) {
-      RolesHelper._instance = new RolesHelper();
+    if (RolesHelper.singleton == null) {
+      RolesHelper.singleton = new RolesHelper();
     }
-    return RolesHelper._instance;
+    return RolesHelper.singleton;
   }
 
-  private _roles: RoleModel[] = [
+  private roles: RoleModel[] = [
     new RoleModel(
       Role.CommandingOfficer,
       'Commanding Officer',
@@ -902,7 +902,7 @@ export class RolesHelper {
   getRoles(character: Character) {
     const departments = this.determineHighestDiscipline(character);
     const roles: RoleModel[] = [];
-    const list = this._roles;
+    const list = this.roles;
     for (const r of list) {
       if (r.isPrerequisitesFilled(character)) {
         if (
@@ -949,7 +949,7 @@ export class RolesHelper {
   }
 
   getRoleModelByName(role: string, type: CharacterType) {
-    const list = this._roles;
+    const list = this.roles;
     for (const r of list) {
       if (r.name === role) {
         return r;
@@ -960,7 +960,7 @@ export class RolesHelper {
   }
 
   getRole(role: Role, characterType: CharacterType) {
-    const roles = this._roles.filter((r) => r.id === role);
+    const roles = this.roles.filter((r) => r.id === role);
     if (roles.length === 0) {
       return undefined;
     } else if (roles.length === 1) {
@@ -983,7 +983,7 @@ export class RolesHelper {
 
   getSoloRole(role: Role) {
     let result = undefined;
-    this._roles.forEach((r) => {
+    this.roles.forEach((r) => {
       if (r.id === role && result == null) {
         result = r;
       }
@@ -992,7 +992,7 @@ export class RolesHelper {
   }
 
   getRoleByName(role: string): Role {
-    const list = this._roles;
+    const list = this.roles;
     for (const r of list) {
       if (r.name === role) {
         return r.id;
@@ -1003,7 +1003,7 @@ export class RolesHelper {
   }
 
   getRoleByTypeName(role: string) {
-    const list = this._roles;
+    const list = this.roles;
     for (const r of list) {
       if (Role[r.id] === role) {
         return r.id;

--- a/WebTools/src/helpers/serviceYear.ts
+++ b/WebTools/src/helpers/serviceYear.ts
@@ -1,5 +1,5 @@
 class ServiceYear {
-  private static _instance?: ServiceYear;
+  private static singleton?: ServiceYear;
 
   private years = {
     2024: 'The Bell Riots, the Irish Reunification, the Europa Mission is launched',
@@ -91,10 +91,10 @@ class ServiceYear {
   };
 
   public static instance() {
-    if (ServiceYear._instance == null) {
-      ServiceYear._instance = new ServiceYear();
+    if (ServiceYear.singleton == null) {
+      ServiceYear.singleton = new ServiceYear();
     }
-    return ServiceYear._instance;
+    return ServiceYear.singleton;
   }
 
   public getTextHint(serviceYear: number) {

--- a/WebTools/src/helpers/sources.ts
+++ b/WebTools/src/helpers/sources.ts
@@ -111,7 +111,7 @@ class Sources {
     new SourceTypeModel(SourceType.Unofficial, 'Unofficial Books'),
   ];
 
-  private _sources: { [id: number]: SourceViewModel } = {
+  private sources: { [id: number]: SourceViewModel } = {
     [Source.Core]: new SourceViewModel(
       Source.Core,
       SourceType.CoreBook,
@@ -295,8 +295,8 @@ class Sources {
 
   getSources() {
     const sources: SourceViewModel[] = [];
-    for (const source in this._sources) {
-      const src = this._sources[source];
+    for (const source in this.sources) {
+      const src = this.sources[source];
       sources.push(src);
     }
     return sources;
@@ -313,11 +313,11 @@ class Sources {
   getSourceName(sources: Source[], alwaysShow: boolean = false) {
     let result = '';
     sources.forEach((s) => {
-      if (s !== Source.None && (this._sources[s].available || alwaysShow)) {
+      if (s !== Source.None && (this.sources[s].available || alwaysShow)) {
         result =
           result === ''
-            ? this._sources[s].localizedName
-            : result + ', ' + this._sources[s].localizedName;
+            ? this.sources[s].localizedName
+            : result + ', ' + this.sources[s].localizedName;
       }
     });
     return result;

--- a/WebTools/src/helpers/spaceframes.ts
+++ b/WebTools/src/helpers/spaceframes.ts
@@ -49,16 +49,16 @@ export class NotSourcePrerequisite implements IConstructPrerequisite {
 }
 
 export class SpaceframeHelper {
-  private static _instance;
+  private static singleton;
 
   static instance(): SpaceframeHelper {
-    if (SpaceframeHelper._instance == null) {
-      SpaceframeHelper._instance = new SpaceframeHelper();
+    if (SpaceframeHelper.singleton == null) {
+      SpaceframeHelper.singleton = new SpaceframeHelper();
     }
-    return SpaceframeHelper._instance;
+    return SpaceframeHelper.singleton;
   }
 
-  private _frames: { [id: number]: SpaceframeModel } = {
+  private frames: { [id: number]: SpaceframeModel } = {
     [Spaceframe.Akira]: new SpaceframeModel(
       Spaceframe.Akira,
       CharacterType.Starfleet,
@@ -3247,8 +3247,8 @@ export class SpaceframeHelper {
 
   getSpaceframes(starship: Starship, ignoreMaxServiceYear: boolean = false) {
     const frames: SpaceframeModel[] = [];
-    for (const frame in this._frames) {
-      const f = this._frames[frame];
+    for (const frame in this.frames) {
+      const f = this.frames[frame];
       if (
         f.serviceYear <= starship.serviceYear &&
         (f.maxServiceYear >= starship.serviceYear || ignoreMaxServiceYear)
@@ -3267,15 +3267,15 @@ export class SpaceframeHelper {
   }
 
   getSpaceframe(frame: Spaceframe) {
-    const result = this._frames[frame];
+    const result = this.frames[frame];
     return result ? result : undefined;
   }
 
   getSpaceframeByName(name: string) {
     let result = undefined;
-    for (const id in this._frames) {
+    for (const id in this.frames) {
       if (Spaceframe[id] === name) {
-        result = this._frames[id];
+        result = this.frames[id];
         break;
       }
     }

--- a/WebTools/src/helpers/species.ts
+++ b/WebTools/src/helpers/species.ts
@@ -25,8 +25,8 @@ export interface ISpecies {
   nameSuggestions: NameModel[];
 }
 
-class _Species {
-  private _species: { [id: number]: SpeciesModel } = {
+class SpeciesRepository {
+  private species: { [id: number]: SpeciesModel } = {
     [Species.Andorian]: new SpeciesModel(
       Species.Andorian,
       'Andorian',
@@ -4200,8 +4200,8 @@ class _Species {
 
   getAllSpecies() {
     const result = [];
-    for (const archetype in this._species) {
-      const spec = this._species[archetype];
+    for (const archetype in this.species) {
+      const spec = this.species[archetype];
       result.push(spec);
     }
     return result;
@@ -4209,8 +4209,8 @@ class _Species {
 
   getSpecies(characterType: CharacterType) {
     const species: SpeciesModel[] = [];
-    for (const archetype in this._species) {
-      const spec = this._species[archetype];
+    for (const archetype in this.species) {
+      const spec = this.species[archetype];
 
       const hasEra =
         spec.eras.indexOf(store.getState().context.era) > -1 ||
@@ -4240,7 +4240,7 @@ class _Species {
           ? [Species.Klingon]
           : [Species.Klingon, Species.KlingonQuchHa, Species.KlingonQuchHa_2E];
       for (const archetype of klingonSpecies) {
-        const spec = this._species[archetype];
+        const spec = this.species[archetype];
         const hasSource = hasAnySource(spec.sources);
 
         if (hasSource && !this.ignoreSpecies(archetype)) {
@@ -4259,7 +4259,7 @@ class _Species {
       const alliedMilitary = (character.typeDetails as AlliedMilitaryDetails)
         .alliedMilitary;
       const species = alliedMilitary.species
-        .map((s) => this._species[s])
+        .map((s) => this.species[s])
         .filter((s) => hasAnySource(s.sources) && !this.ignoreSpecies(s.id));
       return species.sort((a, b) => {
         return a.localizedName.localeCompare(b.localizedName);
@@ -4273,13 +4273,13 @@ class _Species {
   }
 
   getSpeciesByType(species: Species): SpeciesModel {
-    const model = this._species[species];
+    const model = this.species[species];
     return model;
   }
 
   getSpeciesByName(name: string) {
-    for (const sp in this._species) {
-      const spec = this._species[sp];
+    for (const sp in this.species) {
+      const spec = this.species[sp];
 
       if (spec.name === name) {
         return spec.id;
@@ -4290,9 +4290,9 @@ class _Species {
 
   getSpeciesTypeByName(name: string): Species {
     let result = undefined;
-    for (const species in this._species) {
+    for (const species in this.species) {
       if (name === Species[species]) {
-        const speciesModel = this._species[species];
+        const speciesModel = this.species[species];
         result = speciesModel.id;
         break;
       }
@@ -4768,8 +4768,8 @@ class _Species {
 
   getCaptainsLogSpecies() {
     const result: SpeciesModel[] = [];
-    for (const id in this._species) {
-      const species = this._species[id];
+    for (const id in this.species) {
+      const species = this.species[id];
       if (species.sources.indexOf(Source.CaptainsLog) >= 0) {
         result.push(species);
       }
@@ -4780,4 +4780,4 @@ class _Species {
   }
 }
 
-export const SpeciesHelper = new _Species();
+export const SpeciesHelper = new SpeciesRepository();

--- a/WebTools/src/helpers/speciesAbility.ts
+++ b/WebTools/src/helpers/speciesAbility.ts
@@ -82,7 +82,7 @@ export class SpeciesAbility {
 }
 
 export class SpeciesAbilityList {
-  private static _instance: SpeciesAbilityList;
+  private static singleton: SpeciesAbilityList;
 
   private items: { [id: number]: SpeciesAbility } = {
     [Species.Aenar]: new SpeciesAbility(Species.Aenar),
@@ -413,10 +413,10 @@ export class SpeciesAbilityList {
   };
 
   static get instance() {
-    if (SpeciesAbilityList._instance == null) {
-      SpeciesAbilityList._instance = new SpeciesAbilityList();
+    if (SpeciesAbilityList.singleton == null) {
+      SpeciesAbilityList.singleton = new SpeciesAbilityList();
     }
-    return SpeciesAbilityList._instance;
+    return SpeciesAbilityList.singleton;
   }
 
   getBySpecies(species: Species) {

--- a/WebTools/src/helpers/stationScale.ts
+++ b/WebTools/src/helpers/stationScale.ts
@@ -1,5 +1,5 @@
 class StationScale {
-  private static _instance?: StationScale;
+  private static singleton?: StationScale;
 
   private scales = {
     1: 'Smaller than the International Space Station',
@@ -17,10 +17,10 @@ class StationScale {
   };
 
   public static instance() {
-    if (StationScale._instance == null) {
-      StationScale._instance = new StationScale();
+    if (StationScale.singleton == null) {
+      StationScale.singleton = new StationScale();
     }
-    return StationScale._instance;
+    return StationScale.singleton;
   }
 
   public getTextHint(scale: number) {

--- a/WebTools/src/helpers/talentModel.ts
+++ b/WebTools/src/helpers/talentModel.ts
@@ -29,7 +29,7 @@ export class TalentModel implements ITalent {
   maxRank: number;
   category: TalentCategorization;
   aliases: AliasModel[];
-  _specialRule: (version: number) => boolean;
+  specialRule: (version: number) => boolean;
 
   constructor(
     name: string,
@@ -66,15 +66,15 @@ export class TalentModel implements ITalent {
       const f = (version: number) => {
         return specialRule;
       };
-      this._specialRule = f;
+      this.specialRule = f;
     } else {
-      this._specialRule = specialRule;
+      this.specialRule = specialRule;
     }
     this.aliases = aliases || AliasModel[0];
   }
 
   isSpecialRule(version: number): boolean {
-    return this._specialRule(version);
+    return this.specialRule(version);
   }
 
   get isStarshipTalent() {

--- a/WebTools/src/helpers/talents.ts
+++ b/WebTools/src/helpers/talents.ts
@@ -648,7 +648,7 @@ class CreaturePrerequisite implements IConstructPrerequisite {
 }
 
 export class Talents {
-  private _talents: TalentModel[] = [
+  private talents: TalentModel[] = [
     new TalentModel(
       'Advisor',
       'Whenever you assist another character using your Command Discipline, the character being assisted may re-roll one d20.',
@@ -6104,7 +6104,7 @@ export class Talents {
     ),
   ];
 
-  private _starshipTalents: TalentModel[] = [
+  private starshipTalents: TalentModel[] = [
     // Starships
     new TalentModel(
       'Ablative Armor',
@@ -7252,7 +7252,7 @@ export class Talents {
     ),
   ];
 
-  private _specialRules: TalentModel[] = [
+  private specialRules: TalentModel[] = [
     new TalentModel(
       'Additional Propulsion System',
       'The vessel includes an additional, non-standard form of propulsion, such as Transwarp or Quantum Slipstream Drive.',
@@ -9407,8 +9407,8 @@ export class Talents {
 
   getTalents(): TalentModel[] {
     const result = [];
-    this._talents.forEach((t) => result.push(t));
-    this._starshipTalents.forEach((t) => result.push(t));
+    this.talents.forEach((t) => result.push(t));
+    this.starshipTalents.forEach((t) => result.push(t));
     return result;
   }
 
@@ -9420,8 +9420,8 @@ export class Talents {
     }
 
     if (talent == null) {
-      for (let i = 0; i < this._talents.length; i++) {
-        const t = this._talents[i];
+      for (let i = 0; i < this.talents.length; i++) {
+        const t = this.talents[i];
         if (t.matches(name)) {
           talent = t;
           break;
@@ -9430,8 +9430,8 @@ export class Talents {
     }
 
     if (talent == null) {
-      for (let i = 0; i < this._starshipTalents.length; i++) {
-        const t = this._starshipTalents[i];
+      for (let i = 0; i < this.starshipTalents.length; i++) {
+        const t = this.starshipTalents[i];
         if (t.matches(name)) {
           talent = t;
           break;
@@ -9440,8 +9440,8 @@ export class Talents {
     }
 
     if (talent == null) {
-      for (let i = 0; i < this._specialRules.length; i++) {
-        const t = this._specialRules[i];
+      for (let i = 0; i < this.specialRules.length; i++) {
+        const t = this.specialRules[i];
         if (t.matches(name)) {
           talent = t;
           break;
@@ -9491,12 +9491,12 @@ export class Talents {
     ) {
       return [this.getTalent('Morphogenic Matrix')];
     } else {
-      const result = this._talents.filter((t) =>
+      const result = this.talents.filter((t) =>
         t.isPrerequisiteFulfilled(character),
       );
 
       if (character.stereotype === Stereotype.Npc) {
-        const rules = this._specialRules.filter(
+        const rules = this.specialRules.filter(
           (t) =>
             t.isPrerequisiteFulfilled(character) &&
             !character.hasTalent(t.name),
@@ -9516,8 +9516,8 @@ export class Talents {
     includeCustom: boolean = false,
   ) {
     const talents: TalentModel[] = [];
-    for (let i = 0; i < this._starshipTalents.length; i++) {
-      const talent = this._starshipTalents[i];
+    for (let i = 0; i < this.starshipTalents.length; i++) {
+      const talent = this.starshipTalents[i];
       let include = talent.isStarshipTalent;
       if (starship instanceof Station) {
         include = include || talent.isStarbaseTalent;
@@ -9546,11 +9546,11 @@ export class Talents {
   }
 
   getAllAvailableTalentsForNpc(character: Character): TalentModel[] {
-    const result = this._talents.filter((t) =>
+    const result = this.talents.filter((t) =>
       t.isPrerequisiteFulfilled(character),
     );
     result.push(
-      ...this._specialRules.filter((t) => t.isPrerequisiteFulfilled(character)),
+      ...this.specialRules.filter((t) => t.isPrerequisiteFulfilled(character)),
     );
     result.push(this.customTalent);
     return result;

--- a/WebTools/src/helpers/tracks.ts
+++ b/WebTools/src/helpers/tracks.ts
@@ -140,16 +140,16 @@ export class TrackModel {
 }
 
 export class TracksHelper {
-  private static _instance: TracksHelper;
+  private static singleton: TracksHelper;
 
   static get instance() {
-    if (TracksHelper._instance == null) {
-      TracksHelper._instance = new TracksHelper();
+    if (TracksHelper.singleton == null) {
+      TracksHelper.singleton = new TracksHelper();
     }
-    return TracksHelper._instance;
+    return TracksHelper.singleton;
   }
 
-  private _tracks: TrackModel[] = [
+  private tracks: TrackModel[] = [
     new TrackModel(
       Track.Command,
       'Command Track',
@@ -357,7 +357,7 @@ export class TracksHelper {
     ),
   ];
 
-  private _version2Tracks: TrackModel[] = [
+  private version2Tracks: TrackModel[] = [
     new TrackModel(
       Track.Command,
       'Command Track',
@@ -517,7 +517,7 @@ export class TracksHelper {
     ),
   ];
 
-  private _klingonTracks: TrackModel[] = [
+  private klingonTracks: TrackModel[] = [
     new TrackModel(
       Track.Command,
       'Command Officer',
@@ -630,7 +630,7 @@ export class TracksHelper {
     ),
   ];
 
-  private _alliedMilitaryTracks: TrackModel[] = [
+  private alliedMilitaryTracks: TrackModel[] = [
     new TrackModel(
       Track.RankAndFile,
       'Rank and File',
@@ -760,7 +760,7 @@ export class TracksHelper {
     ),
   ];
 
-  private _ambassardorTracks: TrackModel[] = [
+  private ambassardorTracks: TrackModel[] = [
     new TrackModel(
       Track.DiplomaticCorps,
       'Diplomatic Corps',
@@ -814,7 +814,7 @@ export class TracksHelper {
     ),
   ];
 
-  private _civilianTracks: TrackModel[] = [
+  private civilianTracks: TrackModel[] = [
     new TrackModel(
       Track.FreightAndTransport,
       'Freight and Transport',
@@ -1079,23 +1079,23 @@ export class TracksHelper {
 
   private chooseList(type: CharacterType, version: number) {
     if (type === CharacterType.AlliedMilitary) {
-      return this._alliedMilitaryTracks;
+      return this.alliedMilitaryTracks;
     } else if (type === CharacterType.AmbassadorDiplomat) {
-      return this._ambassardorTracks;
+      return this.ambassardorTracks;
     } else if (type === CharacterType.Civilian) {
-      return this._civilianTracks;
+      return this.civilianTracks;
     } else if (isKlingonWarriorType(type)) {
-      return this._klingonTracks;
+      return this.klingonTracks;
     } else if (type === CharacterType.Cadet && version === 1) {
-      return [this._tracks[0], this._tracks[1], this._tracks[2]];
+      return [this.tracks[0], this.tracks[1], this.tracks[2]];
     } else if (type === CharacterType.Cadet) {
       return [
-        this._version2Tracks[0],
-        this._version2Tracks[1],
-        this._version2Tracks[2],
+        this.version2Tracks[0],
+        this.version2Tracks[1],
+        this.version2Tracks[2],
       ];
     } else {
-      return this._tracks;
+      return this.tracks;
     }
   }
 
@@ -1119,22 +1119,22 @@ export class TracksHelper {
 
   getSoloTracks(type: CharacterType) {
     if (type === CharacterType.Starfleet) {
-      return [this._tracks[0], this._tracks[1], this._tracks[2]];
+      return [this.tracks[0], this.tracks[1], this.tracks[2]];
     } else if (type === CharacterType.AlliedMilitary) {
-      return this._alliedMilitaryTracks;
+      return this.alliedMilitaryTracks;
     } else if (type === CharacterType.AmbassadorDiplomat) {
-      return this._ambassardorTracks;
+      return this.ambassardorTracks;
     } else {
-      return this._civilianTracks;
+      return this.civilianTracks;
     }
   }
 
   getSoloTrack(track: Track): TrackModel {
     const tracks = [
-      this._tracks,
-      this._alliedMilitaryTracks,
-      this._ambassardorTracks,
-      this._civilianTracks,
+      this.tracks,
+      this.alliedMilitaryTracks,
+      this.ambassardorTracks,
+      this.civilianTracks,
     ];
     const result = tracks
       .map((list) => list.filter((t) => t.id === track))
@@ -1146,7 +1146,7 @@ export class TracksHelper {
   getTrack(track: Track, type: CharacterType, version: number): TrackModel {
     const list =
       type === CharacterType.Starfleet && version > 1
-        ? this._version2Tracks
+        ? this.version2Tracks
         : this.chooseList(type, version);
     let result = null;
     for (const t of list) {
@@ -1160,7 +1160,7 @@ export class TracksHelper {
 
   getOtherStarfleetTracks(): TrackModel[] {
     if (hasSource(Source.SciencesDivision)) {
-      return this._tracks.filter(
+      return this.tracks.filter(
         (t) =>
           t.id === Track.UniversityAlumni || t.id === Track.ResearchInternship,
       );
@@ -1171,14 +1171,14 @@ export class TracksHelper {
 
   getVersion2StarfleetTracks() {
     if (hasSource(Source.Core2ndEdition)) {
-      return this._version2Tracks;
+      return this.version2Tracks;
     } else {
       return [];
     }
   }
 
   getOfficerStarfleetTracks() {
-    return this._tracks
+    return this.tracks
       .filter(
         (t) =>
           t.id !== Track.UniversityAlumni &&
@@ -1189,7 +1189,7 @@ export class TracksHelper {
   }
 
   getEnlistedStarfleetTracks() {
-    return this._tracks
+    return this.tracks
       .filter(
         (t) =>
           t.id !== Track.UniversityAlumni && t.id !== Track.ResearchInternship,
@@ -1203,7 +1203,7 @@ export class TracksHelper {
       const roll = Math.floor(Math.random() * tracks.length);
       return tracks[roll];
     } else if (characterType === CharacterType.Starfleet) {
-      const list = this._version2Tracks;
+      const list = this.version2Tracks;
       const roll = Math.floor(Math.random() * list.length);
       return list[roll].id;
     } else {

--- a/WebTools/src/helpers/upbringings.ts
+++ b/WebTools/src/helpers/upbringings.ts
@@ -97,7 +97,7 @@ export class EarlyOutlookModel {
 }
 
 class Upbringings {
-  private _upbringings: EarlyOutlookModel[] = [
+  private upbringings: EarlyOutlookModel[] = [
     new EarlyOutlookModel(
       EarlyOutlook.MilitaryOrExploration,
       'Starfleet',
@@ -248,7 +248,7 @@ class Upbringings {
     ),
   ];
 
-  private _alternateUpbringings: EarlyOutlookModel[] = [
+  private alternateUpbringings: EarlyOutlookModel[] = [
     new EarlyOutlookModel(
       EarlyOutlook.ToExplore,
       'To Explore',
@@ -379,7 +379,7 @@ class Upbringings {
     ),
   ];
 
-  private _genericUpbringings: EarlyOutlookModel[] = [
+  private genericUpbringings: EarlyOutlookModel[] = [
     new EarlyOutlookModel(
       EarlyOutlook.MilitaryOrExploration,
       'Military or Exploration',
@@ -542,7 +542,7 @@ class Upbringings {
     ),
   ];
 
-  private _castes: EarlyOutlookModel[] = [
+  private castes: EarlyOutlookModel[] = [
     new EarlyOutlookModel(
       EarlyOutlook.WarriorCaste,
       'Warrior',
@@ -690,13 +690,13 @@ class Upbringings {
 
   private getEarlyOutlooksList(type: CharacterType, alternate: boolean) {
     if (alternate) {
-      return this._alternateUpbringings;
+      return this.alternateUpbringings;
     } else if (type === CharacterType.Starfleet) {
-      return this._upbringings;
+      return this.upbringings;
     } else if (isKlingonWarriorType(type)) {
-      return this._castes;
+      return this.castes;
     } else {
-      return this._genericUpbringings;
+      return this.genericUpbringings;
     }
   }
 

--- a/WebTools/src/helpers/weapons.ts
+++ b/WebTools/src/helpers/weapons.ts
@@ -346,7 +346,7 @@ export class EnergyLoadTypeModel {
 
   readonly type: EnergyLoadType;
   readonly description: string;
-  readonly _qualities: WeaponQuality[];
+  readonly qualities: WeaponQuality[];
   readonly effects: WeaponQuality[];
   readonly century: number;
 
@@ -359,7 +359,7 @@ export class EnergyLoadTypeModel {
   ) {
     this.type = type;
     this.description = description;
-    this._qualities = quality;
+    this.qualities = quality;
     this.effects = effect;
     this.century = century;
   }
@@ -377,7 +377,7 @@ export class EnergyLoadTypeModel {
   }
 
   get effectsAndQualities() {
-    return [...this._qualities].concat(this.effects);
+    return [...this.qualities].concat(this.effects);
   }
 
   static getEnergyLoadTypeModelByType(type: EnergyLoadType, version: number) {
@@ -682,8 +682,8 @@ export class TorpedoLoadTypeModel {
   readonly type: TorpedoLoadType;
   readonly description: string;
   readonly dice: number;
-  readonly _weaponEffects: WeaponQuality[];
-  readonly _weaponQualities: WeaponQuality[];
+  readonly weaponEffects: WeaponQuality[];
+  readonly weaponQualities: WeaponQuality[];
   readonly century: number;
 
   constructor(
@@ -697,8 +697,8 @@ export class TorpedoLoadTypeModel {
     this.type = type;
     this.description = description;
     this.dice = dice;
-    this._weaponEffects = effect;
-    this._weaponQualities = quality;
+    this.weaponEffects = effect;
+    this.weaponQualities = quality;
     this.century = century;
   }
 
@@ -716,8 +716,8 @@ export class TorpedoLoadTypeModel {
 
   get effectAndQualities() {
     const result = [];
-    this._weaponEffects.forEach((e) => result.push(e));
-    this._weaponQualities.forEach((q) => result.push(q));
+    this.weaponEffects.forEach((e) => result.push(e));
+    this.weaponQualities.forEach((q) => result.push(q));
     return result;
   }
 
@@ -748,8 +748,8 @@ export class MineTypeModel {
   readonly type: MineType;
   readonly description: string;
   readonly dice: number;
-  readonly _weaponEffects: WeaponQuality[];
-  readonly _weaponQualities: WeaponQuality[];
+  readonly weaponEffects: WeaponQuality[];
+  readonly weaponQualities: WeaponQuality[];
   readonly century: number;
 
   static readonly TYPES = [
@@ -994,8 +994,8 @@ export class MineTypeModel {
     this.type = type;
     this.description = description;
     this.dice = dice;
-    this._weaponEffects = effect;
-    this._weaponQualities = quality;
+    this.weaponEffects = effect;
+    this.weaponQualities = quality;
     this.century = century;
   }
 
@@ -1011,8 +1011,8 @@ export class MineTypeModel {
 
   get effectAndQualities(): WeaponQuality[] {
     const result = [];
-    result.push(...this._weaponEffects);
-    result.push(...this._weaponQualities);
+    result.push(...this.weaponEffects);
+    result.push(...this.weaponQualities);
     return result;
   }
 
@@ -1029,12 +1029,12 @@ export class MineTypeModel {
   }
 
   get effect() {
-    const result = this._weaponEffects.map((q) => q.localizedDescription);
+    const result = this.weaponEffects.map((q) => q.localizedDescription);
     return result.join(', ');
   }
 
   get qualities() {
-    const result = this._weaponQualities.map((q) => q.localizedDescription);
+    const result = this.weaponQualities.map((q) => q.localizedDescription);
     return result.join(', ');
   }
 
@@ -1098,7 +1098,7 @@ export class DeliverySystemModel {
 
 export class Weapon {
   usageCategory: UsageCategory;
-  _name: string;
+  nameValue: string;
   readonly baseDice: number;
   type: WeaponType;
   eras: Era[][];
@@ -1109,8 +1109,8 @@ export class Weapon {
     | TorpedoLoadTypeModel
     | MineTypeModel;
   deliveryType?: DeliverySystemModel;
-  _qualities: WeaponQuality[];
-  _effects: WeaponQuality[];
+  qualityValues: WeaponQuality[];
+  effectValues: WeaponQuality[];
   hands?: number;
   injuryType?: InjuryType;
   personalWeaponType?: PersonalWeaponType;
@@ -1133,7 +1133,7 @@ export class Weapon {
     requiresTalent: boolean = false,
   ) {
     this.usageCategory = usage;
-    this._name = name;
+    this.nameValue = name;
     this.baseDice = dice;
     this.type = type;
     this.eras = eras;
@@ -1145,7 +1145,7 @@ export class Weapon {
   copy() {
     const result = new Weapon(
       this.usageCategory,
-      this._name,
+      this.nameValue,
       this.baseDice,
       this.type,
       this.loadType,
@@ -1153,8 +1153,8 @@ export class Weapon {
       this.eras,
       this.requiresTalent,
     );
-    result._qualities = this._qualities;
-    result._effects = this._effects;
+    result.qualityValues = this.qualityValues;
+    result.effectValues = this.effectValues;
     result.hands = this.hands;
     result.injuryType = this.injuryType;
     result.personalWeaponType = this.personalWeaponType;
@@ -1202,7 +1202,7 @@ export class Weapon {
       }
       return quality;
     } else if (this.loadType instanceof TorpedoLoadTypeModel) {
-      return (this.loadType as TorpedoLoadTypeModel)._weaponQualities;
+      return (this.loadType as TorpedoLoadTypeModel).weaponQualities;
     } else {
       return [];
     }
@@ -1251,10 +1251,13 @@ export class Weapon {
   }
 
   get name() {
-    if (this.usageCategory === UsageCategory.Character && this._name?.length) {
-      return this._name;
-    } else if (this._name?.length) {
-      return this._name;
+    if (
+      this.usageCategory === UsageCategory.Character &&
+      this.nameValue?.length
+    ) {
+      return this.nameValue;
+    } else if (this.nameValue?.length) {
+      return this.nameValue;
     } else if (this.deliveryType != null) {
       return this.loadType.description + ' ' + this.deliveryType.description;
     } else if (this.type === WeaponType.TORPEDO) {
@@ -1269,12 +1272,12 @@ export class Weapon {
   // returns qualities without effects
   get qualities() {
     if (this.usageCategory === UsageCategory.Character) {
-      return this._qualities;
+      return this.qualityValues;
     } else if (
       this.loadType != null &&
       this.loadType instanceof EnergyLoadTypeModel
     ) {
-      return (this.loadType as EnergyLoadTypeModel)._qualities;
+      return (this.loadType as EnergyLoadTypeModel).qualities;
     } else {
       let result = [];
       if (
@@ -1282,13 +1285,13 @@ export class Weapon {
         this.loadType instanceof TorpedoLoadTypeModel
       ) {
         const torpedoLoadType = this.loadType as TorpedoLoadTypeModel;
-        result = [...torpedoLoadType._weaponQualities];
+        result = [...torpedoLoadType.weaponQualities];
       } else if (
         this.loadType != null &&
         this.loadType instanceof MineTypeModel
       ) {
         const mineType = this.loadType as MineTypeModel;
-        result = [...mineType._weaponQualities];
+        result = [...mineType.weaponQualities];
       }
 
       return result;
@@ -1297,7 +1300,7 @@ export class Weapon {
 
   get effects() {
     if (this.usageCategory === UsageCategory.Character) {
-      return this._effects;
+      return this.effectValues;
     } else {
       let result = [];
       if (
@@ -1310,13 +1313,13 @@ export class Weapon {
         this.loadType instanceof TorpedoLoadTypeModel
       ) {
         const torpedoLoadType = this.loadType as TorpedoLoadTypeModel;
-        result = [...torpedoLoadType._weaponEffects];
+        result = [...torpedoLoadType.weaponEffects];
       } else if (
         this.loadType != null &&
         this.loadType instanceof MineTypeModel
       ) {
         const mineType = this.loadType as MineTypeModel;
-        result = [...mineType._weaponEffects];
+        result = [...mineType.weaponEffects];
       }
 
       if (this.deliveryType?.additionalQuality != null) {
@@ -1395,8 +1398,8 @@ export class Weapon {
     personalWeaponType?: PersonalWeaponType,
   ) {
     const result = new Weapon(UsageCategory.Character, name, dice, type);
-    result._qualities = qualities;
-    result._effects = effects;
+    result.qualityValues = qualities;
+    result.effectValues = effects;
     result.hands = hands;
     result.injuryType = injuryType;
     result.personalWeaponType = personalWeaponType;
@@ -1723,8 +1726,8 @@ export enum PersonalWeaponType {
 }
 
 export class PersonalWeapons {
-  private static _instanceVersion1: PersonalWeaponsVersion1;
-  private static _instance: PersonalWeapons;
+  private static instanceVersion1: PersonalWeaponsVersion1;
+  private static singleton: PersonalWeapons;
 
   allTypes(): PersonalWeaponType[] {
     return Object.keys(PersonalWeaponType)
@@ -2077,15 +2080,15 @@ export class PersonalWeapons {
 
   static instance(version: number) {
     if (version === 1) {
-      if (PersonalWeapons._instanceVersion1 == null) {
-        PersonalWeapons._instanceVersion1 = new PersonalWeaponsVersion1();
+      if (PersonalWeapons.instanceVersion1 == null) {
+        PersonalWeapons.instanceVersion1 = new PersonalWeaponsVersion1();
       }
-      return PersonalWeapons._instanceVersion1;
+      return PersonalWeapons.instanceVersion1;
     } else {
-      if (PersonalWeapons._instance == null) {
-        PersonalWeapons._instance = new PersonalWeapons();
+      if (PersonalWeapons.singleton == null) {
+        PersonalWeapons.singleton = new PersonalWeapons();
       }
-      return PersonalWeapons._instance;
+      return PersonalWeapons.singleton;
     }
   }
 }

--- a/WebTools/src/mapping/table/planetaryFeaturesTable.ts
+++ b/WebTools/src/mapping/table/planetaryFeaturesTable.ts
@@ -83,7 +83,7 @@ export class ColonyFeatureModel implements PlanetaryFeature {
 }
 
 class ColonyFeatureRegistry {
-  private static _instance: ColonyFeatureRegistry;
+  private static singleton: ColonyFeatureRegistry;
 
   private items: ColonyFeatureModel[] = [
     new ColonyFeatureModel(
@@ -123,10 +123,10 @@ class ColonyFeatureRegistry {
   ];
 
   static get instance() {
-    if (ColonyFeatureRegistry._instance == null) {
-      ColonyFeatureRegistry._instance = new ColonyFeatureRegistry();
+    if (ColonyFeatureRegistry.singleton == null) {
+      ColonyFeatureRegistry.singleton = new ColonyFeatureRegistry();
     }
-    return ColonyFeatureRegistry._instance;
+    return ColonyFeatureRegistry.singleton;
   }
 
   getByType(type: ColonyFeature) {

--- a/WebTools/src/mapping/table/spectralClass.ts
+++ b/WebTools/src/mapping/table/spectralClass.ts
@@ -88,13 +88,13 @@ export class SpectralClassModel {
 }
 
 export class SpectralClassRegistry {
-  static _instance: SpectralClassRegistry;
+  static singleton: SpectralClassRegistry;
 
   static get instance() {
-    if (SpectralClassRegistry._instance == null) {
-      SpectralClassRegistry._instance = new SpectralClassRegistry();
+    if (SpectralClassRegistry.singleton == null) {
+      SpectralClassRegistry.singleton = new SpectralClassRegistry();
     }
-    return SpectralClassRegistry._instance;
+    return SpectralClassRegistry.singleton;
   }
 
   readonly classes: SpectralClassModel[] = [

--- a/WebTools/src/modify/model/characterAdvancementType.ts
+++ b/WebTools/src/modify/model/characterAdvancementType.ts
@@ -24,7 +24,7 @@ export class CharacterAdvancementModel {
 }
 
 class CharacterAdvancements {
-  static _instance: CharacterAdvancements;
+  static singleton: CharacterAdvancements;
 
   private items: CharacterAdvancementModel[] = [
     new CharacterAdvancementModel(
@@ -42,10 +42,10 @@ class CharacterAdvancements {
   ];
 
   static get instance() {
-    if (CharacterAdvancements._instance == null) {
-      CharacterAdvancements._instance = new CharacterAdvancements();
+    if (CharacterAdvancements.singleton == null) {
+      CharacterAdvancements.singleton = new CharacterAdvancements();
     }
-    return CharacterAdvancements._instance;
+    return CharacterAdvancements.singleton;
   }
 
   getItems() {

--- a/WebTools/src/modify/model/modificationType.ts
+++ b/WebTools/src/modify/model/modificationType.ts
@@ -28,7 +28,7 @@ export class ModificationModel {
 }
 
 class Modifications {
-  static _instance: Modifications;
+  static singleton: Modifications;
 
   private items: ModificationModel[] = [
     new ModificationModel(ModificationType.LogEntry, 'Log Entry'),
@@ -44,10 +44,10 @@ class Modifications {
   ];
 
   static get instance() {
-    if (Modifications._instance == null) {
-      Modifications._instance = new Modifications();
+    if (Modifications.singleton == null) {
+      Modifications.singleton = new Modifications();
     }
-    return Modifications._instance;
+    return Modifications.singleton;
   }
 
   getItems() {

--- a/WebTools/src/npc/model/npcCharacterType.ts
+++ b/WebTools/src/npc/model/npcCharacterType.ts
@@ -49,16 +49,16 @@ export class NpcCharacterTypeModel {
 }
 
 export class NpcCharacterTypes {
-  private static _instance: NpcCharacterTypes;
+  private static singleton: NpcCharacterTypes;
 
   static get instance() {
-    if (NpcCharacterTypes._instance == null) {
-      NpcCharacterTypes._instance = new NpcCharacterTypes();
+    if (NpcCharacterTypes.singleton == null) {
+      NpcCharacterTypes.singleton = new NpcCharacterTypes();
     }
-    return NpcCharacterTypes._instance;
+    return NpcCharacterTypes.singleton;
   }
 
-  private _types = [
+  private typeValues = [
     new NpcCharacterTypeModel(NpcCharacterType.Starfleet, 'Starfleet'),
     new NpcCharacterTypeModel(
       NpcCharacterType.KlingonDefenseForces,
@@ -87,7 +87,7 @@ export class NpcCharacterTypes {
   }
 
   get types() {
-    return this._types.filter((t) => {
+    return this.typeValues.filter((t) => {
       if (t.type === NpcCharacterType.Starfleet) {
         return true;
       } else if (t.type === NpcCharacterType.KlingonDefenseForces) {

--- a/WebTools/src/npc/model/npcGenerator.ts
+++ b/WebTools/src/npc/model/npcGenerator.ts
@@ -1219,7 +1219,7 @@ export class NpcGenerator {
         }
       }
       character.npcGenerationStep.attributes[a] = attributePoints[i] - 7;
-      character._attributes[a] = attributePoints[i];
+      character.attributeValues[a] = attributePoints[i];
       attributes.splice(attributes.indexOf(a), 1);
     }
   }
@@ -1385,7 +1385,7 @@ export class NpcGenerator {
         character.jobAssignment = specialization.localizedName + ' (Resident)';
       }
 
-      character._rank = new CharacterRank(rank.name, rank.id);
+      character.rankValue = new CharacterRank(rank.name, rank.id);
     }
   }
 }

--- a/WebTools/src/npc/model/specializations.ts
+++ b/WebTools/src/npc/model/specializations.ts
@@ -261,13 +261,13 @@ export class SpecializationModel {
 }
 
 export class Specializations {
-  private static _instance: Specializations;
+  private static singleton: Specializations;
 
   static get instance() {
-    if (Specializations._instance == null) {
-      Specializations._instance = new Specializations();
+    if (Specializations.singleton == null) {
+      Specializations.singleton = new Specializations();
     }
-    return Specializations._instance;
+    return Specializations.singleton;
   }
 
   specializations: SpecializationModel[];

--- a/WebTools/src/npc/nameGenerator.ts
+++ b/WebTools/src/npc/nameGenerator.ts
@@ -74,13 +74,13 @@ const names = [
 ];
 
 export class NameGenerator {
-  private static _instance: NameGenerator;
+  private static singleton: NameGenerator;
 
   static get instance() {
-    if (NameGenerator._instance == null) {
-      NameGenerator._instance = new NameGenerator();
+    if (NameGenerator.singleton == null) {
+      NameGenerator.singleton = new NameGenerator();
     }
-    return NameGenerator._instance;
+    return NameGenerator.singleton;
   }
 
   isSupported(species: ISpecies) {

--- a/WebTools/src/npc/page/npcConfigurationPage.tsx
+++ b/WebTools/src/npc/page/npcConfigurationPage.tsx
@@ -379,9 +379,7 @@ const NpcConfigurationPage: React.FC<INpcConfigurationPageProperties> = ({
                 isChecked={includeDescription}
                 value={'includeDescription'}
                 text={t('NpcConfigurationPage.includeDescription')}
-                onChanged={(_inc) =>
-                  updateIncludeDescription(!includeDescription)
-                }
+                onChanged={() => updateIncludeDescription(!includeDescription)}
               />
             </div>
           </div>

--- a/WebTools/src/npc/page/npcPageFactory.tsx
+++ b/WebTools/src/npc/page/npcPageFactory.tsx
@@ -3,13 +3,13 @@ import { PageIdentity } from '../../pages/pageIdentity';
 import NpcConfigurationPage from './npcConfigurationPage';
 
 export class NpcPageFactory implements IPageFactoryRegistry {
-  private static _instance;
+  private static singleton;
 
   static get instance() {
-    if (NpcPageFactory._instance == null) {
-      NpcPageFactory._instance = new NpcPageFactory();
+    if (NpcPageFactory.singleton == null) {
+      NpcPageFactory.singleton = new NpcPageFactory();
     }
-    return NpcPageFactory._instance;
+    return NpcPageFactory.singleton;
   }
 
   private factories = {};

--- a/WebTools/src/pages/pageFactory.tsx
+++ b/WebTools/src/pages/pageFactory.tsx
@@ -35,13 +35,13 @@ export interface IPageFactoryRegistry {
 }
 
 export class PageFactory {
-  private static _instance;
+  private static singleton;
 
   static get instance() {
-    if (PageFactory._instance == null) {
-      PageFactory._instance = new PageFactory();
+    if (PageFactory.singleton == null) {
+      PageFactory.singleton = new PageFactory();
     }
-    return PageFactory._instance;
+    return PageFactory.singleton;
   }
 
   private factories = {};

--- a/WebTools/src/pages/talentsOverviewPage.tsx
+++ b/WebTools/src/pages/talentsOverviewPage.tsx
@@ -123,7 +123,7 @@ class TalentViewModel {
 }
 
 const TalentsOverviewPage = () => {
-  const _allTalents: TalentViewModel[] = [];
+  const allTalents: TalentViewModel[] = [];
   const [showAdvanced, setShowAdvanced] = useState<boolean>(false);
   const [search, setSearch] = useState('');
   const [version, setVersion] = useState<TalentVersion>(TalentVersion.Both);
@@ -140,8 +140,8 @@ const TalentsOverviewPage = () => {
 
   const selectTalents = () => {
     const talents = [];
-    for (let i = 0; i < _allTalents.length; i++) {
-      const talent = _allTalents[i];
+    for (let i = 0; i < allTalents.length; i++) {
+      const talent = allTalents[i];
       if (search.length && !talent.matches(search)) {
         // don't include
       } else if (
@@ -269,7 +269,7 @@ const TalentsOverviewPage = () => {
 
   const getSpecies = () => {
     const speciesList: Species[] = [];
-    _allTalents.forEach((t) => {
+    allTalents.forEach((t) => {
       if (t.talent.category.category === TalentCategory.Species) {
         t.talent.category.type.forEach((s) => {
           if (!speciesList.includes(s as Species)) {
@@ -303,10 +303,10 @@ const TalentsOverviewPage = () => {
 
       if (available) {
         const model = TalentViewModel.from(talent);
-        _allTalents.push(model);
+        allTalents.push(model);
       }
     }
-    _allTalents.sort((left, right): number => {
+    allTalents.sort((left, right): number => {
       if (left.localizedName < right.localizedName) return -1;
       if (left.localizedName > right.localizedName) return 1;
       return 0;

--- a/WebTools/src/safety/model/safetySection.ts
+++ b/WebTools/src/safety/model/safetySection.ts
@@ -34,7 +34,7 @@ export class SafetySection {
 }
 
 export class SafetySections {
-  private static _instance: SafetySections;
+  private static singleton: SafetySections;
 
   sections = [
     new SafetySection(
@@ -80,9 +80,9 @@ export class SafetySections {
   ];
 
   static get instance() {
-    if (SafetySections._instance == null) {
-      SafetySections._instance = new SafetySections();
+    if (SafetySections.singleton == null) {
+      SafetySections.singleton = new SafetySections();
     }
-    return SafetySections._instance;
+    return SafetySections.singleton;
   }
 }

--- a/WebTools/src/solo/page/captainsLogPageFactory.tsx
+++ b/WebTools/src/solo/page/captainsLogPageFactory.tsx
@@ -22,13 +22,13 @@ import SoloStarshipTalentsPage from './soloStarshipTalentsPage';
 import CustomSpeciesDetailsPage from '../../pages/customSpeciesDetailsPage';
 
 export class CaptainsLogPageFactory implements IPageFactoryRegistry {
-  private static _instance;
+  private static singleton;
 
   static get instance() {
-    if (CaptainsLogPageFactory._instance == null) {
-      CaptainsLogPageFactory._instance = new CaptainsLogPageFactory();
+    if (CaptainsLogPageFactory.singleton == null) {
+      CaptainsLogPageFactory.singleton = new CaptainsLogPageFactory();
     }
-    return CaptainsLogPageFactory._instance;
+    return CaptainsLogPageFactory.singleton;
   }
 
   private factories = {};

--- a/WebTools/src/starship/model/randomStarshipCharacterTypes.ts
+++ b/WebTools/src/starship/model/randomStarshipCharacterTypes.ts
@@ -31,17 +31,17 @@ export class RandomStarshipCharacterTypeModel {
 }
 
 export class RandomStarshipCharacterTypes {
-  private static _instance: RandomStarshipCharacterTypes;
+  private static singleton: RandomStarshipCharacterTypes;
 
   static get instance() {
-    if (RandomStarshipCharacterTypes._instance == null) {
-      RandomStarshipCharacterTypes._instance =
+    if (RandomStarshipCharacterTypes.singleton == null) {
+      RandomStarshipCharacterTypes.singleton =
         new RandomStarshipCharacterTypes();
     }
-    return RandomStarshipCharacterTypes._instance;
+    return RandomStarshipCharacterTypes.singleton;
   }
 
-  private _types = [
+  private typeValues = [
     new RandomStarshipCharacterTypeModel(
       RandomStarshipCharacterType.Starfleet,
       'Starfleet',
@@ -61,7 +61,7 @@ export class RandomStarshipCharacterTypes {
   ];
 
   get types() {
-    return this._types.filter((t) => {
+    return this.typeValues.filter((t) => {
       if (t.type === RandomStarshipCharacterType.Starfleet) {
         return true;
       } else if (t.type === RandomStarshipCharacterType.Romulan) {

--- a/WebTools/src/starship/model/serviceRecord.ts
+++ b/WebTools/src/starship/model/serviceRecord.ts
@@ -73,7 +73,7 @@ export class ServiceRecordModel {
 }
 
 export class ServiceRecordList {
-  private static _instance: ServiceRecordList;
+  private static singleton: ServiceRecordList;
 
   readonly records: ServiceRecordModel[] = [
     new ServiceRecordModel(ServiceRecord.AgingRelic, 'Larger Crew'),
@@ -156,10 +156,10 @@ export class ServiceRecordList {
   ];
 
   static get instance() {
-    if (ServiceRecordList._instance == null) {
-      ServiceRecordList._instance = new ServiceRecordList();
+    if (ServiceRecordList.singleton == null) {
+      ServiceRecordList.singleton = new ServiceRecordList();
     }
-    return ServiceRecordList._instance;
+    return ServiceRecordList.singleton;
   }
 
   getByType(type: ServiceRecord) {

--- a/WebTools/src/starship/page/starshipPageFactory.tsx
+++ b/WebTools/src/starship/page/starshipPageFactory.tsx
@@ -16,13 +16,13 @@ import ServiceRecordPage from './serviceRecordPage';
 import ExtraStarshipTalentChoicesPage from './extraStarshipTalentChoicesPage';
 
 export class StarshipPageFactory implements IPageFactoryRegistry {
-  private static _instance;
+  private static singleton;
 
   static get instance() {
-    if (StarshipPageFactory._instance == null) {
-      StarshipPageFactory._instance = new StarshipPageFactory();
+    if (StarshipPageFactory.singleton == null) {
+      StarshipPageFactory.singleton = new StarshipPageFactory();
     }
-    return StarshipPageFactory._instance;
+    return StarshipPageFactory.singleton;
   }
 
   private factories = {};

--- a/WebTools/src/state/characterReducer.ts
+++ b/WebTools/src/state/characterReducer.ts
@@ -708,7 +708,7 @@ const characterReducer = (
       });
     case SET_CHARACTER_RANK:
       return withCharacter(state, action, (temp, action) => {
-        temp._rank = new CharacterRank(
+        temp.rankValue = new CharacterRank(
           action.payload.name,
           action.payload.rank ?? undefined,
         );

--- a/WebTools/src/table/model/editableTable.ts
+++ b/WebTools/src/table/model/editableTable.ts
@@ -3,9 +3,9 @@ import { v4 as uuidv4 } from 'uuid';
 
 export class EditableTableRow {
   key: string;
-  private _from: number;
-  private _to?: number;
-  private _result: ValueResult;
+  private fromValue: number;
+  private toValue?: number;
+  private resultValue: ValueResult;
   edited: boolean = false;
 
   constructor(
@@ -15,44 +15,44 @@ export class EditableTableRow {
     key: string = uuidv4(),
   ) {
     this.key = key;
-    this._from = from;
-    this._to = to == null ? from : to;
-    this._result = result;
+    this.fromValue = from;
+    this.toValue = to == null ? from : to;
+    this.resultValue = result;
   }
 
   static from(row?: TableRow) {
     const result = new EditableTableRow();
-    result._from = row?.from;
-    result._to = row?.to == null ? row?.from : row?.to;
-    result._result = row?.result;
+    result.fromValue = row?.from;
+    result.toValue = row?.to == null ? row?.from : row?.to;
+    result.resultValue = row?.result;
     result.edited = true;
     return result;
   }
 
   get result() {
-    return this._result;
+    return this.resultValue;
   }
 
   set result(value: ValueResult) {
-    this._result = value;
+    this.resultValue = value;
     this.edited = true;
   }
 
   get from() {
-    return this._from;
+    return this.fromValue;
   }
 
   set from(value: number | undefined) {
-    this._from = value;
+    this.fromValue = value;
     this.edited = true;
   }
 
   get to() {
-    return this._to;
+    return this.toValue;
   }
 
   set to(value: number | undefined) {
-    this._to = value;
+    this.toValue = value;
     this.edited = true;
   }
 
@@ -83,15 +83,15 @@ export class EditableTableRow {
   copy() {
     const result = new EditableTableRow();
     result.key = this.key;
-    result._from = this._from;
-    result._to = this._to;
-    result._result = this._result;
+    result.fromValue = this.fromValue;
+    result.toValue = this.toValue;
+    result.resultValue = this.resultValue;
     result.edited = this.edited;
     return result;
   }
 
   asTableRow() {
-    return new TableRow(this._result, this._from, this.to);
+    return new TableRow(this.resultValue, this.fromValue, this.to);
   }
 }
 

--- a/WebTools/src/table/model/tableMarshaller.ts
+++ b/WebTools/src/table/model/tableMarshaller.ts
@@ -3,13 +3,13 @@ import pako from 'pako';
 import { Table, TableCollection, TableRow, ValueResult } from './table';
 
 class TableMarshaller {
-  private static _instance: TableMarshaller;
+  private static singleton: TableMarshaller;
 
   static get instance() {
-    if (TableMarshaller._instance == null) {
-      TableMarshaller._instance = new TableMarshaller();
+    if (TableMarshaller.singleton == null) {
+      TableMarshaller.singleton = new TableMarshaller();
     }
-    return TableMarshaller._instance;
+    return TableMarshaller.singleton;
   }
 
   marshall(tableCollection: TableCollection) {

--- a/WebTools/src/token/model/earCatalog.ts
+++ b/WebTools/src/token/model/earCatalog.ts
@@ -173,13 +173,13 @@ const CardassianEar = `<g>
 </g>`;
 
 class EarCatalog {
-  private static _instance: EarCatalog;
+  private static singleton: EarCatalog;
 
   public static get instance() {
-    if (EarCatalog._instance == null) {
-      EarCatalog._instance = new EarCatalog();
+    if (EarCatalog.singleton == null) {
+      EarCatalog.singleton = new EarCatalog();
     }
-    return EarCatalog._instance;
+    return EarCatalog.singleton;
   }
 
   getHiddenEar(token: TokenModel) {

--- a/WebTools/src/token/model/extrasCatalog.ts
+++ b/WebTools/src/token/model/extrasCatalog.ts
@@ -16,15 +16,15 @@ export interface IExtendedExtrasLibrary {
 }
 
 class ExtrasCatalog {
-  private static _instance: ExtrasCatalog;
+  private static singleton: ExtrasCatalog;
 
   private extrasLibrary: IExtendedExtrasLibrary;
 
   public static get instance() {
-    if (ExtrasCatalog._instance == null) {
-      ExtrasCatalog._instance = new ExtrasCatalog();
+    if (ExtrasCatalog.singleton == null) {
+      ExtrasCatalog.singleton = new ExtrasCatalog();
     }
-    return ExtrasCatalog._instance;
+    return ExtrasCatalog.singleton;
   }
 
   isInCategory(type: ExtraType, category: ExtraCategory) {
@@ -70,7 +70,7 @@ class ExtrasCatalog {
         );
         this.extrasLibrary = new ExtrasLibrary();
         completion();
-      } catch (_e) {
+      } catch {
         toast('Ooops. Something bad happened', { className: 'bg-danger' });
       }
     }

--- a/WebTools/src/token/model/eyeBrowCatalog.ts
+++ b/WebTools/src/token/model/eyeBrowCatalog.ts
@@ -450,13 +450,13 @@ const CardassianBrows = `<g>
 </g>`;
 
 class EyeBrowCatalog {
-  private static _instance: EyeBrowCatalog;
+  private static singleton: EyeBrowCatalog;
 
   public static get instance() {
-    if (EyeBrowCatalog._instance == null) {
-      EyeBrowCatalog._instance = new EyeBrowCatalog();
+    if (EyeBrowCatalog.singleton == null) {
+      EyeBrowCatalog.singleton = new EyeBrowCatalog();
     }
-    return EyeBrowCatalog._instance;
+    return EyeBrowCatalog.singleton;
   }
 
   getBrow(

--- a/WebTools/src/token/model/eyeCatalog.ts
+++ b/WebTools/src/token/model/eyeCatalog.ts
@@ -208,13 +208,13 @@ const PakledBelowEyeProsthetic = `<g>
 </g>`;
 
 class EyeCatalog {
-  private static _instance: EyeCatalog;
+  private static singleton: EyeCatalog;
 
   public static get instance() {
-    if (EyeCatalog._instance == null) {
-      EyeCatalog._instance = new EyeCatalog();
+    if (EyeCatalog.singleton == null) {
+      EyeCatalog.singleton = new EyeCatalog();
     }
-    return EyeCatalog._instance;
+    return EyeCatalog.singleton;
   }
 
   getEyes(token: TokenModel) {

--- a/WebTools/src/token/model/facialHairCatalog.ts
+++ b/WebTools/src/token/model/facialHairCatalog.ts
@@ -130,7 +130,7 @@ class FacialHairItem {
 }
 
 class FacialHairCatalog {
-  private static _instance: FacialHairCatalog;
+  private static singleton: FacialHairCatalog;
 
   items = [
     new FacialHairItem(
@@ -220,10 +220,10 @@ class FacialHairCatalog {
   ];
 
   public static get instance() {
-    if (FacialHairCatalog._instance == null) {
-      FacialHairCatalog._instance = new FacialHairCatalog();
+    if (FacialHairCatalog.singleton == null) {
+      FacialHairCatalog.singleton = new FacialHairCatalog();
     }
-    return FacialHairCatalog._instance;
+    return FacialHairCatalog.singleton;
   }
 
   static shift(svg: string) {

--- a/WebTools/src/token/model/hairCatalog.ts
+++ b/WebTools/src/token/model/hairCatalog.ts
@@ -906,7 +906,7 @@ class HairItem {
 }
 
 class HairCatalog {
-  private static _instance: HairCatalog;
+  private static singleton: HairCatalog;
 
   items = [
     new HairItem(HairType.Bald, 'Bald', ''),
@@ -1072,10 +1072,10 @@ class HairCatalog {
   ];
 
   public static get instance() {
-    if (HairCatalog._instance == null) {
-      HairCatalog._instance = new HairCatalog();
+    if (HairCatalog.singleton == null) {
+      HairCatalog.singleton = new HairCatalog();
     }
-    return HairCatalog._instance;
+    return HairCatalog.singleton;
   }
 
   getDefinitions(hairType: HairType, token: TokenModel) {

--- a/WebTools/src/token/model/headCatalog.ts
+++ b/WebTools/src/token/model/headCatalog.ts
@@ -432,7 +432,7 @@ export const ReferenceHead = StandardHeads.Head3;
 class HeadCatalog {
   private rubberHeadCatalog: IExtendedHeadCatalog;
 
-  private static _instance: HeadCatalog;
+  private static singleton: HeadCatalog;
 
   swatches = [
     new Swatch(
@@ -505,10 +505,10 @@ class HeadCatalog {
   ];
 
   public static get instance() {
-    if (HeadCatalog._instance == null) {
-      HeadCatalog._instance = new HeadCatalog();
+    if (HeadCatalog.singleton == null) {
+      HeadCatalog.singleton = new HeadCatalog();
     }
-    return HeadCatalog._instance;
+    return HeadCatalog.singleton;
   }
 
   getHead(token: TokenModel) {
@@ -772,7 +772,7 @@ class HeadCatalog {
         );
         this.rubberHeadCatalog = new RubberHeadCatalog();
         completion();
-      } catch (_e) {
+      } catch {
         toast('Ooops. Something bad happened', { className: 'bg-danger' });
       }
     }

--- a/WebTools/src/token/model/mouthCatalog.ts
+++ b/WebTools/src/token/model/mouthCatalog.ts
@@ -367,13 +367,13 @@ const ZakdornMouth = `<g>
 </g>`;
 
 class MouthCatalog {
-  private static _instance: MouthCatalog;
+  private static singleton: MouthCatalog;
 
   public static get instance() {
-    if (MouthCatalog._instance == null) {
-      MouthCatalog._instance = new MouthCatalog();
+    if (MouthCatalog.singleton == null) {
+      MouthCatalog.singleton = new MouthCatalog();
     }
-    return MouthCatalog._instance;
+    return MouthCatalog.singleton;
   }
 
   getMouth(token: TokenModel) {

--- a/WebTools/src/token/model/nasoLabialFoldCatalog.ts
+++ b/WebTools/src/token/model/nasoLabialFoldCatalog.ts
@@ -35,7 +35,7 @@ const CherubicNasoLabial = `<g>
 </g>`;
 
 class NasoLabialFoldCatalog {
-  private static _instance: NasoLabialFoldCatalog;
+  private static singleton: NasoLabialFoldCatalog;
 
   swatches = [
     new Swatch(
@@ -77,10 +77,10 @@ class NasoLabialFoldCatalog {
   ];
 
   public static get instance() {
-    if (NasoLabialFoldCatalog._instance == null) {
-      NasoLabialFoldCatalog._instance = new NasoLabialFoldCatalog();
+    if (NasoLabialFoldCatalog.singleton == null) {
+      NasoLabialFoldCatalog.singleton = new NasoLabialFoldCatalog();
     }
-    return NasoLabialFoldCatalog._instance;
+    return NasoLabialFoldCatalog.singleton;
   }
 
   getNasoLabialFold(token: TokenModel) {

--- a/WebTools/src/token/model/noseCatalog.ts
+++ b/WebTools/src/token/model/noseCatalog.ts
@@ -250,7 +250,7 @@ const CardassianNose1 = `<g>
 </g>`;
 
 class NoseCatalog {
-  private static _instance: NoseCatalog;
+  private static singleton: NoseCatalog;
 
   private swatches = [
     new Swatch(
@@ -328,10 +328,10 @@ class NoseCatalog {
   ];
 
   public static get instance() {
-    if (NoseCatalog._instance == null) {
-      NoseCatalog._instance = new NoseCatalog();
+    if (NoseCatalog.singleton == null) {
+      NoseCatalog.singleton = new NoseCatalog();
     }
-    return NoseCatalog._instance;
+    return NoseCatalog.singleton;
   }
 
   getNose(token: TokenModel) {

--- a/WebTools/src/token/model/prostheticCatalog.ts
+++ b/WebTools/src/token/model/prostheticCatalog.ts
@@ -317,13 +317,13 @@ export enum ProstheticPlacement {
 }
 
 class ProstheticCatalog {
-  private static _instance: ProstheticCatalog;
+  private static singleton: ProstheticCatalog;
 
   public static get instance() {
-    if (ProstheticCatalog._instance == null) {
-      ProstheticCatalog._instance = new ProstheticCatalog();
+    if (ProstheticCatalog.singleton == null) {
+      ProstheticCatalog.singleton = new ProstheticCatalog();
     }
-    return ProstheticCatalog._instance;
+    return ProstheticCatalog.singleton;
   }
 
   getProsthetic(token: TokenModel, placement: ProstheticPlacement) {

--- a/WebTools/src/token/model/rankIndicatorCatalog.ts
+++ b/WebTools/src/token/model/rankIndicatorCatalog.ts
@@ -5,13 +5,13 @@ import { UniformEra } from './uniformEra';
 import UniformPackCollection from './uniformPackCollection';
 
 class RankIndicatorCatalog {
-  private static _instance: RankIndicatorCatalog;
+  private static singleton: RankIndicatorCatalog;
 
   public static get instance() {
-    if (RankIndicatorCatalog._instance == null) {
-      RankIndicatorCatalog._instance = new RankIndicatorCatalog();
+    if (RankIndicatorCatalog.singleton == null) {
+      RankIndicatorCatalog.singleton = new RankIndicatorCatalog();
     }
-    return RankIndicatorCatalog._instance;
+    return RankIndicatorCatalog.singleton;
   }
 
   getRankIndicator(token: TokenModel) {

--- a/WebTools/src/token/model/speciesOptionCatalog.ts
+++ b/WebTools/src/token/model/speciesOptionCatalog.ts
@@ -239,13 +239,13 @@ export const KlingonForehead7 = `<g>
 </g>`;
 
 class SpeciesOptionCatalog {
-  private static _instance: SpeciesOptionCatalog;
+  private static singleton: SpeciesOptionCatalog;
 
   public static get instance() {
-    if (SpeciesOptionCatalog._instance == null) {
-      SpeciesOptionCatalog._instance = new SpeciesOptionCatalog();
+    if (SpeciesOptionCatalog.singleton == null) {
+      SpeciesOptionCatalog.singleton = new SpeciesOptionCatalog();
     }
-    return SpeciesOptionCatalog._instance;
+    return SpeciesOptionCatalog.singleton;
   }
 
   getSwatches(token: TokenModel) {

--- a/WebTools/src/token/model/uniformCatalog.ts
+++ b/WebTools/src/token/model/uniformCatalog.ts
@@ -7,13 +7,13 @@ import UniformPackCollection from './uniformPackCollection';
 export const DefaultRed = /#d30000/g;
 
 class UniformCatalog {
-  private static _instance: UniformCatalog;
+  private static singleton: UniformCatalog;
 
   public static get instance() {
-    if (UniformCatalog._instance == null) {
-      UniformCatalog._instance = new UniformCatalog();
+    if (UniformCatalog.singleton == null) {
+      UniformCatalog.singleton = new UniformCatalog();
     }
-    return UniformCatalog._instance;
+    return UniformCatalog.singleton;
   }
 
   getBody(token: TokenModel) {

--- a/WebTools/src/token/model/uniformEra.ts
+++ b/WebTools/src/token/model/uniformEra.ts
@@ -58,7 +58,7 @@ export class UniformEraModel {
 }
 
 export class UniformEraHelper {
-  private static _instance: UniformEraHelper;
+  private static singleton: UniformEraHelper;
 
   types = [
     new UniformEraModel(UniformEra.None, 'None'),
@@ -101,9 +101,9 @@ export class UniformEraHelper {
   ];
 
   static get instance() {
-    if (UniformEraHelper._instance == null) {
-      UniformEraHelper._instance = new UniformEraHelper();
+    if (UniformEraHelper.singleton == null) {
+      UniformEraHelper.singleton = new UniformEraHelper();
     }
-    return UniformEraHelper._instance;
+    return UniformEraHelper.singleton;
   }
 }

--- a/WebTools/src/token/model/uniformPackCollection.ts
+++ b/WebTools/src/token/model/uniformPackCollection.ts
@@ -7,17 +7,17 @@ import toast from 'react-hot-toast';
 export default class UniformPackCollection {
   uniformPacks: { [era: number]: IUniformPack } = {};
 
-  private static _instance: UniformPackCollection;
+  private static singleton: UniformPackCollection;
 
   public static get instance() {
-    if (UniformPackCollection._instance == null) {
-      UniformPackCollection._instance = new UniformPackCollection();
+    if (UniformPackCollection.singleton == null) {
+      UniformPackCollection.singleton = new UniformPackCollection();
     }
-    UniformPackCollection._instance.uniformPacks[UniformEra.DominionWar] =
+    UniformPackCollection.singleton.uniformPacks[UniformEra.DominionWar] =
       new DominionWarUniformPack();
-    UniformPackCollection._instance.uniformPacks[UniformEra.None] =
+    UniformPackCollection.singleton.uniformPacks[UniformEra.None] =
       new NoneUniformPack();
-    return UniformPackCollection._instance;
+    return UniformPackCollection.singleton;
   }
 
   getUniformPack(uniformEra: UniformEra) {

--- a/WebTools/src/vtt/fantasyGroundsVttExport.ts
+++ b/WebTools/src/vtt/fantasyGroundsVttExport.ts
@@ -16,13 +16,13 @@ import { NpcType } from '../npc/model/npcType';
 import { textTokenizer } from '../exportpdf/textTokenizer';
 
 export class FantasyGroupsVttExporter {
-  private static _instance: FantasyGroupsVttExporter;
+  private static singleton: FantasyGroupsVttExporter;
 
   static get instance() {
-    if (FantasyGroupsVttExporter._instance == null) {
-      FantasyGroupsVttExporter._instance = new FantasyGroupsVttExporter();
+    if (FantasyGroupsVttExporter.singleton == null) {
+      FantasyGroupsVttExporter.singleton = new FantasyGroupsVttExporter();
     }
-    return FantasyGroupsVttExporter._instance;
+    return FantasyGroupsVttExporter.singleton;
   }
 
   private exportNpc(character: Character) {

--- a/WebTools/src/vtt/foundryVttExporter.ts
+++ b/WebTools/src/vtt/foundryVttExporter.ts
@@ -44,13 +44,13 @@ const DEFAULT_EQUIPMENT_ICON =
 const SYSTEM_VERSION = '2.4.2';
 
 export class FoundryVttExporter {
-  private static _instance: FoundryVttExporter;
+  private static singleton: FoundryVttExporter;
 
   static get instance() {
-    if (FoundryVttExporter._instance == null) {
-      FoundryVttExporter._instance = new FoundryVttExporter();
+    if (FoundryVttExporter.singleton == null) {
+      FoundryVttExporter.singleton = new FoundryVttExporter();
     }
-    return FoundryVttExporter._instance;
+    return FoundryVttExporter.singleton;
   }
 
   exportStarship(starship: Starship, type: FoundryPluginType) {

--- a/WebTools/src/vtt/roll20VttExporter.ts
+++ b/WebTools/src/vtt/roll20VttExporter.ts
@@ -84,13 +84,13 @@ class IdHelper {
 }
 
 export class Roll20VttExporter {
-  private static _instance: Roll20VttExporter;
+  private static singleton: Roll20VttExporter;
 
   static get instance() {
-    if (Roll20VttExporter._instance == null) {
-      Roll20VttExporter._instance = new Roll20VttExporter();
+    if (Roll20VttExporter.singleton == null) {
+      Roll20VttExporter.singleton = new Roll20VttExporter();
     }
-    return Roll20VttExporter._instance;
+    return Roll20VttExporter.singleton;
   }
 
   exportStarship(starship: Starship) {

--- a/WebTools/src/vtt/view/VttSelectionDialog.tsx
+++ b/WebTools/src/vtt/view/VttSelectionDialog.tsx
@@ -258,13 +258,13 @@ export const VttSelectionModal: React.FC<IVttSelectionModalProperties> = ({
 };
 
 export class VttSelectionDialog {
-  private static _instance: VttSelectionDialog;
+  private static singleton: VttSelectionDialog;
 
   static get instance() {
-    if (VttSelectionDialog._instance == null) {
-      VttSelectionDialog._instance = new VttSelectionDialog();
+    if (VttSelectionDialog.singleton == null) {
+      VttSelectionDialog.singleton = new VttSelectionDialog();
     }
-    return VttSelectionDialog._instance;
+    return VttSelectionDialog.singleton;
   }
 
   show(construct: Construct) {

--- a/WebTools/src/vtt/vttType.ts
+++ b/WebTools/src/vtt/vttType.ts
@@ -15,7 +15,7 @@ export class VttTypeModel {
 }
 
 export class VttTypes {
-  private static _instance: VttTypes;
+  private static singleton: VttTypes;
 
   private readonly types: VttTypeModel[] = [
     new VttTypeModel(VttType.FantasyGrounds, 'Fantasy Grounds'),
@@ -24,10 +24,10 @@ export class VttTypes {
   ];
 
   static get instance() {
-    if (VttTypes._instance == null) {
-      VttTypes._instance = new VttTypes();
+    if (VttTypes.singleton == null) {
+      VttTypes.singleton = new VttTypes();
     }
-    return VttTypes._instance;
+    return VttTypes.singleton;
   }
 
   public getTypes() {


### PR DESCRIPTION
Removes leading-underscore identifiers per Tier 2 plan item #10.

- Renaming strategy: private backing fields that support a same-named public getter (e.g. _name / get name()) cannot simply drop the underscore (TS disallows a field and getter sharing a name); these were given a Value/Values suffix (e.g. nameValue, attributeValues, resultValue).
- Singleton _instance backing fields -> singleton (public instance() getters unchanged).
- Plain private data fields, locals, and params with no same-name getter had the underscore stripped directly.
- Class names (_Species, _Governments, _AgeHelper) -> XRepository; the underscore existed only to avoid clashing with the exported singleton const of the same name (SpeciesHelper / Governments / AgeHelper).
- Component FCs _Dialog / _CharacterSheetDialog -> DialogContent / CharacterSheetDialogContent (exported control consts keep their names).
- catch (_e) -> catch; dropped unused onChanged parameter (matches existing 0-arg arrow convention).

Excluded (not identifiers): _blank (browser target/window strings), _stats (Foundry VTT export JSON schema keys), _UP/_2E (string comparisons / Spaceframe enum member suffixes - these feed the marshalled bookmarkable view sheet, per the Tier 3 enum-casing guidance), _damageRoll (Roll20 section-name strings), and various repeating_* string keys. The Spaceframe.Akira_UP-style enum members are mid-name underscores and the enum-casing concern, not leading underscores, so intentionally out of scope.

No changes to public API: all get X()/X() getters, the marshaller's string keys ('attributes','rank', etc.), and saved/bookmarkable characters are unaffected; only internal private/protected names changed.

Part of #438