### PR TITLE
Use strict equality for typeof check (part of #438)

### DIFF
--- a/WebTools/src/helpers/talentModel.ts
+++ b/WebTools/src/helpers/talentModel.ts
@@ -62,7 +62,7 @@ export class TalentModel implements ITalent {
       }
     }
 
-    if (typeof specialRule == 'boolean') {
+    if (typeof specialRule === 'boolean') {
       const f = (version: number) => {
         return specialRule;
       };


### PR DESCRIPTION
Convert the one loose equality comparison in `talentModel.ts` (`typeof specialRule == 'boolean'`) to `===` (plan item 12 of #438).

Verification: full_check.sh passes (58 suites / 322 tests, tsc --noEmit, eslint on src and tests, prettier:check).