### PR TITLE
Add default case to switches that omit it (part of #438)

### DIFF
--- a/WebTools/src/asset/assetTypeRandomTable.ts
+++ b/WebTools/src/asset/assetTypeRandomTable.ts
@@ -30,5 +30,7 @@ export const assetTypeRandomTable = (numberOfCharacters: number) => {
     case 19:
     case 20:
       return AssetTypes.instance.getTypes()[AssetType.Character];
+    default:
+      break;
   }
 };

--- a/WebTools/src/creature/model/creatureGenerator.ts
+++ b/WebTools/src/creature/model/creatureGenerator.ts
@@ -672,6 +672,8 @@ const deriveForm = (creature: Creature) => {
           }
         }
         break;
+      default:
+        break;
     }
   }
   return result;

--- a/WebTools/src/creature/model/creatureSize.ts
+++ b/WebTools/src/creature/model/creatureSize.ts
@@ -85,5 +85,7 @@ export const generateRandomCreatureSize = () => {
     case 19:
     case 20:
       return CreatureSize.Gigantic;
+    default:
+      break;
   }
 };

--- a/WebTools/src/creature/model/creatureTalents.ts
+++ b/WebTools/src/creature/model/creatureTalents.ts
@@ -48,6 +48,8 @@ export const generateRandomBasicCreatureTalent = () => {
         generateRandomBasicCreatureTalent(),
       );
       return result;
+    default:
+      break;
   }
 };
 
@@ -98,6 +100,8 @@ export const generateRandomCreatureDietTalent = (diet: DietType) => {
             generateRandomCreatureDietTalent(diet),
           );
           return result;
+        default:
+          break;
       }
       break;
     case DietType.Carnivore:
@@ -141,6 +145,8 @@ export const generateRandomCreatureDietTalent = (diet: DietType) => {
             generateRandomCreatureDietTalent(diet),
           );
           return result;
+        default:
+          break;
       }
       break;
 
@@ -187,6 +193,8 @@ export const generateRandomCreatureDietTalent = (diet: DietType) => {
             generateRandomCreatureDietTalent(diet),
           );
           return result;
+        default:
+          break;
       }
       break;
     default:
@@ -240,6 +248,8 @@ export const generateRandomCreatureTypeTalent = (type: CreatureType) => {
             generateRandomCreatureTypeTalent(type),
           );
           return result;
+        default:
+          break;
       }
       break;
 
@@ -316,6 +326,8 @@ export const generateRandomCreatureTypeTalent = (type: CreatureType) => {
             generateRandomCreatureTypeTalent(type),
           );
           return result;
+        default:
+          break;
       }
       break;
 
@@ -405,6 +417,8 @@ export const generateRandomCreatureTypeTalent = (type: CreatureType) => {
             generateRandomCreatureTypeTalent(type),
           );
           return result;
+        default:
+          break;
       }
       break;
 
@@ -454,6 +468,8 @@ export const generateRandomCreatureTypeTalent = (type: CreatureType) => {
             generateRandomCreatureTypeTalent(type),
           );
           return result;
+        default:
+          break;
       }
       break;
     case CreatureType.Plant:
@@ -510,6 +526,8 @@ export const generateRandomCreatureTypeTalent = (type: CreatureType) => {
             generateRandomCreatureTypeTalent(type),
           );
           return result;
+        default:
+          break;
       }
       break;
     case CreatureType.Reptile:
@@ -586,6 +604,8 @@ export const generateRandomCreatureTypeTalent = (type: CreatureType) => {
             generateRandomCreatureTypeTalent(type),
           );
           return result;
+        default:
+          break;
       }
       break;
 

--- a/WebTools/src/creature/model/creatureType.ts
+++ b/WebTools/src/creature/model/creatureType.ts
@@ -192,6 +192,8 @@ export const createRandomCreatureType = (habitat: Habitat) => {
           return CreatureType.Plant;
         case 20:
           return CreatureType.Energy;
+        default:
+          break;
       }
       break;
     case Habitat.Mountains:
@@ -223,6 +225,8 @@ export const createRandomCreatureType = (habitat: Habitat) => {
         case 19:
         case 20:
           return CreatureType.Plant;
+        default:
+          break;
       }
       break;
     case Habitat.Swamp:
@@ -255,6 +259,8 @@ export const createRandomCreatureType = (habitat: Habitat) => {
         case 19:
         case 20:
           return CreatureType.Fish;
+        default:
+          break;
       }
       break;
     case Habitat.Forest:
@@ -286,6 +292,8 @@ export const createRandomCreatureType = (habitat: Habitat) => {
         case 19:
         case 20:
           return CreatureType.Plant;
+        default:
+          break;
       }
       break;
     case Habitat.Ocean:
@@ -316,6 +324,8 @@ export const createRandomCreatureType = (habitat: Habitat) => {
           return CreatureType.Fish;
         case 20:
           return CreatureType.Energy;
+        default:
+          break;
       }
       break;
     case Habitat.UpperAtmosphere:
@@ -345,6 +355,8 @@ export const createRandomCreatureType = (habitat: Habitat) => {
           return CreatureType.Reptile;
         case 20:
           return CreatureType.Energy;
+        default:
+          break;
       }
       break;
     case Habitat.Space:
@@ -373,6 +385,8 @@ export const createRandomCreatureType = (habitat: Habitat) => {
         case 19:
         case 20:
           return CreatureType.Energy;
+        default:
+          break;
       }
       break;
     default:

--- a/WebTools/src/creature/model/diet.ts
+++ b/WebTools/src/creature/model/diet.ts
@@ -83,6 +83,8 @@ export const createRandomDiet = () => {
       return DietType.Omnivore;
     case 20:
       return createRandomEsotericDietType();
+    default:
+      break;
   }
 };
 
@@ -111,5 +113,7 @@ export const createRandomEsotericDietType = () => {
     case 19:
     case 20:
       return DietType.PsychicEnergy;
+    default:
+      break;
   }
 };

--- a/WebTools/src/creature/model/habitat.ts
+++ b/WebTools/src/creature/model/habitat.ts
@@ -102,5 +102,7 @@ export const createRandomHabitat = () => {
       return Habitat.Swamp;
     case 20:
       return Habitat.UpperAtmosphere;
+    default:
+      break;
   }
 };

--- a/WebTools/src/creature/model/locomotion.ts
+++ b/WebTools/src/creature/model/locomotion.ts
@@ -143,6 +143,8 @@ export const generateRandomLocomotionType = (
               12,
             ),
           ];
+        default:
+          break;
       }
       break;
     case CreatureType.Mammal:
@@ -197,6 +199,8 @@ export const generateRandomLocomotionType = (
               6,
             ),
           ];
+        default:
+          break;
       }
       break;
     case CreatureType.Bird:
@@ -251,6 +255,8 @@ export const generateRandomLocomotionType = (
               2,
             ),
           ];
+        default:
+          break;
       }
       break;
     case CreatureType.Reptile:
@@ -300,6 +306,8 @@ export const generateRandomLocomotionType = (
               6,
             ),
           ];
+        default:
+          break;
       }
       break;
     case CreatureType.Amphibian:
@@ -359,6 +367,8 @@ export const generateRandomLocomotionType = (
               6,
             ),
           ];
+        default:
+          break;
       }
       break;
     case CreatureType.Plant: {
@@ -403,6 +413,8 @@ export const generateRandomLocomotionType = (
               4,
             ),
           ];
+        default:
+          break;
       }
       break;
     default:

--- a/WebTools/src/creature/model/naturalAttacks.ts
+++ b/WebTools/src/creature/model/naturalAttacks.ts
@@ -128,6 +128,8 @@ export class NaturalAttacksHelper {
           WeaponType.MELEE,
           1,
         );
+      default:
+        break;
     }
   }
 
@@ -211,6 +213,8 @@ export const generateRandomNaturalAttacks = (diet: DietType) => {
         case 19:
         case 20:
           return NaturalAttacks.SharpBeak;
+        default:
+          break;
       }
       break;
 
@@ -244,6 +248,8 @@ export const generateRandomNaturalAttacks = (diet: DietType) => {
         case 19:
         case 20:
           return NaturalAttacks.Bludgeoning;
+        default:
+          break;
       }
       break;
 
@@ -274,7 +280,11 @@ export const generateRandomNaturalAttacks = (diet: DietType) => {
         case 19:
         case 20:
           return NaturalAttacks.Bludgeoning;
+        default:
+          break;
       }
+      break;
+    default:
       break;
   }
 };

--- a/WebTools/src/exportpdf/baseFormFillingSheet.ts
+++ b/WebTools/src/exportpdf/baseFormFillingSheet.ts
@@ -109,6 +109,8 @@ export abstract class BaseFormFillingSheet extends BasicGeneratedSheet {
         case Attribute.Reason:
           this.fillField(form, 'Reason', '' + attributes[a]);
           break;
+        default:
+          break;
       }
     });
   }

--- a/WebTools/src/exportpdf/generatedSafetypChecklistSheet.ts
+++ b/WebTools/src/exportpdf/generatedSafetypChecklistSheet.ts
@@ -226,7 +226,10 @@ export class GeneratedSafetyChecklistSheet extends BaseNonForm2eSheet {
             redColour2e,
           );
           evaluationParagraph.write();
+          break;
         }
+        default:
+          break;
       }
 
       this.writeLine(

--- a/WebTools/src/exportpdf/sheets.ts
+++ b/WebTools/src/exportpdf/sheets.ts
@@ -593,6 +593,8 @@ abstract class BasicShortCharacterSheet extends BasicSheet {
         case Attribute.Reason:
           this.fillField(form, 'Reason', '' + attributes[a]);
           break;
+        default:
+          break;
       }
     });
   }
@@ -618,6 +620,8 @@ abstract class BasicShortCharacterSheet extends BasicSheet {
           break;
         case Department.Medicine:
           this.fillField(form, 'Medicine', '' + departments[d]);
+          break;
+        default:
           break;
       }
     });

--- a/WebTools/src/helpers/diceRoller.ts
+++ b/WebTools/src/helpers/diceRoller.ts
@@ -71,6 +71,8 @@ export class Roller {
         case 6:
           result.special++;
           break;
+        default:
+          break;
       }
     }
 

--- a/WebTools/src/helpers/eras.ts
+++ b/WebTools/src/helpers/eras.ts
@@ -29,6 +29,8 @@ export const eraDefaultYear = (era: Era) => {
       return 2400;
     case Era.Discovery32:
       return 3190;
+    default:
+      break;
   }
 };
 

--- a/WebTools/src/helpers/ranks.ts
+++ b/WebTools/src/helpers/ranks.ts
@@ -1458,6 +1458,8 @@ export class RanksHelper {
           Rank.CadetFourthClass,
         ];
         break;
+      default:
+        break;
     }
     return ranks.map((r) => this.getRank(r));
   }

--- a/WebTools/src/helpers/species.ts
+++ b/WebTools/src/helpers/species.ts
@@ -4416,6 +4416,8 @@ class SpeciesRepository {
           }
           break;
         }
+        default:
+          break;
       }
 
       return species;
@@ -4629,6 +4631,8 @@ class SpeciesRepository {
         }
         break;
       }
+      default:
+        break;
     }
 
     return species;
@@ -4741,6 +4745,8 @@ class SpeciesRepository {
         }
         break;
       }
+      default:
+        break;
     }
 
     return species;

--- a/WebTools/src/mapping/table/atmosphereTable.ts
+++ b/WebTools/src/mapping/table/atmosphereTable.ts
@@ -184,6 +184,8 @@ const atmosphereTableClassM = () => {
     case 20:
       result.density = AtmosphericDensityType.VeryDense;
       break;
+    default:
+      break;
   }
 
   result.contaiminants = atmosphericContaminantTable();
@@ -244,5 +246,7 @@ const atmosphericContaminantTable = () => {
         }
       });
       return result;
+    default:
+      break;
   }
 };

--- a/WebTools/src/mapping/table/notableSpacialPhenomenaTable.ts
+++ b/WebTools/src/mapping/table/notableSpacialPhenomenaTable.ts
@@ -66,6 +66,9 @@ export const notableSpatialPhenomenaTable = (
                 NotableSpatialPhenomenon.StellarFlareClass1
               ],
             ];
+            break;
+          default:
+            break;
         }
         break;
       case SpectralClass.F:
@@ -119,6 +122,9 @@ export const notableSpatialPhenomenaTable = (
                 NotableSpatialPhenomenon.RadiationStormClass3
               ],
             ];
+            break;
+          default:
+            break;
         }
         break;
       case SpectralClass.A:
@@ -172,6 +178,9 @@ export const notableSpatialPhenomenaTable = (
                 NotableSpatialPhenomenon.IonStormClass3
               ],
             ];
+            break;
+          default:
+            break;
         }
         break;
       case SpectralClass.B:
@@ -238,6 +247,9 @@ export const notableSpatialPhenomenaTable = (
                 NotableSpatialPhenomenon.IonStormClass4
               ],
             ];
+            break;
+          default:
+            break;
         }
         break;
       default:
@@ -294,6 +306,9 @@ export const notableSpatialPhenomenaTable = (
                 NotableSpatialPhenomenon.StellarFlareClass3
               ],
             ];
+            break;
+          default:
+            break;
         }
     }
   } else {
@@ -349,6 +364,8 @@ export const notableSpatialPhenomenaTable = (
                 NotableSpatialPhenomenon.GravittionalWavesClass3
               ],
             ];
+            break;
+          default:
             break;
         }
         break;
@@ -410,6 +427,8 @@ export const notableSpatialPhenomenaTable = (
               ],
             ];
             break;
+          default:
+            break;
         }
         break;
       case SpecialSectors.EmberSector:
@@ -463,6 +482,8 @@ export const notableSpatialPhenomenaTable = (
                 NotableSpatialPhenomenon.StellarFlareClass2
               ],
             ];
+            break;
+          default:
             break;
         }
         break;
@@ -518,6 +539,8 @@ export const notableSpatialPhenomenaTable = (
               ],
             ];
             break;
+          default:
+            break;
         }
         break;
       case SpecialSectors.GeneralExpanse:
@@ -572,6 +595,8 @@ export const notableSpatialPhenomenaTable = (
                 NotableSpatialPhenomenon.IonStormClass2
               ],
             ];
+            break;
+          default:
             break;
         }
         break;

--- a/WebTools/src/mapping/table/notableSystemTable.ts
+++ b/WebTools/src/mapping/table/notableSystemTable.ts
@@ -33,5 +33,7 @@ export const notableSystemTable: TableRoll<number> = () => {
       return 9;
     case 20:
       return 11;
+    default:
+      break;
   }
 };

--- a/WebTools/src/mapping/table/planetaryFeature.ts
+++ b/WebTools/src/mapping/table/planetaryFeature.ts
@@ -104,6 +104,8 @@ const transporterInhibitorFeature = () => {
       return new TransporterInhibitingConditionsFeature(
         'Atmosphere contains hyperonic radition, lethal to humans, and rendering transporters and phasers inoperable',
       );
+    default:
+      break;
   }
 };
 

--- a/WebTools/src/mapping/table/systemGenerator.ts
+++ b/WebTools/src/mapping/table/systemGenerator.ts
@@ -531,6 +531,8 @@ class SystemGeneration {
       case 19:
       case 20:
         return AsteroidBeltZone.CarbonaceousOrIce;
+      default:
+        break;
     }
   };
 
@@ -1337,6 +1339,8 @@ class SystemGeneration {
           case 10:
             result.rotationPeriod = period;
             break;
+          default:
+            break;
         }
       } else {
         result.rotationPeriod = addNoiseToValue(period);
@@ -1404,6 +1408,8 @@ class SystemGeneration {
           90,
           addNoiseToValue(D20.roll() / 2 + subRoll),
         );
+        break;
+      default:
         break;
     }
 

--- a/WebTools/src/modify/modifyBreadcrumb.tsx
+++ b/WebTools/src/modify/modifyBreadcrumb.tsx
@@ -41,6 +41,8 @@ export const ModifyBreadcrumb = (props: IModifyBreadcrumbProperties) => {
       case ModificationType.Reputation:
         activePageTitle = 'reputationChange';
         break;
+      default:
+        break;
     }
   }
 

--- a/WebTools/src/pages/selectionPage.tsx
+++ b/WebTools/src/pages/selectionPage.tsx
@@ -41,6 +41,8 @@ const SelectionPage = () => {
         navigate('/tools');
         break;
       }
+      default:
+        break;
     }
   };
 

--- a/WebTools/src/solo/table/speciesRandomTable.ts
+++ b/WebTools/src/solo/table/speciesRandomTable.ts
@@ -58,6 +58,8 @@ const enterpriseSpeciesRandomTable = () => {
       return Species.XindiPrimate;
     case 20:
       return Species.XindiReptilian;
+    default:
+      break;
   }
 };
 
@@ -105,6 +107,8 @@ const originalSeriesSpeciesRandomTable = () => {
       return Species.Xahean;
     case 20:
       return Species.Zaranite;
+    default:
+      break;
   }
 };
 
@@ -152,5 +156,7 @@ const nextGenerationSpeciesRandomTable = () => {
       return Species.Tamarian;
     case 20:
       return Species.Zakdorn;
+    default:
+      break;
   }
 };

--- a/WebTools/src/starship/model/starshipTalentMatrix.ts
+++ b/WebTools/src/starship/model/starshipTalentMatrix.ts
@@ -108,5 +108,7 @@ export const starshipTalentMatrix = (roll: number) => {
       return TalentsHelper.getTalent('Versatile Tractor Beam');
     case 60:
       return TalentsHelper.getTalent('Wormhole Relay System');
+    default:
+      break;
   }
 };

--- a/WebTools/src/supportingcharacters/modify/modifySupportCharacterPage.tsx
+++ b/WebTools/src/supportingcharacters/modify/modifySupportCharacterPage.tsx
@@ -131,6 +131,8 @@ const ModifySupportingCharacterPage: React.FC<ICharacterPageProperties> = ({
           character.improvements?.filter((i) => i instanceof Promotion)
             ?.length ?? 0
         );
+      default:
+        break;
     }
   };
 

--- a/WebTools/src/vtt/fantasyGroundsVttExport.ts
+++ b/WebTools/src/vtt/fantasyGroundsVttExport.ts
@@ -582,6 +582,8 @@ export class FantasyGroupsVttExporter {
           return 'Notable Character';
         case NpcType.Major:
           return 'Major Character';
+        default:
+          break;
       }
     }
   }


### PR DESCRIPTION
Add a trailing `default: break;` to the 69 switch statements across src that omitted one (plan item 14 of #438). Empty defaults preserve existing fall-through behavior.

Identified via the TypeScript compiler API; 6 switches whose last case fell through into the new default received an explicit terminating break. All 257 switches in src and tests now have a default clause.

Verification: full_check.sh passes (58 suites / 322 tests, tsc --noEmit, eslint on src and tests, prettier:check).