### PR TITLE
Refactor pilot state slices to @reduxjs/toolkit (Plan A Phases 1 and 2)

### DIFF
--- a/WebTools/src/state/gmTrackerActions.ts
+++ b/WebTools/src/state/gmTrackerActions.ts
@@ -1,3 +1,4 @@
+import { createAction } from '@reduxjs/toolkit';
 import type { Character } from '../common/character';
 import type { CharacterWithTracking } from '../tracker/model/characterWithTracking';
 
@@ -7,40 +8,30 @@ export const SET_GM_TRACKED_CHARACTER_STRESS =
   'SET_GM_TRACKED_CHARACTER_STRESS';
 export const SET_GM_TRACKED_CHARACTER_NOTES = 'SET_GM_TRACKED_CHARACTER_NOTES';
 
-export function addGMTrackedCharacter(character: Character) {
-  const payload = { character: character };
-  return {
-    type: ADD_GM_TRACKED_CHARACTER,
-    payload: payload,
-  };
-}
+export const addGMTrackedCharacter = createAction(
+  ADD_GM_TRACKED_CHARACTER,
+  (character: Character) => ({
+    payload: { character: character },
+  }),
+);
 
-export function removeGMTrackedCharacter(character: CharacterWithTracking) {
-  const payload = { character: character };
-  return {
-    type: REMOVE_GM_TRACKED_CHARACTER,
-    payload: payload,
-  };
-}
+export const removeGMTrackedCharacter = createAction(
+  REMOVE_GM_TRACKED_CHARACTER,
+  (character: CharacterWithTracking) => ({
+    payload: { character: character },
+  }),
+);
 
-export function setGMTrackedCharacterStress(
-  character: CharacterWithTracking,
-  stress: number,
-) {
-  const payload = { character: character, stress: stress };
-  return {
-    type: SET_GM_TRACKED_CHARACTER_STRESS,
-    payload: payload,
-  };
-}
+export const setGMTrackedCharacterStress = createAction(
+  SET_GM_TRACKED_CHARACTER_STRESS,
+  (character: CharacterWithTracking, stress: number) => ({
+    payload: { character: character, stress: stress },
+  }),
+);
 
-export function setGMTrackedCharacterNotes(
-  character: CharacterWithTracking,
-  notes: string,
-) {
-  const payload = { character: character, notes: notes };
-  return {
-    type: SET_GM_TRACKED_CHARACTER_NOTES,
-    payload: payload,
-  };
-}
+export const setGMTrackedCharacterNotes = createAction(
+  SET_GM_TRACKED_CHARACTER_NOTES,
+  (character: CharacterWithTracking, notes: string) => ({
+    payload: { character: character, notes: notes },
+  }),
+);

--- a/WebTools/src/state/gmTrackerReducer.ts
+++ b/WebTools/src/state/gmTrackerReducer.ts
@@ -1,78 +1,88 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { Character } from '../common/character';
 import { CharacterWithTracking } from '../tracker/model/characterWithTracking';
 import {
-  ADD_GM_TRACKED_CHARACTER,
-  REMOVE_GM_TRACKED_CHARACTER,
-  SET_GM_TRACKED_CHARACTER_NOTES,
-  SET_GM_TRACKED_CHARACTER_STRESS,
+  addGMTrackedCharacter,
+  removeGMTrackedCharacter,
+  setGMTrackedCharacterNotes,
+  setGMTrackedCharacterStress,
 } from './gmTrackerActions';
 
 interface IGMTrackerState {
   characters: CharacterWithTracking[];
 }
 
-export const gmTracker = (
-  state: IGMTrackerState = { characters: [] },
-  action,
-) => {
-  switch (action.type) {
-    case ADD_GM_TRACKED_CHARACTER:
-      return {
-        ...state,
-        characters: [
-          ...state.characters,
-          new CharacterWithTracking(action.payload.character),
-        ],
-      };
-    case REMOVE_GM_TRACKED_CHARACTER: {
-      const characters = [...state.characters];
-      const index = characters
-        .map((c, i) => (c.id === action.payload.character?.id ? i : -1))
-        .filter((index) => index !== -1);
-      if (index.length) {
-        characters.splice(index[0], 1);
-      }
-      return {
-        ...state,
-        characters: characters,
-      };
-    }
-    case SET_GM_TRACKED_CHARACTER_STRESS: {
-      const characters = [...state.characters];
-      const index = characters
-        .map((c, i) => (c.id === action.payload.character?.id ? i : -1))
-        .filter((index) => index !== -1);
-      if (index.length) {
-        const existing = characters[index[0]];
-        const tracking = new CharacterWithTracking(existing.character);
-        tracking.id = existing.id;
-        tracking.currentStress = action.payload.stress;
-        tracking.notes = existing.notes;
-        characters[index[0]] = tracking;
-      }
-      return {
-        ...state,
-        characters: characters,
-      };
-    }
-    case SET_GM_TRACKED_CHARACTER_NOTES: {
-      const characters = [...state.characters];
-      const index = characters
-        .map((c, i) => (c.id === action.payload.character?.id ? i : -1))
-        .filter((index) => index !== -1);
-      if (index.length) {
-        const existing = characters[index[0]];
-        const tracking = new CharacterWithTracking(existing.character);
-        tracking.id = existing.id;
-        tracking.currentStress = existing.currentStress;
-        tracking.notes = action.payload.notes;
-        characters[index[0]] = tracking;
-      }
-      return {
-        ...state,
-        characters: characters,
-      };
-    }
-    default:
-      return state;
-  }
-};
+const initialState: IGMTrackerState = { characters: [] };
+
+export const gmTrackerSlice = createSlice({
+  name: 'gmTracker',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(addGMTrackedCharacter, (state, action) => {
+        return {
+          ...state,
+          characters: [
+            ...state.characters,
+            new CharacterWithTracking(action.payload.character),
+          ],
+        };
+      })
+      .addCase(removeGMTrackedCharacter, (state, action) => {
+        const characters = [...state.characters];
+        const index = characters
+          .map((c, i) => (c.id === action.payload.character?.id ? i : -1))
+          .filter((index) => index !== -1);
+        if (index.length) {
+          characters.splice(index[0], 1);
+        }
+        return {
+          ...state,
+          characters: characters,
+        };
+      })
+      .addCase(setGMTrackedCharacterStress, (state, action) => {
+        const characters = [...state.characters];
+        const index = characters
+          .map((c, i) => (c.id === action.payload.character?.id ? i : -1))
+          .filter((index) => index !== -1);
+        if (index.length) {
+          const existing = characters[index[0]];
+          const tracking = new CharacterWithTracking(
+            existing.character as Character,
+          );
+          tracking.id = existing.id;
+          tracking.currentStress = action.payload.stress;
+          tracking.notes = existing.notes;
+          characters[index[0]] = tracking;
+        }
+        return {
+          ...state,
+          characters: characters,
+        };
+      })
+      .addCase(setGMTrackedCharacterNotes, (state, action) => {
+        const characters = [...state.characters];
+        const index = characters
+          .map((c, i) => (c.id === action.payload.character?.id ? i : -1))
+          .filter((index) => index !== -1);
+        if (index.length) {
+          const existing = characters[index[0]];
+          const tracking = new CharacterWithTracking(
+            existing.character as Character,
+          );
+          tracking.id = existing.id;
+          tracking.currentStress = existing.currentStress;
+          tracking.notes = action.payload.notes;
+          characters[index[0]] = tracking;
+        }
+        return {
+          ...state,
+          characters: characters,
+        };
+      });
+  },
+});
+
+export const gmTracker = gmTrackerSlice.reducer;

--- a/WebTools/src/state/safetyActions.ts
+++ b/WebTools/src/state/safetyActions.ts
@@ -1,14 +1,11 @@
+import { createAction } from '@reduxjs/toolkit';
 import type { SafetyEvaluationType } from '../safety/model/safetyEvaluation';
 
 export const SET_SAFETY_EVALUATION = 'SET_SAFETY_EVALUATION';
 
-export function setSafetyEvaluation(
-  category: string,
-  evaluation: SafetyEvaluationType,
-) {
-  const payload = { category: category, evaluation: evaluation };
-  return {
-    type: SET_SAFETY_EVALUATION,
-    payload: payload,
-  };
-}
+export const setSafetyEvaluation = createAction(
+  SET_SAFETY_EVALUATION,
+  (category: string, evaluation: SafetyEvaluationType) => ({
+    payload: { category: category, evaluation: evaluation },
+  }),
+);

--- a/WebTools/src/state/safetyReducer.ts
+++ b/WebTools/src/state/safetyReducer.ts
@@ -1,11 +1,15 @@
+import { createSlice } from '@reduxjs/toolkit';
 import type { SafetyEvaluationType } from '../safety/model/safetyEvaluation';
-import { SET_SAFETY_EVALUATION } from './safetyActions';
+import { setSafetyEvaluation } from './safetyActions';
 
 const initialState: { [key: string]: SafetyEvaluationType } = {};
 
-export const safety = (state: any = initialState, action) => {
-  switch (action.type) {
-    case SET_SAFETY_EVALUATION: {
+export const safetySlice = createSlice({
+  name: 'safety',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(setSafetyEvaluation, (state, action) => {
       const category = action.payload.category;
       const evaluation = action.payload.evaluation;
 
@@ -13,8 +17,8 @@ export const safety = (state: any = initialState, action) => {
       temp[category] = evaluation;
 
       return temp;
-    }
-    default:
-      return state;
-  }
-};
+    });
+  },
+});
+
+export const safety = safetySlice.reducer;

--- a/WebTools/src/state/savedConstructActions.ts
+++ b/WebTools/src/state/savedConstructActions.ts
@@ -1,3 +1,4 @@
+import { createAction } from '@reduxjs/toolkit';
 import type { Character } from '../common/character';
 import { cyrb53 } from '../common/cyrb53';
 import type { Starship } from '../common/starship';
@@ -6,40 +7,36 @@ import { marshaller } from '../helpers/marshaller';
 export const SAVE_CONSTRUCT_TO_LOCAL_STORAGE =
   'SAVE_CONSTRUCT_TO_LOCAL_STORAGE';
 
-export function saveCharacterToLocalStorage(
-  character: Character,
-  replacementHash?: number,
-) {
-  const name = character.nameAndAbbreviatedRank;
-  const marshalled = marshaller.encodeCharacter(character);
-  const payload = {
-    type: 'Character',
-    name: name,
-    marshalled: marshalled,
-    hash: cyrb53(marshalled),
-    replacementHash: replacementHash,
-  };
-  return {
-    type: SAVE_CONSTRUCT_TO_LOCAL_STORAGE,
-    payload: payload,
-  };
-}
+export const saveCharacterToLocalStorage = createAction(
+  SAVE_CONSTRUCT_TO_LOCAL_STORAGE,
+  (character: Character, replacementHash?: number) => {
+    const name = character.nameAndAbbreviatedRank;
+    const marshalled = marshaller.encodeCharacter(character);
+    return {
+      payload: {
+        type: 'Character' as const,
+        name: name,
+        marshalled: marshalled,
+        hash: cyrb53(marshalled),
+        replacementHash: replacementHash,
+      },
+    };
+  },
+);
 
-export function saveStarshipToLocalStorage(
-  starship: Starship,
-  replacementHash?: number,
-) {
-  const name = starship.name;
-  const marshalled = marshaller.encodeStarship(starship);
-  const payload = {
-    type: 'Starship',
-    name: name,
-    marshalled: marshalled,
-    hash: cyrb53(marshalled),
-    replacementHash: replacementHash,
-  };
-  return {
-    type: SAVE_CONSTRUCT_TO_LOCAL_STORAGE,
-    payload: payload,
-  };
-}
+export const saveStarshipToLocalStorage = createAction(
+  SAVE_CONSTRUCT_TO_LOCAL_STORAGE,
+  (starship: Starship, replacementHash?: number) => {
+    const name = starship.name;
+    const marshalled = marshaller.encodeStarship(starship);
+    return {
+      payload: {
+        type: 'Starship' as const,
+        name: name,
+        marshalled: marshalled,
+        hash: cyrb53(marshalled),
+        replacementHash: replacementHash,
+      },
+    };
+  },
+);

--- a/WebTools/src/state/savedConstructReducer.ts
+++ b/WebTools/src/state/savedConstructReducer.ts
@@ -1,5 +1,6 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { AnyAction } from '@reduxjs/toolkit';
 import type { ILocalStorageConstructRecord } from '../common/iLocalStorageConstructRecord';
-import { SAVE_CONSTRUCT_TO_LOCAL_STORAGE } from './savedConstructActions';
 
 const persistItems = (records: ILocalStorageConstructRecord[]) => {
   const data = {
@@ -8,8 +9,20 @@ const persistItems = (records: ILocalStorageConstructRecord[]) => {
   window.localStorage.setItem('constructs.records', JSON.stringify(data));
 };
 
-const getInitialData = () => {
-  const base = { records: [] };
+interface SavedConstructState {
+  records: ILocalStorageConstructRecord[];
+}
+
+interface SaveConstructPayload {
+  type: 'Character' | 'Starship';
+  name: string;
+  marshalled: string;
+  hash: number;
+  replacementHash?: number;
+}
+
+const getInitialData = (): SavedConstructState => {
+  const base: SavedConstructState = { records: [] };
   const initialData = { ...base };
   try {
     const dataJson = window.localStorage.getItem('constructs.records');
@@ -25,34 +38,38 @@ const getInitialData = () => {
   return initialData;
 };
 
-export const savedConstructReducer = (state = getInitialData(), action) => {
-  switch (action.type) {
-    case SAVE_CONSTRUCT_TO_LOCAL_STORAGE: {
-      let records = [...state.records];
-      const hash = action.payload.hash;
-      if (action.payload.replacementHash != null) {
-        records = records.filter(
-          (r) => r.hash !== action.payload.replacementHash,
-        );
-      }
-      if (records.filter((r) => r.hash === hash).length === 0) {
-        records.push({
-          type: action.payload.type,
-          marshalled: action.payload.marshalled,
-          hash: action.payload.hash,
-          name: action.payload.name,
-        });
-      }
-
-      if (records.length > 5) {
-        records.splice(0, records.length - 5);
-      }
-      persistItems(records);
-      return {
-        records: records,
-      };
-    }
-    default:
-      return state;
+const handleSave = (state: SavedConstructState, action: AnyAction) => {
+  const payload = action.payload as SaveConstructPayload;
+  let records: ILocalStorageConstructRecord[] = [...state.records];
+  const hash = payload.hash;
+  if (payload.replacementHash != null) {
+    records = records.filter((r) => r.hash !== payload.replacementHash);
   }
+  if (records.filter((r) => r.hash === hash).length === 0) {
+    records.push({
+      type: payload.type,
+      marshalled: payload.marshalled,
+      hash: payload.hash,
+      name: payload.name,
+    });
+  }
+
+  if (records.length > 5) {
+    records.splice(0, records.length - 5);
+  }
+  persistItems(records);
+  return {
+    records: records,
+  };
 };
+
+export const savedConstructSlice = createSlice({
+  name: 'savedConstruct',
+  initialState: getInitialData,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase('SAVE_CONSTRUCT_TO_LOCAL_STORAGE', handleSave);
+  },
+});
+
+export const savedConstructReducer = savedConstructSlice.reducer;

--- a/WebTools/src/state/starActions.ts
+++ b/WebTools/src/state/starActions.ts
@@ -1,3 +1,4 @@
+import { createAction } from '@reduxjs/toolkit';
 import type { Sector } from '../mapping/table/sector';
 import type { StarSystem } from '../mapping/table/starSystem';
 
@@ -6,34 +7,21 @@ export const SET_SECTOR = 'SET_SECTOR';
 export const SET_SECTOR_NAME = 'SET_SECTOR_NAME';
 export const SET_STAR_SYSTEM_NAME = 'SET_STAR_SYSTEM_NAME';
 
-export function setStar(starSystem: StarSystem) {
-  const payload = { starSystem: starSystem };
-  return {
-    type: SET_STAR,
-    payload: payload,
-  };
-}
+export const setStar = createAction(SET_STAR, (starSystem: StarSystem) => ({
+  payload: { starSystem: starSystem },
+}));
 
-export function setSector(sector: Sector) {
-  const payload = { sector: sector };
-  return {
-    type: SET_SECTOR,
-    payload: payload,
-  };
-}
+export const setSector = createAction(SET_SECTOR, (sector: Sector) => ({
+  payload: { sector: sector },
+}));
 
-export function setSectorName(name: string) {
-  const payload = { name: name };
-  return {
-    type: SET_SECTOR_NAME,
-    payload: payload,
-  };
-}
+export const setSectorName = createAction(SET_SECTOR_NAME, (name: string) => ({
+  payload: { name: name },
+}));
 
-export function setStarSystemName(name: string) {
-  const payload = { name: name };
-  return {
-    type: SET_STAR_SYSTEM_NAME,
-    payload: payload,
-  };
-}
+export const setStarSystemName = createAction(
+  SET_STAR_SYSTEM_NAME,
+  (name: string) => ({
+    payload: { name: name },
+  }),
+);

--- a/WebTools/src/state/starReducer.ts
+++ b/WebTools/src/state/starReducer.ts
@@ -1,10 +1,11 @@
+import { createSlice } from '@reduxjs/toolkit';
 import { Sector } from '../mapping/table/sector';
 import type { StarSystem } from '../mapping/table/starSystem';
 import {
-  SET_SECTOR,
-  SET_SECTOR_NAME,
-  SET_STAR,
-  SET_STAR_SYSTEM_NAME,
+  setSector,
+  setSectorName,
+  setStar,
+  setStarSystemName,
 } from './starActions';
 
 interface StarState {
@@ -12,73 +13,78 @@ interface StarState {
   starSystem?: StarSystem;
 }
 
-export const star = (
-  state: StarState = { starSystem: undefined, sector: undefined },
-  action,
-) => {
-  switch (action.type) {
-    case SET_SECTOR:
-      return {
-        ...state,
-        sector: action.payload.sector,
-      };
-    case SET_SECTOR_NAME: {
-      const name = action.payload.name;
-      const systems = state.sector.systems.map((s) => {
-        const system = s.clone();
-        system.rootName = name;
-        return system;
-      });
-      const sector = new Sector(state.sector.prefix);
-      sector.id = state.sector.id;
-      sector.simpleName = name;
-      sector.systems = systems;
+const initialState: StarState = { starSystem: undefined, sector: undefined };
 
-      const starSystem = state.starSystem
-        ? state.starSystem.clone()
-        : undefined;
-      if (starSystem) {
-        starSystem.rootName = name;
-      }
-      return {
-        ...state,
-        sector: sector,
-        starSystem: starSystem,
-      };
-    }
-    case SET_STAR_SYSTEM_NAME: {
-      const starSystem = state.starSystem
-        ? state.starSystem.clone()
-        : undefined;
-      if (starSystem) {
-        starSystem.friendlyName = action.payload.name;
-        const systems = state.sector.systems.map((s) => {
-          if (s.id === starSystem.id) {
-            return starSystem;
-          } else {
-            return s;
-          }
-        });
-        const sector = new Sector(state.sector.prefix);
-        sector.id = state.sector.id;
-        sector.simpleName = state.sector.simpleName;
-        sector.systems = systems;
-
+export const starSlice = createSlice({
+  name: 'star',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(setSector, (state, action) => {
         return {
           ...state,
-          sector: sector,
-          starSystem: starSystem,
+          sector: action.payload.sector,
         };
-      } else {
-        return state;
-      }
-    }
-    case SET_STAR:
-      return {
-        ...state,
-        starSystem: action.payload.starSystem,
-      };
-    default:
-      return state;
-  }
-};
+      })
+      .addCase(setSectorName, (state, action) => {
+        const sector = state.sector as Sector;
+        const starSystem = state.starSystem as StarSystem | undefined;
+        const name = action.payload.name;
+        const systems = sector.systems.map((s) => {
+          const system = s.clone();
+          system.rootName = name;
+          return system;
+        });
+        const newSector = new Sector(sector.prefix);
+        newSector.id = sector.id;
+        newSector.simpleName = name;
+        newSector.systems = systems;
+
+        const newStarSystem = starSystem ? starSystem.clone() : undefined;
+        if (newStarSystem) {
+          newStarSystem.rootName = name;
+        }
+        return {
+          ...state,
+          sector: newSector,
+          starSystem: newStarSystem,
+        };
+      })
+      .addCase(setStarSystemName, (state, action) => {
+        const sector = state.sector as Sector;
+        const starSystem = state.starSystem as StarSystem | undefined;
+        const newStarSystem = starSystem ? starSystem.clone() : undefined;
+        if (newStarSystem) {
+          newStarSystem.friendlyName = action.payload.name;
+          const systems = sector.systems.map((s) => {
+            if (s.id === newStarSystem.id) {
+              return newStarSystem;
+            } else {
+              return s;
+            }
+          });
+          const newSector = new Sector(sector.prefix);
+          newSector.id = sector.id;
+          newSector.simpleName = sector.simpleName;
+          newSector.systems = systems;
+
+          return {
+            ...state,
+            sector: newSector,
+            starSystem: newStarSystem,
+          };
+        } else {
+          return state;
+        }
+      })
+      .addCase(setStar, (state, action) => {
+        return {
+          ...state,
+          starSystem: action.payload.starSystem,
+        };
+      });
+  },
+});
+
+export const star = starSlice.reducer;

--- a/WebTools/tests/state/gmTrackerReducer.test.ts
+++ b/WebTools/tests/state/gmTrackerReducer.test.ts
@@ -1,0 +1,99 @@
+import { test, expect, describe } from '@jest/globals';
+import { Character } from '../../src/common/character';
+import { CharacterType } from '../../src/common/characterType';
+import { Era } from '../../src/helpers/erasEnum';
+import { CharacterWithTracking } from '../../src/tracker/model/characterWithTracking';
+import { gmTracker } from '../../src/state/gmTrackerReducer';
+import {
+  addGMTrackedCharacter,
+  removeGMTrackedCharacter,
+  setGMTrackedCharacterStress,
+  setGMTrackedCharacterNotes,
+} from '../../src/state/gmTrackerActions';
+
+function makeCharacter(): Character {
+  return Character.createMainCharacter(
+    CharacterType.Starfleet,
+    Era.NextGeneration,
+    2,
+  );
+}
+
+function makeTracking(): CharacterWithTracking {
+  const tracking = new CharacterWithTracking(makeCharacter());
+  tracking.id = 'tracking-1';
+  return tracking;
+}
+
+describe('gmTrackerReducer', () => {
+  test('returns initial state for an unknown action', () => {
+    const result = gmTracker(undefined, { type: 'UNKNOWN' });
+    expect(result).toEqual({ characters: [] });
+  });
+
+  test('ADD_GM_TRACKED_CHARACTER appends a wrapped character', () => {
+    const character = makeCharacter();
+    const result = gmTracker(undefined, addGMTrackedCharacter(character));
+    expect(result.characters).toHaveLength(1);
+    expect(result.characters[0].character).toBe(character);
+    expect(result.characters[0].currentStress).toBe(0);
+    expect(result.characters[0].notes).toBe('');
+  });
+
+  test('REMOVE_GM_TRACKED_CHARACTER removes the matching character', () => {
+    const first = makeTracking();
+    const second = new CharacterWithTracking(makeCharacter());
+    second.id = 'tracking-2';
+    const state = { characters: [first, second] };
+    const result = gmTracker(state, removeGMTrackedCharacter(first));
+    expect(result.characters).toHaveLength(1);
+    expect(result.characters[0].id).toBe('tracking-2');
+  });
+
+  test('REMOVE_GM_TRACKED_CHARACTER is a no-op when the character is not present', () => {
+    const first = makeTracking();
+    const notPresent = makeTracking();
+    notPresent.id = 'tracking-99';
+    const state = { characters: [first] };
+    const result = gmTracker(state, removeGMTrackedCharacter(notPresent));
+    expect(result.characters).toHaveLength(1);
+  });
+
+  test('SET_GM_TRACKED_CHARACTER_STRESS updates stress and preserves id and notes', () => {
+    const tracking = makeTracking();
+    tracking.notes = 'some notes';
+    const result = gmTracker(
+      { characters: [tracking] },
+      setGMTrackedCharacterStress(tracking, 7),
+    );
+    expect(result.characters[0].id).toBe('tracking-1');
+    expect(result.characters[0].currentStress).toBe(7);
+    expect(result.characters[0].notes).toBe('some notes');
+  });
+
+  test('SET_GM_TRACKED_CHARACTER_STRESS is a no-op when the character is not present', () => {
+    const tracking = makeTracking();
+    const state = { characters: [] };
+    const result = gmTracker(state, setGMTrackedCharacterStress(tracking, 5));
+    expect(result.characters).toHaveLength(0);
+  });
+
+  test('SET_GM_TRACKED_CHARACTER_NOTES updates notes and preserves id and stress', () => {
+    const tracking = makeTracking();
+    tracking.currentStress = 4;
+    const result = gmTracker(
+      { characters: [tracking] },
+      setGMTrackedCharacterNotes(tracking, 'updated notes'),
+    );
+    expect(result.characters[0].id).toBe('tracking-1');
+    expect(result.characters[0].currentStress).toBe(4);
+    expect(result.characters[0].notes).toBe('updated notes');
+  });
+
+  test('SET_GM_TRACKED_CHARACTER_NOTES is a no-op when the character is not present', () => {
+    const tracking = makeTracking();
+    const state = { characters: [] };
+    const result = gmTracker(state, setGMTrackedCharacterNotes(tracking, 'x'));
+    expect(result.characters).toHaveLength(0);
+  });
+});

--- a/WebTools/tests/state/safetyReducer.test.ts
+++ b/WebTools/tests/state/safetyReducer.test.ts
@@ -1,0 +1,44 @@
+import { test, expect, describe } from '@jest/globals';
+import { SafetyEvaluationType } from '../../src/safety/model/safetyEvaluation';
+import { safety } from '../../src/state/safetyReducer';
+import { setSafetyEvaluation } from '../../src/state/safetyActions';
+
+describe('safetyReducer', () => {
+  test('returns initial state for an unknown action', () => {
+    const result = safety(undefined, { type: 'UNKNOWN' });
+    expect(result).toEqual({});
+  });
+
+  test('returns the previous state for an unknown action when state is set', () => {
+    const current = { bridge: SafetyEvaluationType.YellowAlert };
+    const result = safety(current, { type: 'UNKNOWN' });
+    expect(result).toBe(current);
+  });
+
+  test('stores an evaluation under its category', () => {
+    const action = setSafetyEvaluation('bridge', SafetyEvaluationType.RedAlert);
+    const result = safety(undefined, action);
+    expect(result).toEqual({ bridge: SafetyEvaluationType.RedAlert });
+  });
+
+  test('adds a new category while preserving existing categories', () => {
+    const current = { bridge: SafetyEvaluationType.YellowAlert };
+    const action = setSafetyEvaluation(
+      'engineering',
+      SafetyEvaluationType.RedAlert,
+    );
+    const result = safety(current, action);
+    expect(result).toEqual({
+      bridge: SafetyEvaluationType.YellowAlert,
+      engineering: SafetyEvaluationType.RedAlert,
+    });
+    expect(result).not.toBe(current);
+  });
+
+  test('overwrites an existing category', () => {
+    const current = { bridge: SafetyEvaluationType.YellowAlert };
+    const action = setSafetyEvaluation('bridge', SafetyEvaluationType.AlwaysOk);
+    const result = safety(current, action);
+    expect(result).toEqual({ bridge: SafetyEvaluationType.AlwaysOk });
+  });
+});

--- a/WebTools/tests/state/savedConstructReducer.test.ts
+++ b/WebTools/tests/state/savedConstructReducer.test.ts
@@ -1,0 +1,132 @@
+import { test, expect, describe, beforeAll, beforeEach } from '@jest/globals';
+import {
+  SAVE_CONSTRUCT_TO_LOCAL_STORAGE,
+  saveCharacterToLocalStorage,
+} from '../../src/state/savedConstructActions';
+import { Character } from '../../src/common/character';
+import { CharacterType } from '../../src/common/characterType';
+import { Era } from '../../src/helpers/erasEnum';
+import { savedConstructReducer } from '../../src/state/savedConstructReducer';
+
+const STORAGE_KEY = 'constructs.records';
+
+function createLocalStorageMock(): Storage {
+  const storage = new Map<string, string>();
+  return {
+    get length() {
+      return storage.size;
+    },
+    clear: () => storage.clear(),
+    getItem: (key: string) =>
+      storage.has(key) ? (storage.get(key) ?? null) : null,
+    key: (index: number) => Array.from(storage.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+  } as Storage;
+}
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, 'window', {
+    value: { localStorage: createLocalStorageMock() },
+    configurable: true,
+    writable: true,
+  });
+});
+
+function makeCharacter(): Character {
+  return Character.createMainCharacter(
+    CharacterType.Starfleet,
+    Era.NextGeneration,
+    2,
+  );
+}
+
+function saveAction(hash: number, replacementHash?: number) {
+  return {
+    type: SAVE_CONSTRUCT_TO_LOCAL_STORAGE,
+    payload: {
+      type: 'Character',
+      name: 'Name ' + hash,
+      marshalled: 'marshalled-' + hash,
+      hash: hash,
+      replacementHash: replacementHash,
+    },
+  };
+}
+
+function recordedHashes(): number[] {
+  const data = JSON.parse(
+    (globalThis.window as any).localStorage.getItem(STORAGE_KEY),
+  );
+  return data.records.map((r: any) => r.hash);
+}
+
+describe('savedConstructReducer', () => {
+  beforeEach(() => {
+    (globalThis.window as any).localStorage.clear();
+  });
+
+  test('returns empty records for an unknown action on fresh state', () => {
+    const result = savedConstructReducer(undefined, { type: 'UNKNOWN' });
+    expect(result).toEqual({ records: [] });
+  });
+
+  test('hydrates the initial state from localStorage', () => {
+    const stored = { records: [{ hash: 111 }] };
+    (globalThis.window as any).localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(stored),
+    );
+    const result = savedConstructReducer(undefined, { type: 'UNKNOWN' });
+    expect(result.records).toEqual([{ hash: 111 }]);
+  });
+
+  test('SAVE_CONSTRUCT_TO_LOCAL_STORAGE appends a record and persists it', () => {
+    const action = saveAction(111);
+    const result = savedConstructReducer(undefined, action);
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].hash).toBe(111);
+    expect(result.records[0].name).toBe('Name 111');
+    expect(recordedHashes()).toEqual([111]);
+  });
+
+  test('SAVE avoids duplicating an identical hash', () => {
+    let state = savedConstructReducer(undefined, saveAction(111));
+    state = savedConstructReducer(state, saveAction(111));
+    expect(state.records).toHaveLength(1);
+  });
+
+  test('SAVE with a replacementHash removes the record with that hash', () => {
+    let state = savedConstructReducer(undefined, saveAction(111));
+    state = savedConstructReducer(state, saveAction(222, 111));
+
+    expect(state.records).toHaveLength(1);
+    expect(state.records[0].hash).toBe(222);
+    expect(recordedHashes()).toEqual([222]);
+  });
+
+  test('SAVE trims the record list down to five entries', () => {
+    let state = undefined;
+    for (let i = 0; i < 7; i++) {
+      state = savedConstructReducer(state, saveAction(1000 + i));
+    }
+    expect(state.records).toHaveLength(5);
+    expect(state.records.map((r: any) => r.hash)).toEqual([
+      1002, 1003, 1004, 1005, 1006,
+    ]);
+    expect(recordedHashes()).toEqual([1002, 1003, 1004, 1005, 1006]);
+  });
+
+  test('SAVE persisting is driven by an action produced by the creator', () => {
+    const action = saveCharacterToLocalStorage(makeCharacter());
+    const result = savedConstructReducer(undefined, action);
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].hash).toBe(action.payload.hash);
+    expect(recordedHashes()).toEqual([action.payload.hash]);
+  });
+});

--- a/WebTools/tests/state/starReducer.test.ts
+++ b/WebTools/tests/state/starReducer.test.ts
@@ -1,0 +1,97 @@
+import { test, expect, describe } from '@jest/globals';
+import { Sector } from '../../src/mapping/table/sector';
+import { StarSystem } from '../../src/mapping/table/starSystem';
+import type { Star } from '../../src/mapping/table/star';
+import { star } from '../../src/state/starReducer';
+import {
+  setSector,
+  setStar,
+  setSectorName,
+  setStarSystemName,
+} from '../../src/state/starActions';
+
+function makeSystem(id: string, rootName: string): StarSystem {
+  const system = new StarSystem({} as Star);
+  system.id = id;
+  system.rootName = rootName;
+  system.friendlyName = '';
+  return system;
+}
+
+function makeSectorWithSystems(systems: StarSystem[]): Sector {
+  const sector = new Sector('SCT');
+  sector.id = 'SCT-1';
+  sector.simpleName = 'Original Sector';
+  sector.systems = systems;
+  return sector;
+}
+
+describe('starReducer', () => {
+  test('returns initial state for an unknown action', () => {
+    const result = star(undefined, { type: 'UNKNOWN' });
+    expect(result).toEqual({ starSystem: undefined, sector: undefined });
+  });
+
+  test('SET_SECTOR stores the sector', () => {
+    const sector = makeSectorWithSystems([]);
+    const result = star(undefined, setSector(sector));
+    expect(result.sector).toBe(sector);
+    expect(result.starSystem).toBeUndefined();
+  });
+
+  test('SET_STAR stores the star system', () => {
+    const system = makeSystem('SYS-1', 'Alpha');
+    const result = star(undefined, setStar(system));
+    expect(result.starSystem).toBe(system);
+  });
+
+  test('SET_SECTOR_NAME renames every system in the sector', () => {
+    const system1 = makeSystem('SYS-1', 'Alpha');
+    const system2 = makeSystem('SYS-2', 'Beta');
+    const sector = makeSectorWithSystems([system1, system2]);
+    const starSystem = makeSystem('SYS-1', 'Alpha');
+
+    const result = star(
+      { sector: sector, starSystem: starSystem },
+      setSectorName('New Name'),
+    );
+
+    expect(result.sector?.name).toBe('New Name');
+    expect(result.sector?.simpleName).toBe('New Name');
+    expect(result.sector?.systems[0].rootName).toBe('New Name');
+    expect(result.sector?.systems[1].rootName).toBe('New Name');
+    expect(result.starSystem?.rootName).toBe('New Name');
+    expect(result).not.toBe(sector);
+  });
+
+  test('SET_SECTOR_NAME does not rebuild the starSystem when absent', () => {
+    const sector = makeSectorWithSystems([makeSystem('SYS-1', 'Alpha')]);
+    const result = star({ sector: sector }, setSectorName('New Name'));
+    expect(result.starSystem).toBeUndefined();
+    expect(result.sector?.simpleName).toBe('New Name');
+  });
+
+  test('SET_STAR_SYSTEM_NAME renames the matching system and starSystem', () => {
+    const system1 = makeSystem('SYS-1', 'Alpha');
+    const system2 = makeSystem('SYS-2', 'Beta');
+    const sector = makeSectorWithSystems([system1, system2]);
+    const starSystem = makeSystem('SYS-2', 'Beta');
+
+    const result = star(
+      { sector: sector, starSystem: starSystem },
+      setStarSystemName('Renamed'),
+    );
+
+    expect(result.starSystem?.friendlyName).toBe('Renamed');
+    expect(result.sector?.systems[1].friendlyName).toBe('Renamed');
+    expect(result.sector?.systems[0].friendlyName).toBe('');
+    expect(result.starSystem?.id).toBe('SYS-2');
+  });
+
+  test('SET_STAR_SYSTEM_NAME returns the same state when starSystem is absent', () => {
+    const sector = makeSectorWithSystems([makeSystem('SYS-1', 'Alpha')]);
+    const state = { sector: sector };
+    const result = star(state, setStarSystemName('Renamed'));
+    expect(result).toBe(state);
+  });
+});


### PR DESCRIPTION
## Summary

Part of the Redux refactor plan (`.opencode/refactoring-plan.md`, Plan A). Migrates the four smallest state slices to `@reduxjs/toolkit` and adds characterization tests for them.

### Phase 1: characterization tests

Adds reducer tests in `tests/state/` that lock current behavior before migration:

- `safetyReducer.test.ts`
- `starReducer.test.ts`
- `gmTrackerReducer.test.ts`
- `savedConstructReducer.test.ts` (uses an in-memory `window.localStorage` mock since tests run in the jest `node` environment)

### Phase 2: pilot slice migration

Converts the action creators to RTK `createAction` and the reducers to `createSlice` for safety, savedConstruct, star, and gmTracker.

- Action type strings and exported creator names are unchanged, so nothing outside `src/state` changes behaviorally.
- Reducer bodies keep their existing copy-mutate logic (no Immer-draft rewrite).

## Requirements

- [x] New characterization tests pass before and after the migration
- [x] No hand-rolled action creators remain in the four migrated slices
- [x] All pre-existing tests pass
- [x] `full_check.sh` clean (test, typecheck, lint, prettier)

## Notes and judgment calls

- Action type strings are preserved exactly using `createAction` plus `createSlice` `extraReducers` rather than default slice `name/action` prefixes, honoring the plan's requirement that action type strings stay identical.
- `savedConstructReducer` registers its case with the literal `'SAVE_CONSTRUCT_TO_LOCAL_STORAGE'` string. The original switch-based code read that constant lazily at dispatch time; `createSlice` reads it during lazy reducer build while the actions module is only partially evaluated through a circular import chain (`savedConstructActions` to `marshaller` to `store` to `savedConstructReducer`). Registering by literal breaks the eager build-time dependency. This can be cleaned up in a later phase by extracting a dependency-free action-type leaf module.
- Immer `WritableDraft` typing frictions with class instances were resolved with casts, since the copy-mutate cases return brand new objects and do not mutate state.

Deferred to later phases (out of scope here): medium and large slices, and the persistence middleware extraction.

Base: `sta-complete`