### PR TITLE
Remove String/Number/Boolean wrapper types (part of #438)

### DIFF
--- a/WebTools/src/common/characterType.ts
+++ b/WebTools/src/common/characterType.ts
@@ -116,7 +116,7 @@ export class CharacterTypeModel {
     });
   }
 
-  public static getCharacterTypeByTypeName(name: String) {
+  public static getCharacterTypeByTypeName(name: string) {
     const matches = CharacterTypeModel.TYPES.filter(
       (t) => CharacterType[t.type] === name,
     );

--- a/WebTools/src/exportpdf/baseFormFillingSheet.ts
+++ b/WebTools/src/exportpdf/baseFormFillingSheet.ts
@@ -229,7 +229,7 @@ export abstract class BaseFormFillingSheet extends BasicGeneratedSheet {
     return {};
   }
 
-  getStatLabelColour(key: String): SimpleColor {
+  getStatLabelColour(key: string): SimpleColor {
     return SimpleColor.from('#ffffff');
   }
 

--- a/WebTools/src/exportpdf/standard2eCharacterSheet.ts
+++ b/WebTools/src/exportpdf/standard2eCharacterSheet.ts
@@ -339,7 +339,7 @@ export class Standard2eCharacterSheet extends BaseFormFillingSheet {
     this.writePersonalLogTitle(page);
   }
 
-  getStatLabelColour(key: String): SimpleColor {
+  getStatLabelColour(key: string): SimpleColor {
     switch (key) {
       case 'Construct.discipline.command':
       case 'Construct.discipline.conn':

--- a/WebTools/src/state/stationActions.ts
+++ b/WebTools/src/state/stationActions.ts
@@ -47,7 +47,7 @@ export function setStationMissionProfileTalent(talent: SelectedTalent) {
   };
 }
 
-export function setStationName(name: String) {
+export function setStationName(name: string) {
   const payload = { name: name };
   return {
     type: SET_STATION_NAME,
@@ -63,7 +63,7 @@ export function setStationCustomScale(scale: number) {
   };
 }
 
-export function setStationTraits(traits: String[]) {
+export function setStationTraits(traits: string[]) {
   const payload = { traits: traits };
   return {
     type: SET_STATION_TRAITS,

--- a/WebTools/src/vtt/roll20VttExporter.ts
+++ b/WebTools/src/vtt/roll20VttExporter.ts
@@ -49,7 +49,7 @@ interface IRoll20Json {
 }
 
 class IdHelper {
-  static readonly ID_PARTS: String = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  static readonly ID_PARTS: string = 'abcdefghijklmnopqrstuvwxyz0123456789';
   currentId: string;
 
   constructor() {


### PR DESCRIPTION
Remove the String wrapper type in favor of the string primitive (part of #438). Type-only change, no runtime impact.