### PR TITLE
Use Number() instead of parseInt() (part of #438)

### DIFF
--- a/WebTools/src/components/registryNumberGenerator.tsx
+++ b/WebTools/src/components/registryNumberGenerator.tsx
@@ -81,7 +81,7 @@ class RegistryNumberGenerator {
     keys.sort();
 
     for (const key of keys) {
-      const year = parseInt(key);
+      const year = Number(key);
       if (serviceYear > year) {
         lower = this.serviceYearRegistryNumbers[key];
       }

--- a/WebTools/src/components/speciesSelection.tsx
+++ b/WebTools/src/components/speciesSelection.tsx
@@ -236,7 +236,7 @@ const SpeciesSelection: React.FC<ISpeciesSelectionProperties> = ({
               title={buttonTitle}
               size="sm"
               onSelect={(eventKey) => {
-                setMode(parseInt(eventKey) as RandomMode);
+                setMode(Number(eventKey) as RandomMode);
               }}
               onClick={() => setRandomSpecies(determineRandomSpecies(mode))}
               className="me-3"

--- a/WebTools/src/helpers/marshaller.ts
+++ b/WebTools/src/helpers/marshaller.ts
@@ -1445,8 +1445,8 @@ class Marshaller {
         if (s === '-') {
           stats[a] = new AssetStat();
         } else if (s?.length && s?.indexOf('/') >= 0) {
-          const base = parseInt(s.substring(0, s.indexOf('/')));
-          const critical = parseInt(s.substring(s.indexOf('/') + 1));
+          const base = Number(s.substring(0, s.indexOf('/')));
+          const critical = Number(s.substring(s.indexOf('/') + 1));
 
           stats[a] = new AssetStat(base, critical);
         }

--- a/WebTools/src/helpers/ranks.ts
+++ b/WebTools/src/helpers/ranks.ts
@@ -269,7 +269,7 @@ export class RankModel {
 
   get levelValue() {
     if (this.level.length > 1) {
-      return parseInt(this.level.substring(1));
+      return Number(this.level.substring(1));
     } else {
       return 0;
     }

--- a/WebTools/src/helpers/talentModel.ts
+++ b/WebTools/src/helpers/talentModel.ts
@@ -57,7 +57,7 @@ export class TalentModel implements ITalent {
       } else {
         this.category = new TalentCategorization(
           TalentCategory.Species,
-          parseInt(species[0]),
+          Number(species[0]),
         );
       }
     }

--- a/WebTools/src/pages/characterTypePage.tsx
+++ b/WebTools/src/pages/characterTypePage.tsx
@@ -176,7 +176,7 @@ class CharacterTypePage extends React.Component<
   }
 
   private selectType(typeAsString: string) {
-    const type = parseInt(typeAsString) as CharacterType;
+    const type = Number(typeAsString) as CharacterType;
     this.setState((state) => ({
       ...state,
       type: type,
@@ -184,7 +184,7 @@ class CharacterTypePage extends React.Component<
   }
 
   private selectAlliedMilitaryType(typeAsString: string) {
-    const type = parseInt(typeAsString) as AlliedMilitaryType;
+    const type = Number(typeAsString) as AlliedMilitaryType;
     this.setState((state) => ({
       ...state,
       alliedMilitary: type,

--- a/WebTools/src/starship/model/randomStarshipEvent.ts
+++ b/WebTools/src/starship/model/randomStarshipEvent.ts
@@ -46,8 +46,8 @@ export const randomStarshipEvent = (
 ) => {
   const events = [];
   Object.keys(majorEvents)
-    .filter((year) => parseInt(year) <= currentYear)
-    .filter((year) => parseInt(year) >= spaceframe.serviceYear)
+    .filter((year) => Number(year) <= currentYear)
+    .filter((year) => Number(year) >= spaceframe.serviceYear)
     .forEach((year) => events.push(...majorEvents[year]));
 
   return events?.length

--- a/WebTools/src/starship/view/customSpaceframeView.tsx
+++ b/WebTools/src/starship/view/customSpaceframeView.tsx
@@ -100,7 +100,7 @@ const CustomSpaceframeView: React.FC<IStarshipProperties> = ({ starship }) => {
   };
 
   const setServiceYear = (serviceYear: string) => {
-    const year = parseInt(serviceYear);
+    const year = Number(serviceYear);
     const systems = getCurrentSystemValuesSortedMaxToMin();
     const newTotalPoints = BuildPoints.systemPointsForType(
       starship.buildType,

--- a/WebTools/src/starship/view/serviceYearView.tsx
+++ b/WebTools/src/starship/view/serviceYearView.tsx
@@ -24,7 +24,7 @@ export const ServiceYearSelector: React.FC<IServiceYearProperties> = ({
           defaultValue={campaignYear.toString()}
           onChange={(e) => {
             const value = e.target.value;
-            onChange(parseInt(value));
+            onChange(Number(value));
           }}
         />
       </div>

--- a/WebTools/src/station/view/scaleSelector.tsx
+++ b/WebTools/src/station/view/scaleSelector.tsx
@@ -28,7 +28,7 @@ export const ScaleSelector: React.FC<IScaleSelectorProperties> = ({
           defaultValue={scale.toString()}
           onChange={(e) => {
             const value = e.target.value;
-            onChange(parseInt(value));
+            onChange(Number(value));
           }}
         />
       </div>

--- a/WebTools/src/table/page/editTablePage.tsx
+++ b/WebTools/src/table/page/editTablePage.tsx
@@ -125,7 +125,7 @@ const EditTablePage: React.FC<IEditTablePageProperties> = ({
   const selectRowFrom = (from: string, index: number) => {
     const collection = tableCollection.copy();
     const row = collection.mainTable.rows[index];
-    row.from = parseInt(from);
+    row.from = Number(from);
     collection.mainTable.fillGaps();
 
     setTableCollection(collection);
@@ -134,7 +134,7 @@ const EditTablePage: React.FC<IEditTablePageProperties> = ({
   const selectRowTo = (to: string, index: number) => {
     const collection = tableCollection.copy();
     const row = collection.mainTable.rows[index];
-    row.to = parseInt(to);
+    row.to = Number(to);
     collection.mainTable.fillGaps();
 
     setTableCollection(collection);


### PR DESCRIPTION
Replace the 15 `parseInt()` decimal-string conversions across 11 files with `Number()` (plan item 11 of #438). All are pure-integer-string inputs (select values, Object.keys of numeric maps, number inputs), where `Number()` and `parseInt` agree.

The three hex-radix parses in `colour.ts` are left as `parseInt(..., 16)`, since `Number()` cannot parse hexadecimal directly.

Verification: full_check.sh passes (58 suites / 322 tests, tsc --noEmit, eslint on src and tests, prettier:check).