### PR TITLE
Migrate context, table, station, and token state slices to RTK

### DIFF
--- a/WebTools/src/state/contextActions.ts
+++ b/WebTools/src/state/contextActions.ts
@@ -1,3 +1,4 @@
+import { createAction } from '@reduxjs/toolkit';
 import type { Era } from '../helpers/erasEnum';
 import type { Source } from '../helpers/sources';
 
@@ -15,50 +16,32 @@ export const SET_ALLOW_ESOTERIC_TALENTS = 'SET_ALLOW_ESOTERIC_TALENTS';
  * "what decisions has the GM made about optional items"
  */
 
-export function addSource(source: Source) {
-  const payload = source;
-  return {
-    type: ADD_SOURCE,
-    payload: payload,
-  };
-}
+export const addSource = createAction(ADD_SOURCE, (source: Source) => ({
+  payload: source,
+}));
 
-export function removeSource(source: Source) {
-  const payload = source;
-  return {
-    type: REMOVE_SOURCE,
-    payload: payload,
-  };
-}
+export const removeSource = createAction(REMOVE_SOURCE, (source: Source) => ({
+  payload: source,
+}));
 
-export function setSources(sources: Source[]) {
-  const payload = sources;
-  return {
-    type: SET_SOURCES,
-    payload: payload,
-  };
-}
+export const setSources = createAction(SET_SOURCES, (sources: Source[]) => ({
+  payload: sources,
+}));
 
-export function setEra(era: Era) {
-  const payload = era;
-  return {
-    type: SET_ERA,
-    payload: payload,
-  };
-}
+export const setEra = createAction(SET_ERA, (era: Era) => ({
+  payload: era,
+}));
 
-export function setAllowCrossSpeciesTalents(value: boolean) {
-  const payload = value;
-  return {
-    type: SET_ALLOW_CROSS_SPECIES_TALENTS,
-    payload: payload,
-  };
-}
+export const setAllowCrossSpeciesTalents = createAction(
+  SET_ALLOW_CROSS_SPECIES_TALENTS,
+  (value: boolean) => ({
+    payload: value,
+  }),
+);
 
-export function setAllowEsotericTalents(value: boolean) {
-  const payload = value;
-  return {
-    type: SET_ALLOW_ESOTERIC_TALENTS,
-    payload: payload,
-  };
-}
+export const setAllowEsotericTalents = createAction(
+  SET_ALLOW_ESOTERIC_TALENTS,
+  (value: boolean) => ({
+    payload: value,
+  }),
+);

--- a/WebTools/src/state/contextReducer.ts
+++ b/WebTools/src/state/contextReducer.ts
@@ -1,13 +1,21 @@
+import { createSlice } from '@reduxjs/toolkit';
 import { Era } from '../helpers/erasEnum';
 import { Source, SourcesHelper } from '../helpers/sources';
 import {
-  ADD_SOURCE,
-  REMOVE_SOURCE,
-  SET_ALLOW_CROSS_SPECIES_TALENTS,
-  SET_ALLOW_ESOTERIC_TALENTS,
-  SET_ERA,
-  SET_SOURCES,
+  addSource,
+  removeSource,
+  setAllowCrossSpeciesTalents,
+  setAllowEsotericTalents,
+  setEra,
+  setSources,
 } from './contextActions';
+
+interface ContextState {
+  sources: Source[];
+  era: Era;
+  allowCrossSpeciesTalents: boolean;
+  allowEsotericTalents: boolean;
+}
 
 const persistContext = (sources: Source[]) => {
   const contextData = {
@@ -19,10 +27,10 @@ const persistContext = (sources: Source[]) => {
   );
 };
 
-let initialData = null;
+let initialData: ContextState = null;
 
-const getInitialData = () => {
-  const base = {
+const getInitialData = (): ContextState => {
+  const base: ContextState = {
     sources: [Source.Core],
     era: Era.NextGeneration,
     allowCrossSpeciesTalents: false,
@@ -59,9 +67,12 @@ const getInitialData = () => {
   return initialData;
 };
 
-export const contextReducer = (state = getInitialData(), action) => {
-  switch (action.type) {
-    case SET_SOURCES: {
+export const contextSlice = createSlice({
+  name: 'context',
+  initialState: getInitialData,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(setSources, (state, action) => {
       const newSources = action.payload;
       if (
         newSources.indexOf(Source.Core2ndEdition) >= 0 &&
@@ -79,8 +90,8 @@ export const contextReducer = (state = getInitialData(), action) => {
         ...state,
         sources: newSources,
       };
-    }
-    case ADD_SOURCE: {
+    });
+    builder.addCase(addSource, (state, action) => {
       if (state.sources.indexOf(action.payload) >= 0) {
         return state;
       } else {
@@ -109,8 +120,8 @@ export const contextReducer = (state = getInitialData(), action) => {
           sources: existing,
         };
       }
-    }
-    case REMOVE_SOURCE:
+    });
+    builder.addCase(removeSource, (state, action) => {
       if (state.sources.indexOf(action.payload) >= 0) {
         if (
           action.payload === Source.Core &&
@@ -134,22 +145,26 @@ export const contextReducer = (state = getInitialData(), action) => {
       } else {
         return state;
       }
-    case SET_ERA:
+    });
+    builder.addCase(setEra, (state, action) => {
       return {
         ...state,
         era: action.payload,
       };
-    case SET_ALLOW_CROSS_SPECIES_TALENTS:
+    });
+    builder.addCase(setAllowCrossSpeciesTalents, (state, action) => {
       return {
         ...state,
         allowCrossSpeciesTalents: action.payload,
       };
-    case SET_ALLOW_ESOTERIC_TALENTS:
+    });
+    builder.addCase(setAllowEsotericTalents, (state, action) => {
       return {
         ...state,
         allowEsotericTalents: action.payload,
       };
-    default:
-      return state;
-  }
-};
+    });
+  },
+});
+
+export const contextReducer = contextSlice.reducer;

--- a/WebTools/src/state/stationActions.ts
+++ b/WebTools/src/state/stationActions.ts
@@ -1,3 +1,4 @@
+import { createAction } from '@reduxjs/toolkit';
 import type { SelectedTalent } from '../common/selectedTalent';
 import type { Station } from '../common/station';
 import type { Department } from '../helpers/department';
@@ -26,109 +27,93 @@ export const SET_STATION_ADDITIONAL_TALENTS = 'SET_STATION_ADDITIONAL_TALENTS';
 export const SET_STATION_FRAME = 'SET_STATION_FRAME';
 export const SET_STATION_FRAME_APPEARANCE = 'SET_STATION_FRAME_APPEARANCE';
 
-export function createStation(station: Station) {
-  const payload = { station: station };
-  return {
-    type: CREATE_STATION,
-    payload: payload,
-  };
-}
+export const createStation = createAction(
+  CREATE_STATION,
+  (station: Station) => ({
+    payload: { station: station },
+  }),
+);
 
-export function setStationMissionProfile(missionProfile: MissionProfile) {
-  const payload = { missionProfile: missionProfile };
-  return {
-    type: SET_STATION_MISSION_PROFILE,
-    payload: payload,
-  };
-}
+export const setStationMissionProfile = createAction(
+  SET_STATION_MISSION_PROFILE,
+  (missionProfile: MissionProfile) => ({
+    payload: { missionProfile: missionProfile },
+  }),
+);
 
-export function setStationMissionProfileTalent(talent: SelectedTalent) {
-  const payload = { talent: talent };
-  return {
-    type: SET_STATION_MISSION_PROFILE_TALENT,
-    payload: payload,
-  };
-}
+export const setStationMissionProfileTalent = createAction(
+  SET_STATION_MISSION_PROFILE_TALENT,
+  (talent: SelectedTalent) => ({
+    payload: { talent: talent },
+  }),
+);
 
-export function setStationName(name: string) {
-  const payload = { name: name };
-  return {
-    type: SET_STATION_NAME,
-    payload: payload,
-  };
-}
+export const setStationName = createAction(
+  SET_STATION_NAME,
+  (name: string) => ({
+    payload: { name: name },
+  }),
+);
 
-export function setStationCustomScale(scale: number) {
-  const payload = { scale: scale };
-  return {
-    type: SET_STATION_CUSTOM_SCALE,
-    payload: payload,
-  };
-}
+export const setStationCustomScale = createAction(
+  SET_STATION_CUSTOM_SCALE,
+  (scale: number) => ({
+    payload: { scale: scale },
+  }),
+);
 
-export function setStationTraits(traits: string[]) {
-  const payload = { traits: traits };
-  return {
-    type: SET_STATION_TRAITS,
-    payload: payload,
-  };
-}
+export const setStationTraits = createAction(
+  SET_STATION_TRAITS,
+  (traits: string[]) => ({
+    payload: { traits: traits },
+  }),
+);
 
-export function changeStationCustomFrameSystem(delta: number, system: System) {
-  const payload = { delta: delta, system: system };
-  return {
-    type: MODIFY_STATION_CUSTOM_FRAME_SYSTEM,
-    payload: payload,
-  };
-}
+export const changeStationCustomFrameSystem = createAction(
+  MODIFY_STATION_CUSTOM_FRAME_SYSTEM,
+  (delta: number, system: System) => ({
+    payload: { delta: delta, system: system },
+  }),
+);
 
-export function changeStationCustomFrameDepartment(
-  delta: number,
-  department: Department,
-) {
-  const payload = { delta: delta, department: department };
-  return {
-    type: MODIFY_STATION_CUSTOM_FRAME_DEPARTMENT,
-    payload: payload,
-  };
-}
+export const changeStationCustomFrameDepartment = createAction(
+  MODIFY_STATION_CUSTOM_FRAME_DEPARTMENT,
+  (delta: number, department: Department) => ({
+    payload: { delta: delta, department: department },
+  }),
+);
 
-export function addStationWeapon(weapon: Weapon) {
-  const payload = { weapon: weapon };
-  return {
-    type: ADD_STATION_WEAPON,
-    payload: payload,
-  };
-}
+export const addStationWeapon = createAction(
+  ADD_STATION_WEAPON,
+  (weapon: Weapon) => ({
+    payload: { weapon: weapon },
+  }),
+);
 
-export function deleteStationWeapon(weapon: Weapon) {
-  const payload = { weapon: weapon };
-  return {
-    type: DELETE_STATION_WEAPON,
-    payload: payload,
-  };
-}
+export const deleteStationWeapon = createAction(
+  DELETE_STATION_WEAPON,
+  (weapon: Weapon) => ({
+    payload: { weapon: weapon },
+  }),
+);
 
-export function setStationAdditionalTalents(talents: SelectedTalent[]) {
-  const payload = { talents: talents };
-  return {
-    type: SET_STATION_ADDITIONAL_TALENTS,
-    payload: payload,
-  };
-}
+export const setStationAdditionalTalents = createAction(
+  SET_STATION_ADDITIONAL_TALENTS,
+  (talents: SelectedTalent[]) => ({
+    payload: { talents: talents },
+  }),
+);
 
-export function setStationFrame(frame: StationFrame) {
-  const payload = { frame: frame };
-  return {
-    type: SET_STATION_FRAME,
-    payload: payload,
-  };
-}
+export const setStationFrame = createAction(
+  SET_STATION_FRAME,
+  (frame: StationFrame) => ({
+    payload: { frame: frame },
+  }),
+);
 
-export function setStationFrameAppearance(appearance: StationFrameAppearance) {
-  const payload = { appearance: appearance };
-  return {
-    type: SET_STATION_FRAME_APPEARANCE,
-    payload: payload,
-  };
-}
+export const setStationFrameAppearance = createAction(
+  SET_STATION_FRAME_APPEARANCE,
+  (appearance: StationFrameAppearance) => ({
+    payload: { appearance: appearance },
+  }),
+);

--- a/WebTools/src/state/stationReducer.ts
+++ b/WebTools/src/state/stationReducer.ts
@@ -1,3 +1,4 @@
+import { createSlice } from '@reduxjs/toolkit';
 import type { Station } from '../common/station';
 import {
   CustomStationSpaceframeStep,
@@ -6,19 +7,19 @@ import {
 } from '../common/station';
 import { StationFrame } from '../helpers/stationFrame';
 import {
-  ADD_STATION_WEAPON,
-  CREATE_STATION,
-  DELETE_STATION_WEAPON,
-  MODIFY_STATION_CUSTOM_FRAME_DEPARTMENT,
-  MODIFY_STATION_CUSTOM_FRAME_SYSTEM,
-  SET_STATION_ADDITIONAL_TALENTS,
-  SET_STATION_CUSTOM_SCALE,
-  SET_STATION_FRAME,
-  SET_STATION_FRAME_APPEARANCE,
-  SET_STATION_MISSION_PROFILE,
-  SET_STATION_MISSION_PROFILE_TALENT,
-  SET_STATION_NAME,
-  SET_STATION_TRAITS,
+  addStationWeapon,
+  changeStationCustomFrameDepartment,
+  changeStationCustomFrameSystem,
+  createStation,
+  deleteStationWeapon,
+  setStationAdditionalTalents,
+  setStationCustomScale,
+  setStationFrame,
+  setStationFrameAppearance,
+  setStationMissionProfile,
+  setStationMissionProfileTalent,
+  setStationName,
+  setStationTraits,
 } from './stationActions';
 
 interface StationState {
@@ -26,7 +27,7 @@ interface StationState {
 }
 
 const withStation = (
-  state: StationState,
+  state: any,
   action: any,
   mutate: (s: Station, action: any) => void,
 ): StationState => {
@@ -40,21 +41,21 @@ const withStation = (
   };
 };
 
-export const stationReducer = (
-  state: StationState = { station: undefined },
-  action,
-) => {
-  switch (action.type) {
-    case CREATE_STATION: {
+export const stationSlice = createSlice({
+  name: 'station',
+  initialState: { station: undefined } as StationState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(createStation, (state, action) => {
       const s = action.payload.station;
       console.log('Create a station');
       return {
         ...state,
         station: s.copy(),
       };
-    }
-    case SET_STATION_MISSION_PROFILE:
-      return withStation(state, action, (s, action) => {
+    });
+    builder.addCase(setStationMissionProfile, (state, action) =>
+      withStation(state, action, (s, action) => {
         const original = s.missionProfileStep;
         s.missionProfileStep = new StationMissionProfileStep(
           action.payload.missionProfile,
@@ -62,9 +63,10 @@ export const stationReducer = (
         if (original?.type === s.missionProfileStep?.type) {
           s.missionProfileStep.talent = original?.talent?.copy();
         }
-      });
-    case SET_STATION_MISSION_PROFILE_TALENT:
-      return withStation(state, action, (s, action) => {
+      }),
+    );
+    builder.addCase(setStationMissionProfileTalent, (state, action) =>
+      withStation(state, action, (s, action) => {
         if (s.missionProfileStep) {
           s.missionProfileStep.talent = action.payload.talent;
         }
@@ -78,13 +80,15 @@ export const stationReducer = (
             i++;
           }
         }
-      });
-    case SET_STATION_NAME:
-      return withStation(state, action, (s, action) => {
+      }),
+    );
+    builder.addCase(setStationName, (state, action) =>
+      withStation(state, action, (s, action) => {
         s.name = action.payload.name;
-      });
-    case SET_STATION_CUSTOM_SCALE:
-      return withStation(state, action, (s, action) => {
+      }),
+    );
+    builder.addCase(setStationCustomScale, (state, action) =>
+      withStation(state, action, (s, action) => {
         if (
           s.stationFrameStep == null ||
           !(s.stationFrameStep instanceof CustomStationSpaceframeStep)
@@ -130,9 +134,10 @@ export const stationReducer = (
         ) {
           s.additionalTalents.splice(0, 1);
         }
-      });
-    case MODIFY_STATION_CUSTOM_FRAME_SYSTEM:
-      return withStation(state, action, (s, action) => {
+      }),
+    );
+    builder.addCase(changeStationCustomFrameSystem, (state, action) =>
+      withStation(state, action, (s, action) => {
         if (
           s.stationFrameStep == null ||
           !(s.stationFrameStep instanceof CustomStationSpaceframeStep)
@@ -144,9 +149,10 @@ export const stationReducer = (
         if (s.stationFrameStep.systems[system] > s.maxSystemValue) {
           s.stationFrameStep.systems[system] = s.maxSystemValue;
         }
-      });
-    case MODIFY_STATION_CUSTOM_FRAME_DEPARTMENT:
-      return withStation(state, action, (s, action) => {
+      }),
+    );
+    builder.addCase(changeStationCustomFrameDepartment, (state, action) =>
+      withStation(state, action, (s, action) => {
         if (
           s.stationFrameStep == null ||
           !(s.stationFrameStep instanceof CustomStationSpaceframeStep)
@@ -158,38 +164,41 @@ export const stationReducer = (
         if (s.stationFrameStep.departments[department] > s.maxDepartmentValue) {
           s.stationFrameStep.departments[department] = s.maxDepartmentValue;
         }
-      });
-    case ADD_STATION_WEAPON:
-      return withStation(state, action, (s, action) => {
+      }),
+    );
+    builder.addCase(addStationWeapon, (state, action) =>
+      withStation(state, action, (s, action) => {
         s.weapons.push(action.payload.weapon);
-      });
-    case DELETE_STATION_WEAPON:
-      return withStation(state, action, (s, action) => {
+      }),
+    );
+    builder.addCase(deleteStationWeapon, (state, action) =>
+      withStation(state, action, (s, action) => {
         if (s.weapons.indexOf(action.payload.weapon) >= 0) {
           s.weapons.splice(s.weapons.indexOf(action.payload.weapon), 1);
         }
-      });
-
-    case SET_STATION_ADDITIONAL_TALENTS:
-      return withStation(state, action, (s, action) => {
+      }),
+    );
+    builder.addCase(setStationAdditionalTalents, (state, action) =>
+      withStation(state, action, (s, action) => {
         s.additionalTalents =
           action.payload.talents?.map((t) => t.copy()) ?? [];
-      });
-
-    case SET_STATION_TRAITS:
-      return withStation(state, action, (s, action) => {
+      }),
+    );
+    builder.addCase(setStationTraits, (state, action) =>
+      withStation(state, action, (s, action) => {
         s.traits = action.payload.traits;
-      });
-
-    case SET_STATION_FRAME_APPEARANCE:
-      return withStation(state, action, (s, action) => {
+      }),
+    );
+    builder.addCase(setStationFrameAppearance, (state, action) =>
+      withStation(state, action, (s, action) => {
         if (s?.stationFrameStep?.type === StationFrame.Custom) {
           (s.stationFrameStep as CustomStationSpaceframeStep).appearance =
             action.payload.appearance;
         }
-      });
-    case SET_STATION_FRAME:
-      return withStation(state, action, (s, action) => {
+      }),
+    );
+    builder.addCase(setStationFrame, (state, action) =>
+      withStation(state, action, (s, action) => {
         if (action.payload.frame === StationFrame.Custom) {
           const scale = s.scale;
           s.stationFrameStep = CustomStationSpaceframeStep.create(scale);
@@ -224,9 +233,9 @@ export const stationReducer = (
         ) {
           s.additionalTalents.splice(0, 1);
         }
-      });
+      }),
+    );
+  },
+});
 
-    default:
-      return state;
-  }
-};
+export const stationReducer = stationSlice.reducer;

--- a/WebTools/src/state/tableActions.ts
+++ b/WebTools/src/state/tableActions.ts
@@ -1,3 +1,4 @@
+import { createAction } from '@reduxjs/toolkit';
 import type { TableCollection } from '../table/model/table';
 
 export const IMPORT_TABLE_COLLECTION = 'IMPORT_TABLE_COLLECTION';
@@ -7,56 +8,47 @@ export const SET_TABLE_FOR_EDITING = 'SET_TABLE_FOR_EDITING';
 export const REPLACE_TABLE_COLLECTION = 'REPLACE_TABLE_COLLECTION';
 export const DELETE_TABLE_COLLECTION = 'DELETE_TABLE_COLLECTION';
 
-export function setTableCollectionSelection(selection: TableCollection) {
-  const payload = { selection: selection };
-  return {
-    type: SET_TABLE_COLLECTION_SELECTION,
-    payload: payload,
-  };
-}
+export const setTableCollectionSelection = createAction(
+  SET_TABLE_COLLECTION_SELECTION,
+  (selection: TableCollection) => ({
+    payload: { selection: selection },
+  }),
+);
 
-export function importTableCollection(collection: TableCollection) {
-  const payload = { collection: collection };
-  return {
-    type: IMPORT_TABLE_COLLECTION,
-    payload: payload,
-  };
-}
+export const importTableCollection = createAction(
+  IMPORT_TABLE_COLLECTION,
+  (collection: TableCollection) => ({
+    payload: { collection: collection },
+  }),
+);
 
-export function setTableForEditing(collection: TableCollection) {
-  const payload = { collection: collection };
-  return {
-    type: SET_TABLE_FOR_EDITING,
-    payload: payload,
-  };
-}
+export const setTableForEditing = createAction(
+  SET_TABLE_FOR_EDITING,
+  (collection: TableCollection) => ({
+    payload: { collection: collection },
+  }),
+);
 
-export function addTableCollection(collection: TableCollection) {
-  const payload = { collection: collection };
-  return {
-    type: ADD_TABLE_COLLECTION,
-    payload: payload,
-  };
-}
+export const addTableCollection = createAction(
+  ADD_TABLE_COLLECTION,
+  (collection: TableCollection) => ({
+    payload: { collection: collection },
+  }),
+);
 
-export function deleteTableCollection(collection: TableCollection) {
-  const payload = { collection: collection };
-  return {
-    type: DELETE_TABLE_COLLECTION,
-    payload: payload,
-  };
-}
+export const deleteTableCollection = createAction(
+  DELETE_TABLE_COLLECTION,
+  (collection: TableCollection) => ({
+    payload: { collection: collection },
+  }),
+);
 
-export function replaceTableCollection(
-  uuid: string,
-  collection: TableCollection,
-) {
-  const payload = {
-    uuid: uuid,
-    collection: collection,
-  };
-  return {
-    type: REPLACE_TABLE_COLLECTION,
-    payload: payload,
-  };
-}
+export const replaceTableCollection = createAction(
+  REPLACE_TABLE_COLLECTION,
+  (uuid: string, collection: TableCollection) => ({
+    payload: {
+      uuid: uuid,
+      collection: collection,
+    },
+  }),
+);

--- a/WebTools/src/state/tableReducer.ts
+++ b/WebTools/src/state/tableReducer.ts
@@ -1,3 +1,4 @@
+import { createSlice } from '@reduxjs/toolkit';
 import {
   Table,
   TableCollection,
@@ -6,12 +7,12 @@ import {
 } from '../table/model/table';
 import { TableMarshaller } from '../table/model/tableMarshaller';
 import {
-  ADD_TABLE_COLLECTION,
-  DELETE_TABLE_COLLECTION,
-  IMPORT_TABLE_COLLECTION,
-  REPLACE_TABLE_COLLECTION,
-  SET_TABLE_COLLECTION_SELECTION,
-  SET_TABLE_FOR_EDITING,
+  addTableCollection,
+  deleteTableCollection,
+  importTableCollection,
+  replaceTableCollection,
+  setTableCollectionSelection,
+  setTableForEditing,
 } from './tableActions';
 
 const tableCollection = new TableCollection(
@@ -324,14 +325,16 @@ const persistTables = (tables: TableCollection[]) => {
   window.localStorage.setItem('settings.tableData', JSON.stringify(data));
 };
 
-let initialData: {
+interface TableState {
   selection: TableCollection;
   collections: TableCollection[];
   editing?: TableCollection;
-} = null;
+}
 
-const getInitialData = () => {
-  const base = {
+let initialData: TableState = null;
+
+const getInitialData = (): TableState => {
+  const base: TableState = {
     selection: null,
     collections: [tableCollection, tableCollection2],
   };
@@ -359,25 +362,34 @@ const getInitialData = () => {
   return initialData;
 };
 
-export const tableReducer = (state = getInitialData(), action) => {
-  switch (action.type) {
-    case IMPORT_TABLE_COLLECTION:
-    case ADD_TABLE_COLLECTION: {
-      const collections = [...state.collections];
-      const collection = action.payload.collection;
-      collections.push(collection);
-      persistTables(collections);
-      return {
-        ...state,
-        collections: collections,
-      };
-    }
-    case SET_TABLE_COLLECTION_SELECTION: {
+const appendCollection = (
+  state: TableState,
+  action: { payload: { collection: TableCollection } },
+): TableState => {
+  const collections = [...state.collections];
+  const collection = action.payload.collection;
+  collections.push(collection);
+  persistTables(collections);
+  return {
+    ...state,
+    collections: collections,
+  };
+};
+
+export const tableSlice = createSlice({
+  name: 'table',
+  initialState: getInitialData,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(importTableCollection, appendCollection)
+      .addCase(addTableCollection, appendCollection);
+    builder.addCase(setTableCollectionSelection, (state, action) => {
       const temp = { ...state };
       temp.selection = action.payload.selection;
       return temp;
-    }
-    case DELETE_TABLE_COLLECTION: {
+    });
+    builder.addCase(deleteTableCollection, (state, action) => {
       const temp = { ...state };
       const tableCollection = action.payload.collection;
       temp.collections = temp.collections.filter(
@@ -385,13 +397,13 @@ export const tableReducer = (state = getInitialData(), action) => {
       );
       persistTables(temp.collections);
       return temp;
-    }
-    case SET_TABLE_FOR_EDITING: {
+    });
+    builder.addCase(setTableForEditing, (state, action) => {
       const temp = { ...state };
       temp.editing = action.payload.collection;
       return temp;
-    }
-    case REPLACE_TABLE_COLLECTION: {
+    });
+    builder.addCase(replaceTableCollection, (state, action) => {
       const temp = { ...state };
       const tableCollection = action.payload.collection;
       temp.collections = temp.collections.filter(
@@ -399,8 +411,8 @@ export const tableReducer = (state = getInitialData(), action) => {
       );
       temp.collections.push(tableCollection);
       return temp;
-    }
-    default:
-      return state;
-  }
-};
+    });
+  },
+});
+
+export const tableReducer = tableSlice.reducer;

--- a/WebTools/src/state/tokenActions.ts
+++ b/WebTools/src/state/tokenActions.ts
@@ -1,3 +1,4 @@
+import { createAction } from '@reduxjs/toolkit';
 import { cyrb53 } from '../common/cyrb53';
 import type { Rank } from '../helpers/ranks';
 import type { Species } from '../helpers/speciesEnum';
@@ -40,201 +41,178 @@ export const CREATE_NEW_TOKEN = 'CREATE_NEW_TOKEN';
 export const SET_TOKEN_ROUNDED = 'SET_TOKEN_ROUNDED';
 export const SET_TOKEN_BORDERED = 'SET_TOKEN_BORDERED';
 
-export function createNewToken(
-  token?: TokenModel,
-  marshalledCharacter?: string,
-  characterName?: string,
-  rounded: boolean = false,
-  bordered: boolean = false,
-) {
-  const hash = marshalledCharacter?.length
-    ? cyrb53(marshalledCharacter)
-    : undefined;
-  const payload = {
-    token: token,
-    marshalledCharacter: marshalledCharacter,
-    characterName: characterName,
-    hash: hash,
-    rounded: rounded,
-    bordered: bordered,
-  };
-  return {
-    type: CREATE_NEW_TOKEN,
-    payload: payload,
-  };
-}
+export const createNewToken = createAction(
+  CREATE_NEW_TOKEN,
+  (
+    token?: TokenModel,
+    marshalledCharacter?: string,
+    characterName?: string,
+    rounded: boolean = false,
+    bordered: boolean = false,
+  ) => {
+    const hash = marshalledCharacter?.length
+      ? cyrb53(marshalledCharacter)
+      : undefined;
+    return {
+      payload: {
+        token: token,
+        marshalledCharacter: marshalledCharacter,
+        characterName: characterName,
+        hash: hash,
+        rounded: rounded,
+        bordered: bordered,
+      },
+    };
+  },
+);
 
-export function setTokenSpecies(species: Species) {
-  const payload = { species: species };
-  return {
-    type: SET_TOKEN_SPECIES,
-    payload: payload,
-  };
-}
+export const setTokenSpecies = createAction(
+  SET_TOKEN_SPECIES,
+  (species: Species) => ({
+    payload: { species: species },
+  }),
+);
 
-export function setTokenSecondarySpecies(species: Species) {
-  const payload = { species: species };
-  return {
-    type: SET_TOKEN_SECONDARY_SPECIES,
-    payload: payload,
-  };
-}
+export const setTokenSecondarySpecies = createAction(
+  SET_TOKEN_SECONDARY_SPECIES,
+  (species: Species) => ({
+    payload: { species: species },
+  }),
+);
 
-export function setUniformEra(era: UniformEra) {
-  const payload = { era: era };
-  return {
-    type: SET_TOKEN_UNIFORM_ERA,
-    payload: payload,
-  };
-}
+export const setUniformEra = createAction(
+  SET_TOKEN_UNIFORM_ERA,
+  (era: UniformEra) => ({
+    payload: { era: era },
+  }),
+);
 
-export function setTokenDivisionColor(color: string) {
-  const payload = { color: color };
-  return {
-    type: SET_TOKEN_DIVISION_COLOR,
-    payload: payload,
-  };
-}
+export const setTokenDivisionColor = createAction(
+  SET_TOKEN_DIVISION_COLOR,
+  (color: string) => ({
+    payload: { color: color },
+  }),
+);
 
-export function setTokenRank(rank: Rank) {
-  const payload = { rank: rank };
-  return {
-    type: SET_TOKEN_RANK,
-    payload: payload,
-  };
-}
+export const setTokenRank = createAction(SET_TOKEN_RANK, (rank: Rank) => ({
+  payload: { rank: rank },
+}));
 
-export function setTokenSkinColor(color: string) {
-  const payload = { color: color };
-  return {
-    type: SET_TOKEN_SKIN_COLOR,
-    payload: payload,
-  };
-}
+export const setTokenSkinColor = createAction(
+  SET_TOKEN_SKIN_COLOR,
+  (color: string) => ({
+    payload: { color: color },
+  }),
+);
 
-export function setTokenEyeColor(color: string) {
-  const payload = { color: color };
-  return {
-    type: SET_TOKEN_EYE_COLOR,
-    payload: payload,
-  };
-}
+export const setTokenEyeColor = createAction(
+  SET_TOKEN_EYE_COLOR,
+  (color: string) => ({
+    payload: { color: color },
+  }),
+);
 
-export function setTokenHairColor(color: string) {
-  const payload = { color: color };
-  return {
-    type: SET_TOKEN_HAIR_COLOR,
-    payload: payload,
-  };
-}
+export const setTokenHairColor = createAction(
+  SET_TOKEN_HAIR_COLOR,
+  (color: string) => ({
+    payload: { color: color },
+  }),
+);
 
-export function setTokenLipstickColor(color: string) {
-  const payload = { color: color };
-  return {
-    type: SET_TOKEN_LIPSTICK_COLOR,
-    payload: payload,
-  };
-}
+export const setTokenLipstickColor = createAction(
+  SET_TOKEN_LIPSTICK_COLOR,
+  (color: string) => ({
+    payload: { color: color },
+  }),
+);
 
-export function setTokenHairType(hairType: HairType) {
-  const payload = { hairType: hairType };
-  return {
-    type: SET_TOKEN_HAIR_TYPE,
-    payload: payload,
-  };
-}
+export const setTokenHairType = createAction(
+  SET_TOKEN_HAIR_TYPE,
+  (hairType: HairType) => ({
+    payload: { hairType: hairType },
+  }),
+);
 
-export function setTokenHeadType(headType: HeadType) {
-  const payload = { headType: headType };
-  return {
-    type: SET_TOKEN_HEAD_TYPE,
-    payload: payload,
-  };
-}
+export const setTokenHeadType = createAction(
+  SET_TOKEN_HEAD_TYPE,
+  (headType: HeadType) => ({
+    payload: { headType: headType },
+  }),
+);
 
-export function setTokenMouthType(mouthType: MouthType) {
-  const payload = { mouthType: mouthType };
-  return {
-    type: SET_TOKEN_MOUTH_TYPE,
-    payload: payload,
-  };
-}
+export const setTokenMouthType = createAction(
+  SET_TOKEN_MOUTH_TYPE,
+  (mouthType: MouthType) => ({
+    payload: { mouthType: mouthType },
+  }),
+);
 
-export function setTokenEyeType(eyeType: EyeType) {
-  const payload = { eyeType: eyeType };
-  return {
-    type: SET_TOKEN_EYE_TYPE,
-    payload: payload,
-  };
-}
+export const setTokenEyeType = createAction(
+  SET_TOKEN_EYE_TYPE,
+  (eyeType: EyeType) => ({
+    payload: { eyeType: eyeType },
+  }),
+);
 
-export function setTokenNoseType(noseType: NoseType) {
-  const payload = { noseType: noseType };
-  return {
-    type: SET_TOKEN_NOSE_TYPE,
-    payload: payload,
-  };
-}
+export const setTokenNoseType = createAction(
+  SET_TOKEN_NOSE_TYPE,
+  (noseType: NoseType) => ({
+    payload: { noseType: noseType },
+  }),
+);
 
-export function setTokenBodyType(type: BodyType) {
-  const payload = { type: type };
-  return {
-    type: SET_TOKEN_BODY_TYPE,
-    payload: payload,
-  };
-}
+export const setTokenBodyType = createAction(
+  SET_TOKEN_BODY_TYPE,
+  (type: BodyType) => ({
+    payload: { type: type },
+  }),
+);
 
-export function setTokenUniformVariantType(type: UniformVariantType) {
-  const payload = { type: type };
-  return {
-    type: SET_TOKEN_UNIFORM_VARIANT_TYPE,
-    payload: payload,
-  };
-}
+export const setTokenUniformVariantType = createAction(
+  SET_TOKEN_UNIFORM_VARIANT_TYPE,
+  (type: UniformVariantType) => ({
+    payload: { type: type },
+  }),
+);
 
-export function setTokenFacialHairTypes(types: FacialHairType[]) {
-  const payload = { types: types };
-  return {
-    type: SET_TOKEN_FACIAL_HAIR_TYPE,
-    payload: payload,
-  };
-}
+export const setTokenFacialHairTypes = createAction(
+  SET_TOKEN_FACIAL_HAIR_TYPE,
+  (types: FacialHairType[]) => ({
+    payload: { types: types },
+  }),
+);
 
-export function setTokenExtrasTypes(types: ExtraType[]) {
-  const payload = { types: types };
-  return {
-    type: SET_TOKEN_EXTRAS_TYPE,
-    payload: payload,
-  };
-}
+export const setTokenExtrasTypes = createAction(
+  SET_TOKEN_EXTRAS_TYPE,
+  (types: ExtraType[]) => ({
+    payload: { types: types },
+  }),
+);
 
-export function setTokenNasoLabialFoldType(type: NasoLabialFoldType) {
-  const payload = { type: type };
-  return {
-    type: SET_TOKEN_NASO_LABIAL_FOLD_TYPE,
-    payload: payload,
-  };
-}
+export const setTokenNasoLabialFoldType = createAction(
+  SET_TOKEN_NASO_LABIAL_FOLD_TYPE,
+  (type: NasoLabialFoldType) => ({
+    payload: { type: type },
+  }),
+);
 
-export function setTokenSpeciesOption(option: SpeciesOption) {
-  const payload = { option: option };
-  return {
-    type: SET_TOKEN_SPECIES_OPTION,
-    payload: payload,
-  };
-}
+export const setTokenSpeciesOption = createAction(
+  SET_TOKEN_SPECIES_OPTION,
+  (option: SpeciesOption) => ({
+    payload: { option: option },
+  }),
+);
 
-export function setTokenRounded(rounded: boolean) {
-  const payload = { rounded: rounded };
-  return {
-    type: SET_TOKEN_ROUNDED,
-    payload: payload,
-  };
-}
-export function setTokenBordered(bordered: boolean) {
-  const payload = { bordered: bordered };
-  return {
-    type: SET_TOKEN_BORDERED,
-    payload: payload,
-  };
-}
+export const setTokenRounded = createAction(
+  SET_TOKEN_ROUNDED,
+  (rounded: boolean) => ({
+    payload: { rounded: rounded },
+  }),
+);
+
+export const setTokenBordered = createAction(
+  SET_TOKEN_BORDERED,
+  (bordered: boolean) => ({
+    payload: { bordered: bordered },
+  }),
+);

--- a/WebTools/src/state/tokenReducer.ts
+++ b/WebTools/src/state/tokenReducer.ts
@@ -1,3 +1,4 @@
+import { createSlice } from '@reduxjs/toolkit';
 import { Rank } from '../helpers/ranks';
 import { Species } from '../helpers/speciesEnum';
 import { BodyType } from '../token/model/bodyTypeEnum';
@@ -15,29 +16,30 @@ import { UniformEra } from '../token/model/uniformEra';
 import { UniformVariantRestrictions } from '../token/model/uniformVariantRestrictions';
 import { UniformVariantType } from '../token/model/uniformVariantTypeEnum';
 import {
-  CREATE_NEW_TOKEN,
-  SET_TOKEN_BODY_TYPE,
-  SET_TOKEN_BORDERED,
-  SET_TOKEN_DIVISION_COLOR,
-  SET_TOKEN_EXTRAS_TYPE,
-  SET_TOKEN_EYE_COLOR,
-  SET_TOKEN_EYE_TYPE,
-  SET_TOKEN_FACIAL_HAIR_TYPE,
-  SET_TOKEN_HAIR_COLOR,
-  SET_TOKEN_HAIR_TYPE,
-  SET_TOKEN_HEAD_TYPE,
-  SET_TOKEN_LIPSTICK_COLOR,
-  SET_TOKEN_MOUTH_TYPE,
-  SET_TOKEN_NASO_LABIAL_FOLD_TYPE,
-  SET_TOKEN_NOSE_TYPE,
-  SET_TOKEN_RANK,
-  SET_TOKEN_ROUNDED,
+  createNewToken,
+  setTokenBordered,
+  setTokenBodyType,
+  setTokenDivisionColor,
+  setTokenExtrasTypes,
+  setTokenEyeColor,
+  setTokenEyeType,
+  setTokenFacialHairTypes,
+  setTokenHairColor,
+  setTokenHairType,
+  setTokenHeadType,
+  setTokenLipstickColor,
+  setTokenMouthType,
+  setTokenNasoLabialFoldType,
+  setTokenNoseType,
+  setTokenRank,
+  setTokenRounded,
+  setTokenSecondarySpecies,
+  setTokenSkinColor,
+  setTokenSpecies,
+  setTokenSpeciesOption,
+  setTokenUniformVariantType,
+  setUniformEra,
   SET_TOKEN_SECONDARY_SPECIES,
-  SET_TOKEN_SKIN_COLOR,
-  SET_TOKEN_SPECIES,
-  SET_TOKEN_SPECIES_OPTION,
-  SET_TOKEN_UNIFORM_ERA,
-  SET_TOKEN_UNIFORM_VARIANT_TYPE,
 } from './tokenActions';
 
 const initialState = {
@@ -71,155 +73,156 @@ interface TokenState {
   bordered?: boolean;
 }
 
-export const token = (state: TokenState = { token: initialState }, action) => {
-  switch (action.type) {
-    case SET_TOKEN_SECONDARY_SPECIES:
-    case SET_TOKEN_SPECIES: {
-      const token = state.token;
-      let newSpecies = action.payload.species;
-      let skinColor = token.skinColor;
-      const palette = SpeciesRestrictions.getSkinColors(newSpecies);
-      if (palette.indexOf(skinColor) < 0) {
-        skinColor = palette[Math.floor(palette.length / 2)];
-      }
-      let hairColour = token.hairColor;
-      const hairColours = SpeciesRestrictions.getHairColors(newSpecies);
-      if (hairColours.indexOf(hairColour) < 0) {
-        hairColour = hairColours[0];
-      }
+const handleSpeciesChange = (
+  state: TokenState,
+  action: { type: string; payload: any },
+): TokenState => {
+  const token = state.token as Token;
+  let newSpecies = action.payload.species;
+  let skinColor = token.skinColor;
+  const palette = SpeciesRestrictions.getSkinColors(newSpecies);
+  if (palette.indexOf(skinColor) < 0) {
+    skinColor = palette[Math.floor(palette.length / 2)];
+  }
+  let hairColour = token.hairColor;
+  const hairColours = SpeciesRestrictions.getHairColors(newSpecies);
+  if (hairColours.indexOf(hairColour) < 0) {
+    hairColour = hairColours[0];
+  }
 
-      let hairType = token.hairType;
-      const hairTypes = SpeciesRestrictions.getHairTypes(newSpecies);
-      if (hairTypes.indexOf(hairType) < 0) {
-        hairType = SpeciesRestrictions.getDefaultHairType(newSpecies);
-      }
+  let hairType = token.hairType;
+  const hairTypes = SpeciesRestrictions.getHairTypes(newSpecies);
+  if (hairTypes.indexOf(hairType) < 0) {
+    hairType = SpeciesRestrictions.getDefaultHairType(newSpecies);
+  }
 
-      let noseType = token.noseType;
-      const noseTypes = SpeciesRestrictions.getNoseTypes(newSpecies);
-      if (noseTypes.indexOf(noseType) < 0) {
-        noseType = noseTypes[0];
-      }
+  let noseType = token.noseType;
+  const noseTypes = SpeciesRestrictions.getNoseTypes(newSpecies);
+  if (noseTypes.indexOf(noseType) < 0) {
+    noseType = noseTypes[0];
+  }
 
-      let headType = token.headType;
-      const headTypes = SpeciesRestrictions.getHeadTypes(newSpecies);
-      if (headTypes.indexOf(headType) < 0) {
-        headType = headTypes[0];
-      }
+  let headType = token.headType;
+  const headTypes = SpeciesRestrictions.getHeadTypes(newSpecies);
+  if (headTypes.indexOf(headType) < 0) {
+    headType = headTypes[0];
+  }
 
-      let mouthType = token.mouthType;
-      const mouthTypes = SpeciesRestrictions.getMouthTypes(newSpecies);
-      if (mouthTypes.indexOf(mouthType) < 0) {
-        mouthType = mouthTypes[0];
-      }
+  let mouthType = token.mouthType;
+  const mouthTypes = SpeciesRestrictions.getMouthTypes(newSpecies);
+  if (mouthTypes.indexOf(mouthType) < 0) {
+    mouthType = mouthTypes[0];
+  }
 
-      let facialHairType = token.facialHairType;
-      if (!SpeciesRestrictions.isFacialHairSupportedFor(newSpecies)) {
-        facialHairType = [];
-      }
+  let facialHairType = token.facialHairType;
+  if (!SpeciesRestrictions.isFacialHairSupportedFor(newSpecies)) {
+    facialHairType = [];
+  }
 
-      let eyeColor = token.eyeColor;
-      const speciesEyeColours = SpeciesRestrictions.getEyeColors(
-        action.payload.species,
-      );
-      if (speciesEyeColours.indexOf(eyeColor) < 0) {
-        eyeColor = speciesEyeColours[Math.floor(speciesEyeColours.length / 2)];
-      }
-      let option = token.speciesOption;
-      const options = SpeciesRestrictions.getSpeciesOptions(newSpecies);
-      if (options.indexOf(option) < 0) {
-        option = SpeciesOption.Option1;
-      }
-      const extras = token.extras.filter((e) =>
-        action.type === SET_TOKEN_SECONDARY_SPECIES
-          ? SpeciesRestrictions.isExtraAvailableFor(
-              e,
-              Species.LiberatedBorg,
-              newSpecies,
-              token.uniformEra,
-            )
-          : SpeciesRestrictions.isExtraAvailableFor(
-              e,
-              newSpecies,
-              token.secondarySpecies,
-              token.uniformEra,
-            ),
-      );
+  let eyeColor = token.eyeColor;
+  const speciesEyeColours = SpeciesRestrictions.getEyeColors(
+    action.payload.species,
+  );
+  if (speciesEyeColours.indexOf(eyeColor) < 0) {
+    eyeColor = speciesEyeColours[Math.floor(speciesEyeColours.length / 2)];
+  }
+  let option = token.speciesOption;
+  const options = SpeciesRestrictions.getSpeciesOptions(newSpecies);
+  if (options.indexOf(option) < 0) {
+    option = SpeciesOption.Option1;
+  }
+  const extras = token.extras.filter((e) =>
+    action.type === SET_TOKEN_SECONDARY_SPECIES
+      ? SpeciesRestrictions.isExtraAvailableFor(
+          e,
+          Species.LiberatedBorg,
+          newSpecies,
+          token.uniformEra,
+        )
+      : SpeciesRestrictions.isExtraAvailableFor(
+          e,
+          newSpecies,
+          token.secondarySpecies,
+          token.uniformEra,
+        ),
+  );
 
-      let uniformEra = token.uniformEra;
-      let colour = token.divisionColor;
-      let rank = token.rankIndicator;
-      const uniforms = SpeciesRestrictions.getUniformTypes(newSpecies);
-      if (uniforms.indexOf(uniformEra) < 0) {
-        uniformEra = uniforms[0];
+  let uniformEra = token.uniformEra;
+  let colour = token.divisionColor;
+  let rank = token.rankIndicator;
+  const uniforms = SpeciesRestrictions.getUniformTypes(newSpecies);
+  if (uniforms.indexOf(uniformEra) < 0) {
+    uniformEra = uniforms[0];
 
-        const newColourOptions = DivisionColors.getColors(
-          action.payload.era,
-          rank,
-        );
-        const index = DivisionColors.indexOf(token.uniformEra, colour);
-        if (index >= 0 && index < newColourOptions.length) {
-          colour = newColourOptions[index].color;
-        } else {
-          colour = newColourOptions[0].color;
-        }
-        if (
-          !UniformVariantRestrictions.isRankSupported(rank, action.payload.era)
-        ) {
-          rank = Rank.None;
-        }
-      }
-
-      let variant = token.variant;
-      const variants = UniformVariantRestrictions.getAvailableVariants(
-        uniformEra,
-        token.bodyType,
-        newSpecies,
-        token.divisionColor,
-        token.rankIndicator,
-      );
-      if (variants.indexOf(variant) < 0) {
-        variant = UniformVariantType.Base;
-      }
-
-      let secondarySpecies = token.secondarySpecies;
-      if (action.type === SET_TOKEN_SECONDARY_SPECIES) {
-        secondarySpecies = newSpecies;
-        if (secondarySpecies == null) {
-          secondarySpecies = Species.Human;
-        }
-        newSpecies = token.species;
-      } else if (
-        newSpecies === Species.LiberatedBorg &&
-        secondarySpecies == null
-      ) {
-        secondarySpecies = Species.Human;
-      }
-
-      return {
-        ...state,
-        token: {
-          ...token,
-          eyeColor: eyeColor,
-          hairType: hairType,
-          hairColor: hairColour,
-          headType: headType,
-          noseType: noseType,
-          mouthType: mouthType,
-          skinColor: skinColor,
-          facialHairType: facialHairType,
-          species: newSpecies,
-          secondarySpecies: secondarySpecies,
-          speciesOption: option,
-          extras: extras,
-          uniformEra: uniformEra,
-          rankIndicator: rank,
-          divisionColor: colour,
-          variant: variant,
-        },
-      };
+    const newColourOptions = DivisionColors.getColors(action.payload.era, rank);
+    const index = DivisionColors.indexOf(token.uniformEra, colour);
+    if (index >= 0 && index < newColourOptions.length) {
+      colour = newColourOptions[index].color;
+    } else {
+      colour = newColourOptions[0].color;
     }
-    case SET_TOKEN_UNIFORM_ERA: {
-      const token = state.token;
+    if (!UniformVariantRestrictions.isRankSupported(rank, action.payload.era)) {
+      rank = Rank.None;
+    }
+  }
+
+  let variant = token.variant;
+  const variants = UniformVariantRestrictions.getAvailableVariants(
+    uniformEra,
+    token.bodyType,
+    newSpecies,
+    token.divisionColor,
+    token.rankIndicator,
+  );
+  if (variants.indexOf(variant) < 0) {
+    variant = UniformVariantType.Base;
+  }
+
+  let secondarySpecies = token.secondarySpecies;
+  if (action.type === SET_TOKEN_SECONDARY_SPECIES) {
+    secondarySpecies = newSpecies;
+    if (secondarySpecies == null) {
+      secondarySpecies = Species.Human;
+    }
+    newSpecies = token.species;
+  } else if (newSpecies === Species.LiberatedBorg && secondarySpecies == null) {
+    secondarySpecies = Species.Human;
+  }
+
+  return {
+    ...state,
+    token: {
+      ...token,
+      eyeColor: eyeColor,
+      hairType: hairType,
+      hairColor: hairColour,
+      headType: headType,
+      noseType: noseType,
+      mouthType: mouthType,
+      skinColor: skinColor,
+      facialHairType: facialHairType,
+      species: newSpecies,
+      secondarySpecies: secondarySpecies,
+      speciesOption: option,
+      extras: extras,
+      uniformEra: uniformEra,
+      rankIndicator: rank,
+      divisionColor: colour,
+      variant: variant,
+    },
+  };
+};
+
+export const tokenSlice = createSlice({
+  name: 'token',
+  initialState: { token: initialState } as TokenState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(setTokenSpecies, handleSpeciesChange)
+      .addCase(setTokenSecondarySpecies, handleSpeciesChange);
+    builder.addCase(setUniformEra, (state, action) => {
+      const token = state.token as Token;
       let colour = token.divisionColor;
       const newColourOptions = DivisionColors.getColors(
         action.payload.era,
@@ -279,9 +282,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           extras: extras,
         },
       };
-    }
-    case SET_TOKEN_DIVISION_COLOR: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenDivisionColor, (state, action) => {
+      const token = state.token as Token;
       let variant = token.variant;
       const variants = UniformVariantRestrictions.getAvailableVariants(
         token.uniformEra,
@@ -302,9 +305,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           variant: variant,
         },
       };
-    }
-    case SET_TOKEN_RANK: {
-      const token = { ...state.token };
+    });
+    builder.addCase(setTokenRank, (state, action) => {
+      const token = { ...(state.token as Token) };
       const variant = token.variant;
       const variants = UniformVariantRestrictions.getAvailableVariants(
         token.uniformEra,
@@ -332,9 +335,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
         ...state,
         token: token,
       };
-    }
-    case SET_TOKEN_HAIR_TYPE: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenHairType, (state, action) => {
+      const token = state.token as Token;
       return {
         ...state,
         token: {
@@ -342,9 +345,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           hairType: action.payload.hairType,
         },
       };
-    }
-    case SET_TOKEN_HEAD_TYPE: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenHeadType, (state, action) => {
+      const token = state.token as Token;
       return {
         ...state,
         token: {
@@ -352,9 +355,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           headType: action.payload.headType,
         },
       };
-    }
-    case SET_TOKEN_NOSE_TYPE: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenNoseType, (state, action) => {
+      const token = state.token as Token;
       return {
         ...state,
         token: {
@@ -362,9 +365,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           noseType: action.payload.noseType,
         },
       };
-    }
-    case SET_TOKEN_NASO_LABIAL_FOLD_TYPE: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenNasoLabialFoldType, (state, action) => {
+      const token = state.token as Token;
       return {
         ...state,
         token: {
@@ -372,9 +375,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           nasoLabialFold: action.payload.type,
         },
       };
-    }
-    case SET_TOKEN_BODY_TYPE: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenBodyType, (state, action) => {
+      const token = state.token as Token;
       let variant = token.variant;
       const variants = UniformVariantRestrictions.getAvailableVariants(
         token.uniformEra,
@@ -394,9 +397,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           variant: variant,
         },
       };
-    }
-    case SET_TOKEN_UNIFORM_VARIANT_TYPE: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenUniformVariantType, (state, action) => {
+      const token = state.token as Token;
       return {
         ...state,
         token: {
@@ -404,9 +407,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           variant: action.payload.type,
         },
       };
-    }
-    case SET_TOKEN_EYE_TYPE: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenEyeType, (state, action) => {
+      const token = state.token as Token;
       return {
         ...state,
         token: {
@@ -414,9 +417,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           eyeType: action.payload.eyeType,
         },
       };
-    }
-    case SET_TOKEN_MOUTH_TYPE: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenMouthType, (state, action) => {
+      const token = state.token as Token;
       return {
         ...state,
         token: {
@@ -424,9 +427,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           mouthType: action.payload.mouthType,
         },
       };
-    }
-    case SET_TOKEN_FACIAL_HAIR_TYPE: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenFacialHairTypes, (state, action) => {
+      const token = state.token as Token;
       return {
         ...state,
         token: {
@@ -434,9 +437,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           facialHairType: action.payload.types,
         },
       };
-    }
-    case SET_TOKEN_EXTRAS_TYPE: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenExtrasTypes, (state, action) => {
+      const token = state.token as Token;
       return {
         ...state,
         token: {
@@ -444,9 +447,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           extras: action.payload.types,
         },
       };
-    }
-    case SET_TOKEN_EYE_COLOR: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenEyeColor, (state, action) => {
+      const token = state.token as Token;
       return {
         ...state,
         token: {
@@ -454,9 +457,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           eyeColor: action.payload.color,
         },
       };
-    }
-    case SET_TOKEN_HAIR_COLOR: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenHairColor, (state, action) => {
+      const token = state.token as Token;
       return {
         ...state,
         token: {
@@ -464,9 +467,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           hairColor: action.payload.color,
         },
       };
-    }
-    case SET_TOKEN_LIPSTICK_COLOR: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenLipstickColor, (state, action) => {
+      const token = state.token as Token;
       return {
         ...state,
         token: {
@@ -474,9 +477,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           lipstickColor: action.payload.color,
         },
       };
-    }
-    case SET_TOKEN_SKIN_COLOR: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenSkinColor, (state, action) => {
+      const token = state.token as Token;
       return {
         ...state,
         token: {
@@ -484,9 +487,9 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           skinColor: action.payload.color,
         },
       };
-    }
-    case SET_TOKEN_SPECIES_OPTION: {
-      const token = state.token;
+    });
+    builder.addCase(setTokenSpeciesOption, (state, action) => {
+      const token = state.token as Token;
       return {
         ...state,
         token: {
@@ -494,8 +497,8 @@ export const token = (state: TokenState = { token: initialState }, action) => {
           speciesOption: action.payload.option,
         },
       };
-    }
-    case CREATE_NEW_TOKEN: {
+    });
+    builder.addCase(createNewToken, (state, action) => {
       const newToken = action.payload.token;
       const token: Token = { ...initialState };
       if (newToken) {
@@ -529,20 +532,20 @@ export const token = (state: TokenState = { token: initialState }, action) => {
         characterName: action.payload.characterName,
         replacementHash: action.payload.hash,
       };
-    }
-    case SET_TOKEN_ROUNDED: {
+    });
+    builder.addCase(setTokenRounded, (state, action) => {
       return {
         ...state,
         rounded: action.payload.rounded,
       };
-    }
-    case SET_TOKEN_BORDERED: {
+    });
+    builder.addCase(setTokenBordered, (state, action) => {
       return {
         ...state,
         bordered: action.payload.bordered,
       };
-    }
-    default:
-      return state;
-  }
-};
+    });
+  },
+});
+
+export const token = tokenSlice.reducer;

--- a/WebTools/tests/state/contextReducer.test.ts
+++ b/WebTools/tests/state/contextReducer.test.ts
@@ -1,0 +1,153 @@
+import { test, expect, describe, beforeAll, beforeEach } from '@jest/globals';
+import { Era } from '../../src/helpers/erasEnum';
+import { Source } from '../../src/helpers/sources';
+import { contextReducer } from '../../src/state/contextReducer';
+import {
+  addSource,
+  removeSource,
+  setAllowCrossSpeciesTalents,
+  setAllowEsotericTalents,
+  setEra,
+  setSources,
+} from '../../src/state/contextActions';
+
+const STORAGE_KEY = 'settings.contextData';
+
+function createLocalStorageMock(): Storage {
+  const storage = new Map<string, string>();
+  return {
+    get length() {
+      return storage.size;
+    },
+    clear: () => storage.clear(),
+    getItem: (key: string) =>
+      storage.has(key) ? (storage.get(key) ?? null) : null,
+    key: (index: number) => Array.from(storage.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+  } as Storage;
+}
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, 'window', {
+    value: { localStorage: createLocalStorageMock() },
+    configurable: true,
+    writable: true,
+  });
+});
+
+function storedContext() {
+  return JSON.parse(
+    (globalThis.window as any).localStorage.getItem(STORAGE_KEY),
+  );
+}
+
+function stateWithSources(sources: Source[]) {
+  return {
+    sources: sources,
+    era: Era.NextGeneration,
+    allowCrossSpeciesTalents: false,
+    allowEsotericTalents: false,
+  };
+}
+
+describe('contextReducer', () => {
+  beforeEach(() => {
+    (globalThis.window as any).localStorage.clear();
+  });
+
+  test('returns the base configuration for an unknown action on fresh storage', () => {
+    const result = contextReducer(undefined, { type: 'UNKNOWN' });
+    expect(result).toEqual({
+      sources: [Source.Core],
+      era: Era.NextGeneration,
+      allowCrossSpeciesTalents: false,
+      allowEsotericTalents: false,
+    });
+  });
+
+  test('SET_SOURCES replaces the source list and persists it', () => {
+    const result = contextReducer(
+      undefined,
+      setSources([Source.Core, Source.AlphaQuadrant]),
+    );
+    expect(result.sources).toEqual([Source.Core, Source.AlphaQuadrant]);
+    expect(storedContext().sources).toEqual(['Core', 'AlphaQuadrant']);
+  });
+
+  test('SET_SOURCES refuses both core books: the incoming duplicate is dropped', () => {
+    const twoCore = contextReducer(
+      undefined,
+      setSources([Source.Core, Source.Core2ndEdition]),
+    );
+    expect(twoCore.sources).toEqual([Source.Core]);
+
+    const twoSecond = contextReducer(
+      stateWithSources([Source.Core2ndEdition]),
+      setSources([Source.Core, Source.Core2ndEdition]),
+    );
+    expect(twoSecond.sources).toEqual([Source.Core2ndEdition]);
+  });
+
+  test('ADD_SOURCE appends a source and persists; adding a duplicate is a no-op', () => {
+    let result = contextReducer(undefined, addSource(Source.AlphaQuadrant));
+    expect(result.sources).toEqual([Source.Core, Source.AlphaQuadrant]);
+    expect(storedContext().sources).toEqual(['Core', 'AlphaQuadrant']);
+
+    result = contextReducer(result, addSource(Source.AlphaQuadrant));
+    expect(result.sources).toEqual([Source.Core, Source.AlphaQuadrant]);
+  });
+
+  test('ADD_SOURCE Core2ndEdition removes the original Core book', () => {
+    const result = contextReducer(undefined, addSource(Source.Core2ndEdition));
+    expect(result.sources).toEqual([Source.Core2ndEdition]);
+    expect(storedContext().sources).toEqual(['Core2ndEdition']);
+  });
+
+  test('ADD_SOURCE Core removes Core2ndEdition but keeps first edition sources', () => {
+    const result = contextReducer(
+      stateWithSources([Source.Core2ndEdition, Source.PlayersGuide]),
+      addSource(Source.Core),
+    );
+    expect(result.sources).toEqual([Source.PlayersGuide, Source.Core]);
+  });
+
+  test('REMOVE_SOURCE refuses to remove the only core book', () => {
+    const coreOnly = contextReducer(undefined, removeSource(Source.Core));
+    expect(coreOnly.sources).toEqual([Source.Core]);
+
+    const secondOnly = contextReducer(
+      stateWithSources([Source.Core2ndEdition]),
+      removeSource(Source.Core2ndEdition),
+    );
+    expect(secondOnly.sources).toEqual([Source.Core2ndEdition]);
+  });
+
+  test('REMOVE_SOURCE removes an existing source and persists the result', () => {
+    let result = contextReducer(
+      undefined,
+      setSources([Source.Core, Source.AlphaQuadrant]),
+    );
+    result = contextReducer(result, removeSource(Source.AlphaQuadrant));
+    expect(result.sources).toEqual([Source.Core]);
+    expect(storedContext().sources).toEqual(['Core']);
+
+    const missing = contextReducer(result, removeSource(Source.BetaQuadrant));
+    expect(missing.sources).toEqual([Source.Core]);
+  });
+
+  test('SET_ERA and the talent-allowance flags update their fields', () => {
+    let result = contextReducer(undefined, setEra(Era.Enterprise));
+    expect(result.era).toBe(Era.Enterprise);
+
+    result = contextReducer(result, setAllowCrossSpeciesTalents(true));
+    expect(result.allowCrossSpeciesTalents).toBe(true);
+
+    result = contextReducer(result, setAllowEsotericTalents(true));
+    expect(result.allowEsotericTalents).toBe(true);
+  });
+});

--- a/WebTools/tests/state/stationReducer.test.ts
+++ b/WebTools/tests/state/stationReducer.test.ts
@@ -1,0 +1,271 @@
+import { test, expect, describe } from '@jest/globals';
+import '../../src/common/character';
+import { CharacterType } from '../../src/common/characterType';
+import {
+  CustomStationSpaceframeStep,
+  Station,
+  StationMissionProfileStep,
+  StandardStationSpaceframeStep,
+} from '../../src/common/station';
+import { SelectedTalent } from '../../src/common/selectedTalent';
+import { Department } from '../../src/helpers/department';
+import { Era } from '../../src/helpers/erasEnum';
+import { MissionProfile } from '../../src/helpers/missionProfiles';
+import {
+  StationFrame,
+  StationFrameAppearance,
+} from '../../src/helpers/stationFrame';
+import { System } from '../../src/helpers/systems';
+import { StarshipWeaponRegistry } from '../../src/helpers/weapons';
+import { stationReducer } from '../../src/state/stationReducer';
+import {
+  addStationWeapon,
+  changeStationCustomFrameDepartment,
+  changeStationCustomFrameSystem,
+  createStation,
+  deleteStationWeapon,
+  setStationAdditionalTalents,
+  setStationCustomScale,
+  setStationFrame,
+  setStationFrameAppearance,
+  setStationMissionProfile,
+  setStationMissionProfileTalent,
+  setStationName,
+  setStationTraits,
+} from '../../src/state/stationActions';
+
+function makeStation(): Station {
+  return Station.create(CharacterType.Federation, 2, Era.NextGeneration);
+}
+
+function dispatchAll(
+  initialState: { station?: Station },
+  ...actions: any[]
+): { station?: Station } {
+  return actions.reduce(stationReducer as any, initialState);
+}
+
+describe('stationReducer', () => {
+  test('returns an empty station for an unknown action', () => {
+    const result = stationReducer(undefined, { type: 'UNKNOWN' });
+    expect(result).toEqual({ station: undefined });
+  });
+
+  test('CREATE_STATION stores a copy of the station', () => {
+    const station = makeStation();
+    station.name = 'Deep Space Nine';
+    const result = stationReducer(undefined, createStation(station));
+    expect(result.station?.name).toBe('Deep Space Nine');
+    expect(result.station).not.toBe(station);
+  });
+
+  test('SET_STATION_NAME updates the name', () => {
+    const result = dispatchAll(
+      { station: makeStation() },
+      setStationName('Regula'),
+    );
+    expect(result.station?.name).toBe('Regula');
+  });
+
+  test('SET_STATION_MISSION_PROFILE replaces the profile, dropping the talent on type change', () => {
+    const station = makeStation();
+    station.missionProfileStep = new StationMissionProfileStep(
+      MissionProfile.ResearchStation,
+    );
+    station.missionProfileStep.talent = new SelectedTalent('Bold');
+
+    let result = stationReducer(
+      { station },
+      setStationMissionProfile(MissionProfile.ResearchStation),
+    );
+    expect(result.station?.missionProfileStep?.type).toBe(
+      MissionProfile.ResearchStation,
+    );
+    expect(result.station?.missionProfileStep?.talent?.name).toBe('Bold');
+    expect(result.station?.missionProfileStep?.talent).not.toBe(
+      station.missionProfileStep?.talent,
+    );
+
+    result = stationReducer(
+      result,
+      setStationMissionProfile(MissionProfile.DiplomaticRelationsStation),
+    );
+    expect(result.station?.missionProfileStep?.type).toBe(
+      MissionProfile.DiplomaticRelationsStation,
+    );
+    expect(result.station?.missionProfileStep?.talent).toBeUndefined();
+  });
+
+  test('SET_STATION_MISSION_PROFILE_TALENT sets the talent and prunes base talents with maxRank 1', () => {
+    const station = makeStation();
+    station.stationFrameStep = new StandardStationSpaceframeStep(
+      StationFrame.InternationalSpaceStation,
+    );
+    station.missionProfileStep = new StationMissionProfileStep(
+      MissionProfile.ResearchStation,
+    );
+    station.additionalTalents = [
+      new SelectedTalent('Advanced Research Facilities'),
+    ];
+    const result = stationReducer(
+      { station },
+      setStationMissionProfileTalent(new SelectedTalent('Rapid Maneuvering')),
+    );
+    expect(result.station?.missionProfileStep?.talent?.name).toBe(
+      'Rapid Maneuvering',
+    );
+    expect(result.station?.additionalTalents).toEqual([]);
+  });
+
+  test('SET_STATION_CUSTOM_SCALE converts a standard frame to a custom frame', () => {
+    const station = makeStation();
+    station.stationFrameStep = new StandardStationSpaceframeStep(
+      StationFrame.InternationalSpaceStation,
+    );
+    const result = stationReducer({ station }, setStationCustomScale(6));
+    expect(result.station?.stationFrameStep).toBeInstanceOf(
+      CustomStationSpaceframeStep,
+    );
+    expect(result.station?.scale).toBe(6);
+  });
+
+  test('SET_STATION_CUSTOM_SCALE trims departments and systems to the reduced budget', () => {
+    let result: { station?: Station } = { station: makeStation() };
+    result = stationReducer(result, setStationCustomScale(20));
+    result = stationReducer(
+      result,
+      changeStationCustomFrameDepartment(20, Department.Command),
+    );
+    result = stationReducer(
+      result,
+      changeStationCustomFrameSystem(40, System.Structure),
+    );
+    const inflated = result.station as Station;
+    expect(inflated.sumDepartmentPoints).toBeGreaterThan(
+      inflated.totalAvailableDepartmentPoints,
+    );
+    expect(inflated.sumSystemPoints).toBeGreaterThan(
+      inflated.totalAvailableSystemPoints,
+    );
+
+    result = stationReducer(result, setStationCustomScale(3));
+    const station = result.station as Station;
+    expect(station.scale).toBe(3);
+    expect(station.sumDepartmentPoints).toBe(
+      station.totalAvailableDepartmentPoints,
+    );
+    expect(station.sumSystemPoints).toBe(station.totalAvailableSystemPoints);
+  });
+
+  test('custom frame system changes are clamped to the maximum allowed value', () => {
+    let result: { station?: Station } = { station: makeStation() };
+    result = stationReducer(result, setStationCustomScale(20));
+    result = stationReducer(
+      result,
+      changeStationCustomFrameSystem(100, System.Structure),
+    );
+    const station = result.station as Station;
+    expect(station.systems[System.Structure]).toBe(station.maxSystemValue);
+  });
+
+  test('custom frame department changes are clamped to the maximum allowed value', () => {
+    let result: { station?: Station } = { station: makeStation() };
+    result = stationReducer(result, setStationCustomScale(20));
+    result = stationReducer(
+      result,
+      changeStationCustomFrameDepartment(100, Department.Command),
+    );
+    const station = result.station as Station;
+    expect(station.departments[Department.Command]).toBe(
+      station.maxDepartmentValue,
+    );
+  });
+
+  test('ADD_STATION_WEAPON and DELETE_STATION_WEAPON manage the weapon list by identity', () => {
+    const phaser = StarshipWeaponRegistry.getWeaponByName('Phaser Banks', 2);
+    let result: { station?: Station } = { station: makeStation() };
+    result = stationReducer(result, addStationWeapon(phaser));
+    expect(result.station?.weapons).toHaveLength(1);
+    expect(result.station?.weapons[0]).toBe(phaser);
+
+    result = stationReducer(result, deleteStationWeapon(phaser));
+    expect(result.station?.weapons).toHaveLength(0);
+
+    result = stationReducer(result, deleteStationWeapon(phaser));
+    expect(result.station?.weapons).toHaveLength(0);
+  });
+
+  test('SET_STATION_ADDITIONAL_TALENTS copies the supplied talents', () => {
+    const talent = new SelectedTalent('Bold');
+    const result = stationReducer(
+      { station: makeStation() },
+      setStationAdditionalTalents([talent]),
+    );
+    expect(result.station?.additionalTalents).toHaveLength(1);
+    expect(result.station?.additionalTalents[0].name).toBe('Bold');
+    expect(result.station?.additionalTalents[0]).not.toBe(talent);
+  });
+
+  test('SET_STATION_TRAITS replaces the trait list', () => {
+    const result = stationReducer(
+      { station: makeStation() },
+      setStationTraits(['Reinforced Hull']),
+    );
+    expect(result.station?.traits).toEqual(['Reinforced Hull']);
+  });
+
+  test('SET_STATION_FRAME to a standard frame sets its profile and clears weapons', () => {
+    const station = makeStation();
+    station.weapons = [
+      StarshipWeaponRegistry.getWeaponByName('Phaser Banks', 2),
+    ];
+    const result = stationReducer(
+      { station },
+      setStationFrame(StationFrame.InternationalSpaceStation),
+    );
+    expect(result.station?.stationFrameStep).toBeInstanceOf(
+      StandardStationSpaceframeStep,
+    );
+    expect(result.station?.missionProfileStep?.type).toBe(
+      MissionProfile.ResearchStation,
+    );
+    expect(result.station?.weapons).toEqual([]);
+  });
+
+  test('SET_STATION_FRAME to Custom preserves the current scale', () => {
+    const station = makeStation();
+    station.stationFrameStep = new StandardStationSpaceframeStep(
+      StationFrame.InternationalSpaceStation,
+    );
+    const result = stationReducer(
+      { station },
+      setStationFrame(StationFrame.Custom),
+    );
+    expect(result.station?.stationFrameStep).toBeInstanceOf(
+      CustomStationSpaceframeStep,
+    );
+    expect(result.station?.scale).toBe(3);
+  });
+
+  test('SET_STATION_FRAME_APPEARANCE applies only to custom frames', () => {
+    const custom = stationReducer(
+      { station: makeStation() },
+      setStationFrameAppearance(StationFrameAppearance.Spacedock),
+    );
+    expect(custom.station?.stationFrameStep?.appearance).toBe(
+      StationFrameAppearance.Spacedock,
+    );
+
+    const station = makeStation();
+    station.stationFrameStep = new StandardStationSpaceframeStep(
+      StationFrame.InternationalSpaceStation,
+    );
+    const standard = stationReducer(
+      { station },
+      setStationFrameAppearance(StationFrameAppearance.Spacedock),
+    );
+    expect(standard.station?.stationFrameStep?.appearance).toBe(
+      StationFrameAppearance.InternationalSpaceStation,
+    );
+  });
+});

--- a/WebTools/tests/state/tableReducer.test.ts
+++ b/WebTools/tests/state/tableReducer.test.ts
@@ -1,0 +1,162 @@
+import { test, expect, describe, beforeAll, beforeEach } from '@jest/globals';
+import {
+  Table,
+  TableCollection,
+  TableRow,
+  ValueResult,
+} from '../../src/table/model/table';
+import { TableMarshaller } from '../../src/table/model/tableMarshaller';
+import { tableReducer } from '../../src/state/tableReducer';
+import {
+  addTableCollection,
+  deleteTableCollection,
+  importTableCollection,
+  replaceTableCollection,
+  setTableCollectionSelection,
+  setTableForEditing,
+} from '../../src/state/tableActions';
+
+const STORAGE_KEY = 'settings.tableData';
+
+function createLocalStorageMock(): Storage {
+  const storage = new Map<string, string>();
+  return {
+    get length() {
+      return storage.size;
+    },
+    clear: () => storage.clear(),
+    getItem: (key: string) =>
+      storage.has(key) ? (storage.get(key) ?? null) : null,
+    key: (index: number) => Array.from(storage.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+  } as Storage;
+}
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, 'window', {
+    value: { localStorage: createLocalStorageMock() },
+    configurable: true,
+    writable: true,
+  });
+});
+
+function makeCollection(name: string, uuid: string): TableCollection {
+  return new TableCollection(
+    new Table(name, [new TableRow(new ValueResult(name + ' result'), 1)]),
+    'blurb',
+    'category',
+    uuid,
+  );
+}
+
+function storedCollections() {
+  const data = JSON.parse(
+    (globalThis.window as any).localStorage.getItem(STORAGE_KEY),
+  );
+  return data.collections;
+}
+
+describe('tableReducer', () => {
+  beforeEach(() => {
+    (globalThis.window as any).localStorage.clear();
+  });
+
+  test('returns the two built-in deployments for an unknown action', () => {
+    const result = tableReducer(undefined, { type: 'UNKNOWN' });
+    expect(result.selection).toBeNull();
+    expect(result.collections).toHaveLength(2);
+    expect(result.collections[0].mainTable.name).toBe(
+      'Probability Matrix: Things That Could Go Wrong While Visiting an Alien Bar',
+    );
+    expect(result.collections[1].mainTable.name).toBe(
+      'Probability Matrix: Things That Could Go Wrong While Spacewalking',
+    );
+  });
+
+  test('ADD_TABLE_COLLECTION appends a collection and persists it', () => {
+    const added = makeCollection('New Collection', 'uuid-new');
+    const result = tableReducer(
+      { selection: null, collections: [] },
+      addTableCollection(added),
+    );
+    expect(result.collections).toEqual([added]);
+    expect(storedCollections()).toHaveLength(1);
+    expect(
+      TableMarshaller.instance.unmarshall(storedCollections()[0]).uuid,
+    ).toBe('uuid-new');
+  });
+
+  test('IMPORT_TABLE_COLLECTION behaves like ADD_TABLE_COLLECTION', () => {
+    const imported = makeCollection('Imported', 'uuid-import');
+    const result = tableReducer(
+      { selection: null, collections: [] },
+      importTableCollection(imported),
+    );
+    expect(result.collections).toEqual([imported]);
+    expect(storedCollections()).toHaveLength(1);
+    expect(
+      TableMarshaller.instance.unmarshall(storedCollections()[0]).uuid,
+    ).toBe('uuid-import');
+  });
+
+  test('SET_TABLE_COLLECTION_SELECTION stores the selected collection', () => {
+    const selected = makeCollection('Selected', 'uuid-selected');
+    const result = tableReducer(undefined, {
+      type: 'UNKNOWN',
+    });
+    const updated = tableReducer(result, setTableCollectionSelection(selected));
+    expect(updated.selection).toBe(selected);
+  });
+
+  test('SET_TABLE_FOR_EDITING stores the collection being edited', () => {
+    const editing = makeCollection('Editing', 'uuid-edit');
+    const updated = tableReducer(
+      { selection: null, collections: [] },
+      setTableForEditing(editing),
+    );
+    expect(updated.editing).toBe(editing);
+  });
+
+  test('DELETE_TABLE_COLLECTION removes the matching uuid and persists', () => {
+    const first = makeCollection('First', 'uuid-1');
+    const second = makeCollection('Second', 'uuid-2');
+    const result = tableReducer(
+      { selection: null, collections: [first, second] },
+      deleteTableCollection(first),
+    );
+    expect(result.collections).toEqual([second]);
+    expect(storedCollections()).toHaveLength(1);
+    expect(
+      TableMarshaller.instance.unmarshall(storedCollections()[0]).uuid,
+    ).toBe('uuid-2');
+  });
+
+  test('REPLACE_TABLE_COLLECTION removes the old uuid and appends the new', () => {
+    const first = makeCollection('First', 'uuid-1');
+    const second = makeCollection('Second', 'uuid-2');
+    const replacement = makeCollection('Replacement', 'uuid-3');
+    const result = tableReducer(
+      { selection: null, collections: [first, second] },
+      replaceTableCollection(first.uuid, replacement),
+    );
+    expect(result.collections.map((c) => c.uuid)).toEqual(['uuid-2', 'uuid-3']);
+  });
+
+  test('persisted collections unmarshall back to the same collections', () => {
+    const added = makeCollection('Round Trip', 'uuid-roundtrip');
+    tableReducer(
+      { selection: null, collections: [] },
+      addTableCollection(added),
+    );
+    const reparsed = TableMarshaller.instance.unmarshall(
+      storedCollections()[0],
+    );
+    expect(reparsed.uuid).toBe('uuid-roundtrip');
+    expect(reparsed.mainTable.name).toBe('Round Trip');
+  });
+});

--- a/WebTools/tests/state/tokenReducer.test.ts
+++ b/WebTools/tests/state/tokenReducer.test.ts
@@ -1,0 +1,242 @@
+import { test, expect, describe } from '@jest/globals';
+import '../../src/common/character';
+import { cyrb53 } from '../../src/common/cyrb53';
+import { Rank } from '../../src/helpers/ranks';
+import { Species } from '../../src/helpers/speciesEnum';
+import { BodyType } from '../../src/token/model/bodyTypeEnum';
+import { DivisionColors } from '../../src/token/model/divisionColors';
+import { ExtraType } from '../../src/token/model/extrasTypeEnum';
+import { EyeType } from '../../src/token/model/eyeTypeEnum';
+import { FacialHairType } from '../../src/token/model/facialHairEnum';
+import { HairType } from '../../src/token/model/hairTypeEnum';
+import { HeadType } from '../../src/token/model/headTypeEnum';
+import { MouthType } from '../../src/token/model/mouthTypeEnum';
+import { NasoLabialFoldType } from '../../src/token/model/nasoLabialFoldTypeEnum';
+import { NoseType } from '../../src/token/model/noseTypeEnum';
+import { SpeciesOption } from '../../src/token/model/speciesOptionEnum';
+import { SpeciesRestrictions } from '../../src/token/model/speciesRestrictions';
+import { TokenModel } from '../../src/token/model/tokenModel';
+import { UniformEra } from '../../src/token/model/uniformEra';
+import { UniformVariantRestrictions } from '../../src/token/model/uniformVariantRestrictions';
+import { UniformVariantType } from '../../src/token/model/uniformVariantTypeEnum';
+import { token } from '../../src/state/tokenReducer';
+import {
+  createNewToken,
+  setTokenBordered,
+  setTokenBodyType,
+  setTokenDivisionColor,
+  setTokenEyeColor,
+  setTokenEyeType,
+  setTokenExtrasTypes,
+  setTokenFacialHairTypes,
+  setTokenHairColor,
+  setTokenHairType,
+  setTokenHeadType,
+  setTokenLipstickColor,
+  setTokenMouthType,
+  setTokenNasoLabialFoldType,
+  setTokenNoseType,
+  setTokenRank,
+  setTokenRounded,
+  setTokenSecondarySpecies,
+  setTokenSkinColor,
+  setTokenSpecies,
+  setTokenSpeciesOption,
+  setTokenUniformVariantType,
+  setUniformEra,
+} from '../../src/state/tokenActions';
+
+function baseState() {
+  return token(undefined, { type: 'UNKNOWN' });
+}
+
+describe('tokenReducer', () => {
+  test('returns the default token for an unknown action', () => {
+    const result = token(undefined, { type: 'UNKNOWN' });
+    expect(result.token?.species).toBe(Species.Human);
+    expect(result.token?.uniformEra).toBe(UniformEra.DominionWar);
+    expect(result.token?.rankIndicator).toBe(Rank.None);
+    expect(result.token?.variant).toBe(UniformVariantType.Base);
+    expect(result.token?.secondarySpecies).toBeUndefined();
+    expect(result.rounded).toBeUndefined();
+    expect(result.bordered).toBeUndefined();
+  });
+
+  test('CREATE_NEW_TOKEN maps the model and computes the replacement hash', () => {
+    const model = TokenModel.createDefault();
+    model.primarySpecies = Species.Vulcan;
+    const result = token(
+      baseState(),
+      createNewToken(model, 'marshalled-data', 'Spock', true, true),
+    );
+    expect(result.token?.species).toBe(Species.Vulcan);
+    expect(result.characterName).toBe('Spock');
+    expect(result.marshalledCharacter).toBe('marshalled-data');
+    expect(result.replacementHash).toBe(cyrb53('marshalled-data'));
+    expect(result.rounded).toBe(true);
+    expect(result.bordered).toBe(true);
+  });
+
+  test('CREATE_NEW_TOKEN without a model falls back to defaults', () => {
+    const result = token(baseState(), createNewToken());
+    expect(result.token?.species).toBe(Species.Human);
+    expect(result.rounded).toBe(false);
+    expect(result.bordered).toBe(false);
+    expect(result.marshalledCharacter).toBeUndefined();
+    expect(result.replacementHash).toBeUndefined();
+  });
+
+  test('SET_TOKEN_SPECIES recalibrates features for the new species', () => {
+    const result = token(baseState(), setTokenSpecies(Species.Vulcan));
+    const t = result.token as any;
+    expect(t.species).toBe(Species.Vulcan);
+    expect(SpeciesRestrictions.getSkinColors(Species.Vulcan)).toContain(
+      t.skinColor,
+    );
+    expect(SpeciesRestrictions.getHairColors(Species.Vulcan)).toContain(
+      t.hairColor,
+    );
+    expect(SpeciesRestrictions.getHairTypes(Species.Vulcan)).toContain(
+      t.hairType,
+    );
+    expect(SpeciesRestrictions.getNoseTypes(Species.Vulcan)).toContain(
+      t.noseType,
+    );
+    expect(SpeciesRestrictions.getHeadTypes(Species.Vulcan)).toContain(
+      t.headType,
+    );
+    expect(SpeciesRestrictions.getMouthTypes(Species.Vulcan)).toContain(
+      t.mouthType,
+    );
+    expect(SpeciesRestrictions.getEyeColors(Species.Vulcan)).toContain(
+      t.eyeColor,
+    );
+    expect(SpeciesRestrictions.getSpeciesOptions(Species.Vulcan)).toContain(
+      t.speciesOption,
+    );
+  });
+
+  test('SET_TOKEN_SPECIES to LiberatedBorg defaults the secondary species to Human', () => {
+    const result = token(baseState(), setTokenSpecies(Species.LiberatedBorg));
+    expect(result.token?.species).toBe(Species.LiberatedBorg);
+    expect(result.token?.secondarySpecies).toBe(Species.Human);
+  });
+
+  test('SET_TOKEN_SECONDARY_SPECIES stores the secondary species without swapping the primary', () => {
+    const result = token(
+      baseState(),
+      setTokenSecondarySpecies(Species.KlingonExt),
+    );
+    expect(result.token?.species).toBe(Species.Human);
+    expect(result.token?.secondarySpecies).toBe(Species.KlingonExt);
+  });
+
+  test('SET_TOKEN_UNIFORM_ERA updates the era and rebalances body, color, and variant', () => {
+    const result = token(baseState(), setUniformEra(UniformEra.NextGeneration));
+    const t = result.token as any;
+    expect(t.uniformEra).toBe(UniformEra.NextGeneration);
+    expect(
+      UniformVariantRestrictions.getSupportedBodyTypes(
+        UniformEra.NextGeneration,
+      ),
+    ).toContain(t.bodyType);
+    expect(
+      UniformVariantRestrictions.getAvailableVariants(
+        t.uniformEra,
+        t.bodyType,
+        t.species,
+        t.divisionColor,
+        t.rankIndicator,
+      ),
+    ).toContain(t.variant);
+    expect(
+      DivisionColors.getColors(t.uniformEra, t.rankIndicator).map(
+        (c: any) => c.color,
+      ),
+    ).toContain(t.divisionColor);
+  });
+
+  test('SET_TOKEN_RANK updates the rank and keeps color and variant supported', () => {
+    const result = token(baseState(), setTokenRank(Rank.Lieutenant));
+    const t = result.token as any;
+    expect(t.rankIndicator).toBe(Rank.Lieutenant);
+    expect(
+      UniformVariantRestrictions.getAvailableVariants(
+        t.uniformEra,
+        t.bodyType,
+        t.species,
+        t.divisionColor,
+        t.rankIndicator,
+      ),
+    ).toContain(t.variant);
+    const colors = DivisionColors.getColors(t.uniformEra, t.rankIndicator).map(
+      (c: any) => c.color,
+    );
+    if (colors.length) {
+      expect(colors).toContain(t.divisionColor);
+    }
+  });
+
+  test.each([
+    ['SET_TOKEN_BODY_TYPE', setTokenBodyType(BodyType.AverageFemale)],
+    ['SET_TOKEN_HAIR_TYPE', setTokenHairType(HairType.Bald)],
+    ['SET_TOKEN_HEAD_TYPE', setTokenHeadType(HeadType.AverageAngular)],
+    ['SET_TOKEN_NOSE_TYPE', setTokenNoseType(NoseType.Convex)],
+    ['SET_TOKEN_MOUTH_TYPE', setTokenMouthType(MouthType.Mouth1)],
+    ['SET_TOKEN_EYE_TYPE', setTokenEyeType(EyeType.Eye1)],
+    [
+      'SET_TOKEN_NASO_LABIAL_FOLD_TYPE',
+      setTokenNasoLabialFoldType(NasoLabialFoldType.Subtle),
+    ],
+    ['SET_TOKEN_HAIR_COLOR', setTokenHairColor('#00bb00')],
+    ['SET_TOKEN_EYE_COLOR', setTokenEyeColor('#aa0000')],
+    ['SET_TOKEN_LIPSTICK_COLOR', setTokenLipstickColor('#cc00ee')],
+    ['SET_TOKEN_SKIN_COLOR', setTokenSkinColor('#dd9966')],
+    [
+      'SET_TOKEN_FACIAL_HAIR_TYPE',
+      setTokenFacialHairTypes([FacialHairType.SoulPatch]),
+    ],
+    ['SET_TOKEN_EXTRAS_TYPE', setTokenExtrasTypes([ExtraType.Visor])],
+    ['SET_TOKEN_SPECIES_OPTION', setTokenSpeciesOption(SpeciesOption.Option2)],
+    [
+      'SET_TOKEN_UNIFORM_VARIANT_TYPE',
+      setTokenUniformVariantType(UniformVariantType.Variant1),
+    ],
+    ['SET_TOKEN_ROUNDED', setTokenRounded(true)],
+    ['SET_TOKEN_BORDERED', setTokenBordered(true)],
+  ])('%s stores its payload', (_name, action) => {
+    const expected = token(undefined, action);
+    const actual = token(baseState(), action);
+    expect(actual).toEqual(expected);
+  });
+
+  test('SET_TOKEN_DIVISION_COLOR updates the color and rechecks the variant', () => {
+    const result = token(baseState(), setTokenDivisionColor('#123456'));
+    const t = result.token as any;
+    expect(t.divisionColor).toBe('#123456');
+    expect(
+      UniformVariantRestrictions.getAvailableVariants(
+        t.uniformEra,
+        t.bodyType,
+        t.species,
+        t.divisionColor,
+        t.rankIndicator,
+      ),
+    ).toContain(t.variant);
+  });
+
+  test('SET_TOKEN_BODY_TYPE updates the body type and rechecks the variant', () => {
+    const result = token(baseState(), setTokenBodyType(BodyType.AverageFemale));
+    const t = result.token as any;
+    expect(t.bodyType).toBe(BodyType.AverageFemale);
+    expect(
+      UniformVariantRestrictions.getAvailableVariants(
+        t.uniformEra,
+        t.bodyType,
+        t.species,
+        t.divisionColor,
+        t.rankIndicator,
+      ),
+    ).toContain(t.variant);
+  });
+});


### PR DESCRIPTION
**Summary**

Part of the Redux refactoring plan: migrate the four remaining non-pilot state slices in WebTools (context, table, station, token) to the @reduxjs/toolkit `createAction`/`createSlice` pattern established in PR #452, with no behavioral change.

**What changed**

- Adds characterization tests for all four slices (59 tests in `tests/state/`), locking down current behavior before the migration.
- Converts all action creators to `createAction` (with prepare callbacks for multi-argument creators), keeping action type strings and exported creator names identical.
- Converts all reducers to `createSlice` using `extraReducers` keyed on the creators; reducer case bodies keep the existing copy-mutate logic (no Immer rewrite), including the shared SET_TOKEN_SPECIES / SET_TOKEN_SECONDARY_SPECIES handler and the station CREATE_STATION log.
- `createNewToken` keeps its hash computation (cyrb53) in a prepare callback.

**Verification**

`full_check.sh` passes from `WebTools/`: 410 tests, `tsc --noEmit`, eslint, and prettier.