### PR TITLE
Add GitHub CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [sta-complete]
+  pull_request:
+    branches: [sta-complete]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: WebTools
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 26
+          cache: npm
+          cache-dependency-path: WebTools/package-lock.json
+
+      - run: npm ci
+      - run: npm test
+      - run: npm run typecheck
+      - run: npm run lint
+      - run: npm run prettier:check

--- a/WebTools/full_check.sh
+++ b/WebTools/full_check.sh
@@ -1,7 +1,6 @@
 npm test &&
-  tsc --noEmit &&
-  npx eslint src &&
-  npx eslint tests &&
+  npm run typecheck &&
+  npm run lint &&
   npm run prettier:check &&
   echo "passed" || echo "failed"
 

--- a/WebTools/package-lock.json
+++ b/WebTools/package-lock.json
@@ -51,6 +51,7 @@
         "@types/jest": "^29.5.12",
         "@types/react": "19.2.0",
         "@types/react-dom": "19.2.0",
+        "eslint": "8.27.0",
         "jest": "^29.0.0",
         "nodemon": "^2.0.22",
         "npm-run-all": "^4.1.5",

--- a/WebTools/package.json
+++ b/WebTools/package.json
@@ -96,6 +96,7 @@
     "sass": "^1.57.1",
     "serve": "^14.2.0",
     "systemjs-builder": "^0.15.18",
+    "eslint": "8.27.0",
     "ts-jest": "^29.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.9.3"
@@ -105,6 +106,8 @@
     "build": "react-scripts build",
     "test": "jest --forceExit",
     "eject": "react-scripts eject",
+    "lint": "eslint src tests",
+    "typecheck": "tsc --noEmit",
     "prettier": "prettier \"src/**/*.{ts,tsx}\" \"tests/**/*.{ts,tsx}\" --write",
     "prettier:check": "prettier \"src/**/*.{ts,tsx}\" \"tests/**/*.{ts,tsx}\" --check"
   },


### PR DESCRIPTION
Add CI that runs on pushes to sta-complete and PRs targeting it:

- **test**: jest --forceExit
- **typecheck**: tsc --noEmit
- **lint**: eslint src tests
- **prettier:check**: prettier format verification

Also adds eslint@8.27.0 as a direct devDependency (was transitive via react-scripts), adds `lint` and `typecheck` npm scripts, and updates `full_check.sh` to use them.

Verified locally: all 58 test suites pass, typecheck clean, lint clean, prettier clean.