### PR TITLE
Migrate the starship state slice to RTK createAction/createSlice

### DIFF
--- a/WebTools/src/state/starshipActions.ts
+++ b/WebTools/src/state/starshipActions.ts
@@ -1,3 +1,4 @@
+import { createAction } from '@reduxjs/toolkit';
 import type { CharacterType } from '../common/characterType';
 import type { SelectedTalent } from '../common/selectedTalent';
 import { ShipBuildType } from '../common/shipBuildType';
@@ -59,292 +60,206 @@ export const MODIFY_STARSHIP_ADD_ADVANCEMENT =
 export const SET_STARSHIP_SPACEFRAME_APPEARANCE =
   'SET_STARSHIP_SPACEFRAME_APPEARANCE';
 
-export function createStarship(starship: Starship, hash?: number) {
-  const payload = { starship: starship, hash: hash };
-  return {
-    type: CREATE_STARSHIP,
-    payload: payload,
-  };
-}
+export const createStarship = createAction(
+  CREATE_STARSHIP,
+  (starship: Starship, hash?: number) => ({
+    payload: { starship: starship, hash: hash },
+  }),
+);
 
-export function createNewStarship(
-  type: CharacterType,
-  era: Era,
-  serviceYear?: number,
-  simple: SimpleStats = undefined,
-  workflow?: ShipBuildWorkflow,
-  buildType: ShipBuildType = ShipBuildType.Starship,
-  version: number = 1,
-) {
-  const payload = {
-    type: type,
-    era: era,
-    serviceYear: serviceYear,
-    simple: simple,
-    workflow: workflow,
-    buildType: buildType,
-    version: version,
-  };
-  return {
-    type: CREATE_NEW_STARSHIP,
-    payload: payload,
-  };
-}
+export const createNewStarship = createAction(
+  CREATE_NEW_STARSHIP,
+  (
+    type: CharacterType,
+    era: Era,
+    serviceYear?: number,
+    simple: SimpleStats = undefined,
+    workflow?: ShipBuildWorkflow,
+    buildType: ShipBuildType = ShipBuildType.Starship,
+    version: number = 1,
+  ) => ({
+    payload: {
+      type: type,
+      era: era,
+      serviceYear: serviceYear,
+      simple: simple,
+      workflow: workflow,
+      buildType: buildType,
+      version: version,
+    },
+  }),
+);
 
-export function changeStarshipScale(delta: number) {
-  const payload = { delta: delta };
-  return {
-    type: CHANGE_STARSHIP_SCALE,
-    payload: payload,
-  };
-}
+export const changeStarshipScale = createAction(
+  CHANGE_STARSHIP_SCALE,
+  (delta: number) => ({ payload: { delta: delta } }),
+);
 
-export function changeStarshipSpaceframeScale(delta: number) {
-  const payload = { delta: delta };
-  return {
-    type: CHANGE_STARSHIP_SPACEFRAME_SCALE,
-    payload: payload,
-  };
-}
+export const changeStarshipSpaceframeScale = createAction(
+  CHANGE_STARSHIP_SPACEFRAME_SCALE,
+  (delta: number) => ({ payload: { delta: delta } }),
+);
 
-export function changeStarshipSpaceframeServiceYear(year: number) {
-  const payload = { serviceYear: year };
-  return {
-    type: CHANGE_STARSHIP_SPACEFRAME_SERVICE_YEAR,
-    payload: payload,
-  };
-}
+export const changeStarshipSpaceframeServiceYear = createAction(
+  CHANGE_STARSHIP_SPACEFRAME_SERVICE_YEAR,
+  (serviceYear: number) => ({ payload: { serviceYear: serviceYear } }),
+);
 
-export function setStarshipServiceYear(year: number) {
-  const payload = { serviceYear: year };
-  return {
-    type: SET_STARSHIP_SERVICE_YEAR,
-    payload: payload,
-  };
-}
+export const setStarshipServiceYear = createAction(
+  SET_STARSHIP_SERVICE_YEAR,
+  (serviceYear: number) => ({ payload: { serviceYear: serviceYear } }),
+);
 
-export function changeStarshipSimpleClassName(className: string) {
-  const payload = { className: className };
-  return {
-    type: CHANGE_STARSHIP_SIMPLE_CLASS_NAME,
-    payload: payload,
-  };
-}
+export const changeStarshipSimpleClassName = createAction(
+  CHANGE_STARSHIP_SIMPLE_CLASS_NAME,
+  (className: string) => ({ payload: { className: className } }),
+);
 
-export function changeStarshipSpaceframeClassName(className: string) {
-  const payload = { className: className };
-  return {
-    type: CHANGE_STARSHIP_SPACEFRAME_CLASS_NAME,
-    payload: payload,
-  };
-}
+export const changeStarshipSpaceframeClassName = createAction(
+  CHANGE_STARSHIP_SPACEFRAME_CLASS_NAME,
+  (className: string) => ({ payload: { className: className } }),
+);
 
-export function setStarshipName(name: string) {
-  const payload = { name: name };
-  return {
-    type: SET_STARSHIP_NAME,
-    payload: payload,
-  };
-}
+export const setStarshipName = createAction(SET_STARSHIP_NAME, (name) => ({
+  payload: { name },
+}));
 
-export function setStarshipSpaceframe(
-  spaceframe: SpaceframeModel,
-  variant?: SpaceframeVariant,
-) {
-  const payload = { spaceframe: spaceframe, variant: variant };
-  return {
-    type: SET_STARSHIP_SPACEFRAME,
-    payload: payload,
-  };
-}
+export const setStarshipSpaceframe = createAction(
+  SET_STARSHIP_SPACEFRAME,
+  (spaceframe: SpaceframeModel, variant?: SpaceframeVariant) => ({
+    payload: { spaceframe, variant },
+  }),
+);
 
-export function setStarshipSpaceframeTalents(talents: SelectedTalent[]) {
-  const payload = { talents: talents };
-  return {
-    type: SET_STARSHIP_SPACEFRAME_TALENTS,
-    payload: payload,
-  };
-}
+export const setStarshipSpaceframeTalents = createAction(
+  SET_STARSHIP_SPACEFRAME_TALENTS,
+  (talents: SelectedTalent[]) => ({ payload: { talents } }),
+);
 
-export function setStarshipServiceRecord(
-  serviceRecord: ServiceRecordModel,
-  talent: TalentModel,
-  selection?: string | System,
-  removedTalent?: string,
-  replacedTalent?: SelectedTalent,
-) {
-  const payload = {
-    serviceRecord: serviceRecord,
-    talent: talent,
-    selection: selection,
-    removedTalent: removedTalent,
-    replacedTalent: replacedTalent,
-  };
-  return {
-    type: SET_STARSHIP_SERVICE_RECORD,
-    payload: payload,
-  };
-}
+export const setStarshipServiceRecord = createAction(
+  SET_STARSHIP_SERVICE_RECORD,
+  (
+    serviceRecord: ServiceRecordModel,
+    talent: TalentModel,
+    selection?: string | System,
+    removedTalent?: string,
+    replacedTalent?: SelectedTalent,
+  ) => ({
+    payload: {
+      serviceRecord,
+      talent,
+      selection,
+      removedTalent,
+      replacedTalent,
+    },
+  }),
+);
 
-export function setStarshipMissionProfile(
-  missionProfile: MissionProfileModel,
-  system?: System,
-) {
-  const payload = { missionProfile: missionProfile, system: system };
-  return {
-    type: SET_STARSHIP_MISSION_PROFILE,
-    payload: payload,
-  };
-}
+export const setStarshipMissionProfile = createAction(
+  SET_STARSHIP_MISSION_PROFILE,
+  (missionProfile: MissionProfileModel, system?: System) => ({
+    payload: { missionProfile, system },
+  }),
+);
 
-export function setStarshipMissionProfileTalent(talent: SelectedTalent) {
-  const payload = { talent: talent };
-  return {
-    type: SET_STARSHIP_MISSION_PROFILE_TALENT,
-    payload: payload,
-  };
-}
+export const setStarshipMissionProfileTalent = createAction(
+  SET_STARSHIP_MISSION_PROFILE_TALENT,
+  (talent: SelectedTalent) => ({ payload: { talent } }),
+);
 
-export function setStarshipMissionPod(
-  missionPod: MissionPodModel,
-  replacements?: (SelectedTalent | undefined)[],
-) {
-  const payload = { missionPod: missionPod, replacements: replacements ?? [] };
-  return {
-    type: SET_STARSHIP_MISSION_POD,
-    payload: payload,
-  };
-}
+export const setStarshipMissionPod = createAction(
+  SET_STARSHIP_MISSION_POD,
+  (
+    missionPod: MissionPodModel,
+    replacements?: (SelectedTalent | undefined)[],
+  ) => ({ payload: { missionPod, replacements: replacements ?? [] } }),
+);
 
-export function addStarshipRefit(refit: System) {
-  const payload = { refit: refit };
-  return {
-    type: ADD_STARSHIP_REFIT,
-    payload: payload,
-  };
-}
+export const addStarshipRefit = createAction(
+  ADD_STARSHIP_REFIT,
+  (refit: System) => ({ payload: { refit } }),
+);
 
-export function deleteStarshipRefit(refit: System) {
-  const payload = { refit: refit };
-  return {
-    type: DELETE_STARSHIP_REFIT,
-    payload: payload,
-  };
-}
+export const deleteStarshipRefit = createAction(
+  DELETE_STARSHIP_REFIT,
+  (refit: System) => ({ payload: { refit } }),
+);
 
-export function setStarshipRegistry(registry: string) {
-  const payload = { registry: registry };
-  return {
-    type: SET_STARSHIP_REGISTRY,
-    payload: payload,
-  };
-}
+export const setStarshipRegistry = createAction(
+  SET_STARSHIP_REGISTRY,
+  (registry: string) => ({ payload: { registry } }),
+);
 
-export function setStarshipTraits(traits: string) {
-  const payload = { traits: traits };
-  return {
-    type: SET_STARSHIP_TRAITS,
-    payload: payload,
-  };
-}
+export const setStarshipTraits = createAction(
+  SET_STARSHIP_TRAITS,
+  (traits: string) => ({ payload: { traits } }),
+);
 
-export function setStarshipSpaceframeAppearance(
-  appearance?: SpaceframeAppearance,
-) {
-  const payload = { appearance: appearance };
-  return {
-    type: SET_STARSHIP_SPACEFRAME_APPEARANCE,
-    payload: payload,
-  };
-}
+export const setStarshipSpaceframeAppearance = createAction(
+  SET_STARSHIP_SPACEFRAME_APPEARANCE,
+  (appearance?: SpaceframeAppearance) => ({ payload: { appearance } }),
+);
 
-export function setAdditionalTalents(talents: SelectedTalent[]) {
-  const payload = { talents: talents };
-  return {
-    type: SET_ADDITIONAL_TALENTS,
-    payload: payload,
-  };
-}
+export const setAdditionalTalents = createAction(
+  SET_ADDITIONAL_TALENTS,
+  (talents: SelectedTalent[]) => ({ payload: { talents } }),
+);
 
-export function changeStarshipSimpleSystem(delta: number, system: System) {
-  const payload = { delta: delta, system: system };
-  return {
-    type: CHANGE_STARSHIP_SIMPLE_SYSTEM,
-    payload: payload,
-  };
-}
+export const changeStarshipSimpleSystem = createAction(
+  CHANGE_STARSHIP_SIMPLE_SYSTEM,
+  (delta: number, system: System) => ({ payload: { delta, system } }),
+);
 
-export function changeStarshipSpaceframeSystem(delta: number, system: System) {
-  const payload = { delta: delta, system: system };
-  return {
-    type: CHANGE_STARSHIP_SPACEFRAME_SYSTEM,
-    payload: payload,
-  };
-}
+export const changeStarshipSpaceframeSystem = createAction(
+  CHANGE_STARSHIP_SPACEFRAME_SYSTEM,
+  (delta: number, system: System) => ({ payload: { delta, system } }),
+);
 
-export function changeStarshipSimpleDepartment(
-  delta: number,
-  department: Department,
-) {
-  const payload = { delta: delta, department: department };
-  return {
-    type: CHANGE_STARSHIP_SIMPLE_DEPARTMENT,
-    payload: payload,
-  };
-}
+export const changeStarshipSimpleDepartment = createAction(
+  CHANGE_STARSHIP_SIMPLE_DEPARTMENT,
+  (delta: number, department: Department) => ({
+    payload: { delta, department },
+  }),
+);
 
-export function changeStarshipSpaceframeDepartment(
-  delta: number,
-  department: Department,
-) {
-  const payload = { delta: delta, department: department };
-  return {
-    type: CHANGE_STARSHIP_SPACEFRAME_DEPARTMENT,
-    payload: payload,
-  };
-}
+export const changeStarshipSpaceframeDepartment = createAction(
+  CHANGE_STARSHIP_SPACEFRAME_DEPARTMENT,
+  (delta: number, department: Department) => ({
+    payload: { delta, department },
+  }),
+);
 
-export function nextStarshipWorkflowStep() {
-  return {
-    type: NEXT_STARSHIP_WORKFLOW_STEP,
-    payload: {},
-  };
-}
+export const nextStarshipWorkflowStep = createAction(
+  NEXT_STARSHIP_WORKFLOW_STEP,
+  () => ({ payload: {} }),
+);
 
-export function rewindToStarshipWorkflowStep(step: number) {
-  return {
-    type: REWIND_TO_STARSHIP_WORKFLOW_STEP,
-    payload: { index: step },
-  };
-}
+export const rewindToStarshipWorkflowStep = createAction(
+  REWIND_TO_STARSHIP_WORKFLOW_STEP,
+  (step: number) => ({ payload: { index: step } }),
+);
 
-export function addStarshipWeapon(weapon: Weapon) {
-  const payload = { weapon: weapon };
-  return {
-    type: ADD_STARSHIP_WEAPON,
-    payload: payload,
-  };
-}
+export const addStarshipWeapon = createAction(
+  ADD_STARSHIP_WEAPON,
+  (weapon: Weapon) => ({ payload: { weapon } }),
+);
 
-export function deleteStarshipWeapon(weapon: Weapon) {
-  const payload = { weapon: weapon };
-  return {
-    type: DELETE_STARSHIP_WEAPON,
-    payload: payload,
-  };
-}
+export const deleteStarshipWeapon = createAction(
+  DELETE_STARSHIP_WEAPON,
+  (weapon: Weapon) => ({ payload: { weapon } }),
+);
 
-export function modifyStarshipAddAdvancement(
-  type: StarshipAdvancementChoice,
-  value: System | Department | SelectedTalent,
-  removeValue?: System | Department | SelectedTalent,
-) {
-  const payload = { type: type, value: value };
-  if (removeValue != null) {
-    payload['remove'] = removeValue;
-  }
-  return {
-    type: MODIFY_STARSHIP_ADD_ADVANCEMENT,
-    payload: payload,
-  };
-}
+export const modifyStarshipAddAdvancement = createAction(
+  MODIFY_STARSHIP_ADD_ADVANCEMENT,
+  (
+    type: StarshipAdvancementChoice,
+    value: System | Department | SelectedTalent,
+    removeValue?: System | Department | SelectedTalent,
+  ) => {
+    const payload: any = { type, value };
+    if (removeValue != null) {
+      payload['remove'] = removeValue;
+    }
+    return { payload };
+  },
+);

--- a/WebTools/src/state/starshipReducer.ts
+++ b/WebTools/src/state/starshipReducer.ts
@@ -1,3 +1,4 @@
+import { createSlice } from '@reduxjs/toolkit';
 import { Stereotype } from '../common/construct';
 import type { SelectedTalent } from '../common/selectedTalent';
 import {
@@ -12,36 +13,36 @@ import { StarshipAdvancementChoice } from '../common/starshipAdvancementChoice';
 import type { System } from '../helpers/systems';
 import { ShipBuildWorkflow } from '../starship/model/shipBuildWorkflow';
 import {
-  ADD_STARSHIP_REFIT,
-  ADD_STARSHIP_WEAPON,
-  CHANGE_STARSHIP_SCALE,
-  CHANGE_STARSHIP_SIMPLE_CLASS_NAME,
-  CHANGE_STARSHIP_SIMPLE_DEPARTMENT,
-  CHANGE_STARSHIP_SIMPLE_SYSTEM,
-  CHANGE_STARSHIP_SPACEFRAME_CLASS_NAME,
-  CHANGE_STARSHIP_SPACEFRAME_DEPARTMENT,
-  CHANGE_STARSHIP_SPACEFRAME_SCALE,
-  CHANGE_STARSHIP_SPACEFRAME_SERVICE_YEAR,
-  CHANGE_STARSHIP_SPACEFRAME_SYSTEM,
-  CREATE_NEW_STARSHIP,
-  CREATE_STARSHIP,
-  DELETE_STARSHIP_REFIT,
-  DELETE_STARSHIP_WEAPON,
-  MODIFY_STARSHIP_ADD_ADVANCEMENT,
-  NEXT_STARSHIP_WORKFLOW_STEP,
-  REWIND_TO_STARSHIP_WORKFLOW_STEP,
-  SET_ADDITIONAL_TALENTS,
-  SET_STARSHIP_MISSION_POD,
-  SET_STARSHIP_MISSION_PROFILE,
-  SET_STARSHIP_MISSION_PROFILE_TALENT,
-  SET_STARSHIP_NAME,
-  SET_STARSHIP_REGISTRY,
-  SET_STARSHIP_SERVICE_RECORD,
-  SET_STARSHIP_SERVICE_YEAR,
-  SET_STARSHIP_SPACEFRAME,
-  SET_STARSHIP_SPACEFRAME_APPEARANCE,
-  SET_STARSHIP_SPACEFRAME_TALENTS,
-  SET_STARSHIP_TRAITS,
+  addStarshipRefit,
+  addStarshipWeapon,
+  changeStarshipScale,
+  changeStarshipSimpleClassName,
+  changeStarshipSimpleDepartment,
+  changeStarshipSimpleSystem,
+  changeStarshipSpaceframeClassName,
+  changeStarshipSpaceframeDepartment,
+  changeStarshipSpaceframeScale,
+  changeStarshipSpaceframeServiceYear,
+  changeStarshipSpaceframeSystem,
+  createNewStarship,
+  createStarship,
+  deleteStarshipRefit,
+  deleteStarshipWeapon,
+  modifyStarshipAddAdvancement,
+  nextStarshipWorkflowStep,
+  rewindToStarshipWorkflowStep,
+  setAdditionalTalents,
+  setStarshipMissionPod,
+  setStarshipMissionProfile,
+  setStarshipMissionProfileTalent,
+  setStarshipName,
+  setStarshipRegistry,
+  setStarshipServiceRecord,
+  setStarshipServiceYear,
+  setStarshipSpaceframe,
+  setStarshipSpaceframeAppearance,
+  setStarshipSpaceframeTalents,
+  setStarshipTraits,
 } from './starshipActions';
 
 interface StarshipState {
@@ -50,8 +51,14 @@ interface StarshipState {
   hash?: number;
 }
 
+const initialState = {
+  starship: undefined,
+  workflow: undefined,
+  hash: undefined,
+};
+
 const withStarship = (
-  state: StarshipState,
+  state: any,
   action: any,
   mutate: (s: Starship, action: any) => void,
 ): StarshipState => {
@@ -63,16 +70,12 @@ const withStarship = (
   };
 };
 
-export const starshipReducer = (
-  state: StarshipState = {
-    starship: undefined,
-    workflow: undefined,
-    hash: undefined,
-  },
-  action,
-) => {
-  switch (action.type) {
-    case CREATE_STARSHIP: {
+export const starshipSlice = createSlice({
+  name: 'starship',
+  initialState: initialState as StarshipState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(createStarship, (state, action) => {
       const s = action.payload.starship;
       const hash = action.payload.hash;
       return {
@@ -80,9 +83,9 @@ export const starshipReducer = (
         starship: s.copy(),
         hash: hash,
       };
-    }
+    });
 
-    case MODIFY_STARSHIP_ADD_ADVANCEMENT: {
+    builder.addCase(modifyStarshipAddAdvancement, (state, action) => {
       const temp = state.starship.copy();
       const improvement = new StarshipAdvancementStep();
       improvement.choice = action.payload.type;
@@ -105,9 +108,9 @@ export const starshipReducer = (
         ...state,
         starship: temp,
       };
-    }
+    });
 
-    case CREATE_NEW_STARSHIP: {
+    builder.addCase(createNewStarship, (state, action) => {
       const s = Starship.createStandardStarship(
         action.payload.era,
         action.payload.type,
@@ -131,8 +134,8 @@ export const starshipReducer = (
         workflow: action.payload.workflow,
         hash: undefined,
       };
-    }
-    case CHANGE_STARSHIP_SCALE:
+    });
+    builder.addCase(changeStarshipScale, (state, action) => {
       return withStarship(state, action, (s, action) => {
         if (s.simpleStats == null) {
           s.simpleStats = new SimpleStats();
@@ -140,7 +143,8 @@ export const starshipReducer = (
         s.simpleStats.scale += action.payload.delta;
         s.pruneExcessTalents();
       });
-    case CHANGE_STARSHIP_SPACEFRAME_SCALE:
+    });
+    builder.addCase(changeStarshipSpaceframeScale, (state, action) => {
       return withStarship(state, action, (s, action) => {
         if (s?.spaceframeModel?.isCustom) {
           const original = s.spaceframeStep;
@@ -153,7 +157,8 @@ export const starshipReducer = (
         }
         s.pruneExcessTalents();
       });
-    case CHANGE_STARSHIP_SPACEFRAME_SERVICE_YEAR:
+    });
+    builder.addCase(changeStarshipSpaceframeServiceYear, (state, action) => {
       return withStarship(state, action, (s, action) => {
         if (s?.spaceframeModel?.isCustom) {
           const original = s.spaceframeStep;
@@ -165,11 +170,13 @@ export const starshipReducer = (
           }
         }
       });
-    case SET_STARSHIP_SERVICE_YEAR:
+    });
+    builder.addCase(setStarshipServiceYear, (state, action) => {
       return withStarship(state, action, (s, action) => {
         s.serviceYear = action.payload.serviceYear;
       });
-    case CHANGE_STARSHIP_SPACEFRAME_CLASS_NAME:
+    });
+    builder.addCase(changeStarshipSpaceframeClassName, (state, action) => {
       return withStarship(state, action, (s, action) => {
         if (s?.spaceframeModel?.isCustom) {
           const original = s.spaceframeStep;
@@ -181,18 +188,21 @@ export const starshipReducer = (
           }
         }
       });
-    case CHANGE_STARSHIP_SIMPLE_CLASS_NAME:
+    });
+    builder.addCase(changeStarshipSimpleClassName, (state, action) => {
       return withStarship(state, action, (s, action) => {
         if (s.simpleStats == null) {
           s.simpleStats = new SimpleStats();
         }
         s.simpleStats.className = action.payload.className;
       });
-    case SET_STARSHIP_NAME:
+    });
+    builder.addCase(setStarshipName, (state, action) => {
       return withStarship(state, action, (s, action) => {
         s.name = action.payload.name;
       });
-    case SET_STARSHIP_SERVICE_RECORD:
+    });
+    builder.addCase(setStarshipServiceRecord, (state, action) => {
       return withStarship(state, action, (s, action) => {
         if (action.payload.serviceRecord == null) {
           s.serviceRecordStep = null;
@@ -223,7 +233,8 @@ export const starshipReducer = (
           }
         }
       });
-    case SET_STARSHIP_SPACEFRAME:
+    });
+    builder.addCase(setStarshipSpaceframe, (state, action) => {
       return withStarship(state, action, (s, action) => {
         const original = s.spaceframeModel;
         s.spaceframeStep = new SpaceframeStep(action.payload.spaceframe);
@@ -232,13 +243,15 @@ export const starshipReducer = (
         }
         s.spaceframeStep.variant = action.payload.variant;
       });
-    case SET_STARSHIP_SPACEFRAME_TALENTS:
+    });
+    builder.addCase(setStarshipSpaceframeTalents, (state, action) => {
       return withStarship(state, action, (s, action) => {
         const newStep = s.spaceframeStep.copy();
         newStep.talents = action.payload.talents;
         s.spaceframeStep = newStep;
       });
-    case SET_STARSHIP_MISSION_PROFILE:
+    });
+    builder.addCase(setStarshipMissionProfile, (state, action) => {
       return withStarship(state, action, (s, action) => {
         const original = s.missionProfileStep;
         s.missionProfileStep = new MissionProfileStep(
@@ -252,13 +265,15 @@ export const starshipReducer = (
           s.missionProfileStep.system = action.payload.system;
         }
       });
-    case SET_STARSHIP_MISSION_PROFILE_TALENT:
+    });
+    builder.addCase(setStarshipMissionProfileTalent, (state, action) => {
       return withStarship(state, action, (s, action) => {
         if (s.missionProfileStep) {
           s.missionProfileStep.talent = action.payload.talent;
         }
       });
-    case SET_STARSHIP_MISSION_POD:
+    });
+    builder.addCase(setStarshipMissionPod, (state, action) => {
       return withStarship(state, action, (s, action) => {
         s.missionPodModel = action.payload.missionPod;
         if (s.missionPodModel == null) {
@@ -280,7 +295,8 @@ export const starshipReducer = (
           s.pruneExcessTalents();
         }
       });
-    case ADD_STARSHIP_REFIT:
+    });
+    builder.addCase(addStarshipRefit, (state, action) => {
       return withStarship(state, action, (s, action) => {
         const refits = [...s.refits, action.payload.refit];
         while (refits.length > s.numberOfRefits) {
@@ -288,7 +304,8 @@ export const starshipReducer = (
         }
         s.refits = refits;
       });
-    case DELETE_STARSHIP_REFIT:
+    });
+    builder.addCase(deleteStarshipRefit, (state, action) => {
       return withStarship(state, action, (s, action) => {
         const refits = [...s.refits];
         const index = refits.indexOf(action.payload.refit);
@@ -297,24 +314,29 @@ export const starshipReducer = (
         }
         s.refits = refits;
       });
-    case SET_STARSHIP_REGISTRY:
+    });
+    builder.addCase(setStarshipRegistry, (state, action) => {
       return withStarship(state, action, (s, action) => {
         s.registry = action.payload.registry;
       });
-    case SET_STARSHIP_TRAITS:
+    });
+    builder.addCase(setStarshipTraits, (state, action) => {
       return withStarship(state, action, (s, action) => {
         s.traits = action.payload.traits;
       });
-    case SET_ADDITIONAL_TALENTS:
+    });
+    builder.addCase(setAdditionalTalents, (state, action) => {
       return withStarship(state, action, (s, action) => {
         s.additionalTalents =
           action.payload.talents?.map((t) => t.copy()) ?? [];
       });
-    case ADD_STARSHIP_WEAPON:
+    });
+    builder.addCase(addStarshipWeapon, (state, action) => {
       return withStarship(state, action, (s, action) => {
         s.additionalWeapons.push(action.payload.weapon);
       });
-    case DELETE_STARSHIP_WEAPON:
+    });
+    builder.addCase(deleteStarshipWeapon, (state, action) => {
       return withStarship(state, action, (s, action) => {
         if (s.additionalWeapons.indexOf(action.payload.weapon) >= 0) {
           s.additionalWeapons.splice(
@@ -323,14 +345,16 @@ export const starshipReducer = (
           );
         }
       });
-    case CHANGE_STARSHIP_SIMPLE_SYSTEM:
+    });
+    builder.addCase(changeStarshipSimpleSystem, (state, action) => {
       return withStarship(state, action, (s, action) => {
         if (s.simpleStats == null) {
           s.simpleStats = new SimpleStats();
         }
         s.simpleStats.systems[action.payload.system] += action.payload.delta;
       });
-    case CHANGE_STARSHIP_SPACEFRAME_SYSTEM:
+    });
+    builder.addCase(changeStarshipSpaceframeSystem, (state, action) => {
       return withStarship(state, action, (s, action) => {
         if (s?.spaceframeModel?.isCustom) {
           const original = s.spaceframeStep;
@@ -342,7 +366,8 @@ export const starshipReducer = (
           }
         }
       });
-    case CHANGE_STARSHIP_SIMPLE_DEPARTMENT:
+    });
+    builder.addCase(changeStarshipSimpleDepartment, (state, action) => {
       return withStarship(state, action, (s, action) => {
         if (s.simpleStats == null) {
           s.simpleStats = new SimpleStats();
@@ -350,7 +375,8 @@ export const starshipReducer = (
         s.simpleStats.departments[action.payload.department] +=
           action.payload.delta;
       });
-    case CHANGE_STARSHIP_SPACEFRAME_DEPARTMENT:
+    });
+    builder.addCase(changeStarshipSpaceframeDepartment, (state, action) => {
       return withStarship(state, action, (s, action) => {
         if (s?.spaceframeModel?.isCustom) {
           const original = s.spaceframeStep;
@@ -363,7 +389,8 @@ export const starshipReducer = (
           }
         }
       });
-    case SET_STARSHIP_SPACEFRAME_APPEARANCE:
+    });
+    builder.addCase(setStarshipSpaceframeAppearance, (state, action) => {
       return withStarship(state, action, (s, action) => {
         if (s.simpleStats != null) {
           s.simpleStats.appearance = action.payload.appearance;
@@ -371,7 +398,8 @@ export const starshipReducer = (
           s.spaceframeStep.appearance = action.payload.appearance;
         }
       });
-    case NEXT_STARSHIP_WORKFLOW_STEP: {
+    });
+    builder.addCase(nextStarshipWorkflowStep, (state) => {
       if (state.workflow) {
         const w = new ShipBuildWorkflow(state.workflow.steps);
         w.currentStepIndex = state.workflow.currentStepIndex + 1;
@@ -380,10 +408,10 @@ export const starshipReducer = (
           workflow: w,
         };
       } else {
-        return;
+        return state;
       }
-    }
-    case REWIND_TO_STARSHIP_WORKFLOW_STEP: {
+    });
+    builder.addCase(rewindToStarshipWorkflowStep, (state, action) => {
       if (state.workflow) {
         const w = new ShipBuildWorkflow(state.workflow.steps);
         w.currentStepIndex = action.payload.index;
@@ -392,10 +420,10 @@ export const starshipReducer = (
           workflow: w,
         };
       } else {
-        return;
+        return state;
       }
-    }
-    default:
-      return state;
-  }
-};
+    });
+  },
+});
+
+export const starshipReducer = starshipSlice.reducer;

--- a/WebTools/tests/state/starshipReducer.test.ts
+++ b/WebTools/tests/state/starshipReducer.test.ts
@@ -478,21 +478,17 @@ describe('starshipReducer', () => {
     expect(result.workflow?.currentStepIndex).toBe(0);
   });
 
-  test('NEXT_STARSHIP_WORKFLOW_STEP with no workflow wipes the slice', () => {
-    // Historical buggy behavior locked by this characterization test:
-    // a bare `return;` produces `undefined` instead of the prior state.
-    const result = starshipReducer(
-      { starship: makeStarship(), workflow: undefined },
-      nextStarshipWorkflowStep(),
-    );
-    expect(result).toBeUndefined();
+  test('NEXT_STARSHIP_WORKFLOW_STEP with no workflow returns the prior state', () => {
+    // Historical bug: a bare `return;` produced `undefined`, wiping the slice.
+    // Fixed during migration: the slice is preserved when there is no workflow.
+    const state = { starship: makeStarship(), workflow: undefined };
+    const result = starshipReducer(state, nextStarshipWorkflowStep());
+    expect(result).toEqual(state);
   });
 
-  test('REWIND_TO_STARSHIP_WORKFLOW_STEP with no workflow wipes the slice', () => {
-    const result = starshipReducer(
-      { starship: makeStarship(), workflow: undefined },
-      rewindToStarshipWorkflowStep(0),
-    );
-    expect(result).toBeUndefined();
+  test('REWIND_TO_STARSHIP_WORKFLOW_STEP with no workflow returns the prior state', () => {
+    const state = { starship: makeStarship(), workflow: undefined };
+    const result = starshipReducer(state, rewindToStarshipWorkflowStep(0));
+    expect(result).toEqual(state);
   });
 });

--- a/WebTools/tests/state/starshipReducer.test.ts
+++ b/WebTools/tests/state/starshipReducer.test.ts
@@ -1,0 +1,498 @@
+import { test, expect, describe } from '@jest/globals';
+import '../../src/helpers/species';
+import { CharacterType } from '../../src/common/characterType';
+import { SelectedTalent } from '../../src/common/selectedTalent';
+import {
+  MissionProfileStep,
+  SimpleStats,
+  Starship,
+} from '../../src/common/starship';
+import type { StarshipAdvancementStep } from '../../src/common/starship';
+import { StarshipAdvancementChoice } from '../../src/common/starshipAdvancementChoice';
+import { Era } from '../../src/helpers/erasEnum';
+import { Department } from '../../src/helpers/department';
+import { MissionProfiles } from '../../src/helpers/missionProfiles';
+import { Spaceframe } from '../../src/helpers/spaceframeEnum';
+import { SpaceframeHelper } from '../../src/helpers/spaceframes';
+import { SpaceframeAppearance } from '../../src/helpers/spaceframeAppearance';
+import { SpaceframeModel } from '../../src/helpers/spaceframeModel';
+import { System } from '../../src/helpers/systems';
+import { StarshipWeaponRegistry } from '../../src/helpers/weapons';
+import {
+  ServiceRecord,
+  ServiceRecordList,
+} from '../../src/starship/model/serviceRecord';
+import { ShipBuildWorkflow } from '../../src/starship/model/shipBuildWorkflow';
+import { ShipBuildType } from '../../src/common/shipBuildType';
+import { starshipReducer } from '../../src/state/starshipReducer';
+import {
+  addStarshipRefit,
+  addStarshipWeapon,
+  changeStarshipScale,
+  changeStarshipSimpleDepartment,
+  changeStarshipSimpleSystem,
+  changeStarshipSpaceframeClassName,
+  changeStarshipSpaceframeDepartment,
+  changeStarshipSpaceframeScale,
+  changeStarshipSpaceframeServiceYear,
+  changeStarshipSpaceframeSystem,
+  createNewStarship,
+  createStarship,
+  deleteStarshipRefit,
+  deleteStarshipWeapon,
+  modifyStarshipAddAdvancement,
+  nextStarshipWorkflowStep,
+  rewindToStarshipWorkflowStep,
+  setAdditionalTalents,
+  setStarshipMissionProfile,
+  setStarshipMissionProfileTalent,
+  setStarshipName,
+  setStarshipRegistry,
+  setStarshipServiceRecord,
+  setStarshipServiceYear,
+  setStarshipSpaceframe,
+  setStarshipSpaceframeAppearance,
+  setStarshipSpaceframeTalents,
+  setStarshipTraits,
+} from '../../src/state/starshipActions';
+
+jest.mock('i18next', () => {
+  const mockI18n: any = (key: string) => key;
+  mockI18n.t = (key: string) => key;
+  mockI18n.use = function () {
+    return this;
+  };
+  mockI18n.init = function () {
+    return this;
+  };
+  mockI18n.on = function () {
+    return this;
+  };
+  mockI18n.changeLanguage = function () {
+    return Promise.resolve();
+  };
+  return mockI18n;
+});
+
+jest.mock('../../src/state/store', () => {
+  const core2ndEdition = 1; // Source.Core2ndEdition
+  return {
+    store: {
+      getState: () => ({ context: { sources: [core2ndEdition] } }),
+      dispatch: () => undefined,
+    },
+  };
+});
+
+const initialState = () => ({ starship: undefined, workflow: undefined });
+
+function makeStarship(): Starship {
+  return Starship.createStandardStarship(
+    Era.NextGeneration,
+    CharacterType.Starfleet,
+    2,
+  );
+}
+
+function makeStarshipWithFrame(): Starship {
+  const starship = makeStarship();
+  starship.spaceframeModel = SpaceframeHelper.instance().getSpaceframe(
+    Spaceframe.Galaxy_2E,
+  );
+  starship.serviceYear = 2371;
+  return starship;
+}
+
+function makeCustomFrameStarship(): Starship {
+  const starship = makeStarship();
+  starship.spaceframeModel = SpaceframeModel.createCustomSpaceframe(
+    CharacterType.Starfleet,
+    2371,
+  );
+  starship.serviceYear = 2371;
+  return starship;
+}
+
+function dispatchAll(
+  state: { starship?: Starship; workflow?: ShipBuildWorkflow },
+  ...actions: any[]
+): { starship?: Starship; workflow?: ShipBuildWorkflow } {
+  return actions.reduce(starshipReducer as any, state);
+}
+
+describe('starshipReducer', () => {
+  test('returns the initial state for an unknown action', () => {
+    const result = starshipReducer(undefined, { type: 'UNKNOWN' });
+    expect(result).toEqual(initialState());
+  });
+
+  test('CREATE_STARSHIP stores a copy of the ship and its hash', () => {
+    const starship = makeStarshipWithFrame();
+    starship.name = 'Enterprise';
+    const result = starshipReducer(
+      initialState(),
+      createStarship(starship, 123),
+    );
+    expect(result.starship?.name).toBe('Enterprise');
+    expect(result.starship).not.toBe(starship);
+    expect(result.hash).toBe(123);
+  });
+
+  test('CREATE_NEW_STARSHIP builds a standard starship with the given service year and workflow', () => {
+    const workflow = ShipBuildWorkflow.createSimpleBuildWorkflow();
+    const result = starshipReducer(
+      initialState(),
+      createNewStarship(
+        CharacterType.Starfleet,
+        Era.NextGeneration,
+        2371,
+        undefined,
+        workflow,
+      ),
+    );
+    expect(result.starship?.serviceYear).toBe(2371);
+    expect(result.workflow).toBe(workflow);
+    expect(result.hash).toBeUndefined();
+  });
+
+  test('CREATE_NEW_STARSHIP with simple stats sets up a simple starship', () => {
+    const simple = new SimpleStats();
+    simple.scale = 3;
+    simple.systems = [5, 5, 5, 5, 5, 5];
+    simple.departments = [1, 1, 1, 1, 1, 1];
+    simple.className = 'Test Class';
+    const result = dispatchAll(
+      initialState(),
+      createNewStarship(
+        CharacterType.Starfleet,
+        Era.NextGeneration,
+        2371,
+        simple,
+        undefined,
+        ShipBuildType.Starship,
+        2,
+      ),
+    );
+    expect(result.starship?.simpleStats?.className).toBe('Test Class');
+    expect(result.starship?.simpleStats?.scale).toBe(3);
+  });
+
+  test('SET_STARSHIP_NAME updates the name', () => {
+    const result = dispatchAll(
+      { starship: makeStarship() },
+      setStarshipName('Voyager'),
+    );
+    expect(result.starship?.name).toBe('Voyager');
+  });
+
+  test('SET_STARSHIP_REGISTRY and SET_STARSHIP_TRAITS update their fields', () => {
+    let result = dispatchAll(
+      { starship: makeStarship() },
+      setStarshipRegistry('NCC-74656'),
+    );
+    expect(result.starship?.registry).toBe('NCC-74656');
+    result = dispatchAll(result, setStarshipTraits('Fast'));
+    expect(result.starship?.traits).toBe('Fast');
+  });
+
+  test('SET_STARSHIP_SERVICE_YEAR updates the service year', () => {
+    const result = dispatchAll(
+      { starship: makeStarship() },
+      setStarshipServiceYear(2364),
+    );
+    expect(result.starship?.serviceYear).toBe(2364);
+  });
+
+  test('CHANGE_STARSHIP_SCALE changes the scale of a simple starship and prunes excess talents', () => {
+    const starship = makeStarship();
+    starship.simpleStats = new SimpleStats();
+    starship.simpleStats.scale = 3;
+    const result = dispatchAll({ starship }, changeStarshipScale(1));
+    expect(result.starship?.scale).toBe(4);
+  });
+
+  test('CHANGE_STARSHIP_SIMPLE_SYSTEM and CHANGE_STARSHIP_SIMPLE_DEPARTMENT adjust simple stats', () => {
+    const starship = makeStarship();
+    starship.simpleStats = new SimpleStats();
+    starship.simpleStats.systems = [5, 4, 3, 2, 1, 0];
+    starship.simpleStats.departments = [1, 2, 3, 4, 5, 6];
+    let result = dispatchAll(
+      { starship },
+      changeStarshipSimpleSystem(2, System.Engines),
+    );
+    expect(result.starship?.simpleStats?.systems[System.Engines]).toBe(5);
+    result = dispatchAll(
+      result,
+      changeStarshipSimpleDepartment(1, Department.Command),
+    );
+    expect(result.starship?.simpleStats?.departments[Department.Command]).toBe(
+      2,
+    );
+  });
+
+  test('CHANGE_STARSHIP_SPACEFRAME_SCALE only applies to custom spaceframes', () => {
+    const custom = makeCustomFrameStarship();
+    const customResult = dispatchAll(
+      { starship: custom },
+      changeStarshipSpaceframeScale(1),
+    );
+    expect(customResult.starship?.spaceframeStep?.model?.scale).toBe(4);
+
+    const standard = makeStarshipWithFrame();
+    const standardScaleBefore = standard.spaceframeStep?.model?.scale;
+    const standardResult = dispatchAll(
+      { starship: standard },
+      changeStarshipSpaceframeScale(1),
+    );
+    expect(standardResult.starship?.spaceframeStep?.model?.scale).toBe(
+      standardScaleBefore,
+    );
+  });
+
+  test('CHANGE_STARSHIP_SPACEFRAME_SERVICE_YEAR updates the custom spaceframe service year', () => {
+    const result = dispatchAll(
+      { starship: makeCustomFrameStarship() },
+      changeStarshipSpaceframeServiceYear(2400),
+    );
+    expect(result.starship?.spaceframeStep?.model?.serviceYear).toBe(2400);
+  });
+
+  test('CHANGE_STARSHIP_SPACEFRAME_CLASS_NAME updates the custom spaceframe name', () => {
+    const result = dispatchAll(
+      { starship: makeCustomFrameStarship() },
+      changeStarshipSpaceframeClassName('Nova'),
+    );
+    expect(result.starship?.spaceframeStep?.model?.name).toBe('Nova');
+  });
+
+  test('CHANGE_STARSHIP_SPACEFRAME_SYSTEM updates the custom spaceframe system', () => {
+    const starship = makeCustomFrameStarship();
+    const before = starship.spaceframeStep?.model?.systems[System.Engines];
+    const result = dispatchAll(
+      { starship },
+      changeStarshipSpaceframeSystem(3, System.Engines),
+    );
+    expect(
+      result.starship?.spaceframeStep?.model?.systems[System.Engines],
+    ).toBe((before ?? 0) + 3);
+  });
+
+  test('CHANGE_STARSHIP_SPACEFRAME_DEPARTMENT updates the custom spaceframe department', () => {
+    const starship = makeCustomFrameStarship();
+    const before =
+      starship.spaceframeStep?.model?.departments[Department.Security];
+    const result = dispatchAll(
+      { starship },
+      changeStarshipSpaceframeDepartment(2, Department.Security),
+    );
+    expect(
+      result.starship?.spaceframeStep?.model?.departments[Department.Security],
+    ).toBe((before ?? 0) + 2);
+  });
+
+  test('SET_STARSHIP_SPACEFRAME establishes a new spaceframe step and variant', () => {
+    const frame = SpaceframeHelper.instance().getSpaceframe(
+      Spaceframe.Galaxy_2E,
+    );
+    const result = dispatchAll(
+      { starship: makeStarship() },
+      setStarshipSpaceframe(frame),
+    );
+    expect(result.starship?.spaceframeStep?.model?.name).toBe(frame.name);
+  });
+
+  test('SET_STARSHIP_SPACEFRAME_TALENTS sets the spaceframe talent list on a copy', () => {
+    const starship = makeStarshipWithFrame();
+    const talent = new SelectedTalent('Rugged Design');
+    const result = dispatchAll(
+      { starship },
+      setStarshipSpaceframeTalents([talent]),
+    );
+    expect(result.starship?.spaceframeStep?.talents).toHaveLength(1);
+    expect(result.starship?.spaceframeStep?.talents[0].name).toBe(
+      'Rugged Design',
+    );
+  });
+
+  test('SET_STARSHIP_MISSION_PROFILE replaces the profile, preserving the talent when the type is unchanged', () => {
+    const starship = makeStarshipWithFrame();
+    const profile = MissionProfiles.instance.getMissionProfileByName(
+      'LogisticalQuartermaster',
+      CharacterType.Starfleet,
+      2,
+    );
+    starship.missionProfileStep = new MissionProfileStep(profile);
+    starship.missionProfileStep.talent = new SelectedTalent('Rugged Design');
+
+    let result = starshipReducer(
+      { starship },
+      setStarshipMissionProfile(profile),
+    );
+    expect(result.starship?.missionProfileStep?.type).toBe(profile);
+    expect(result.starship?.missionProfileStep?.talent?.name).toBe(
+      'Rugged Design',
+    );
+
+    const other = MissionProfiles.instance.getMissionProfileByName(
+      'DiplomaticOperations',
+      CharacterType.Starfleet,
+      2,
+    );
+    result = starshipReducer(result, setStarshipMissionProfile(other));
+    expect(result.starship?.missionProfileStep?.type).toBe(other);
+    expect(result.starship?.missionProfileStep?.talent).toBeUndefined();
+  });
+
+  test('SET_STARSHIP_MISSION_PROFILE_TALENT sets the talent on the mission profile step', () => {
+    const starship = makeStarshipWithFrame();
+    starship.missionProfileStep = new MissionProfileStep(
+      MissionProfiles.instance.getMissionProfileByName(
+        'LogisticalQuartermaster',
+        CharacterType.Starfleet,
+        2,
+      ),
+    );
+    const result = dispatchAll(
+      { starship },
+      setStarshipMissionProfileTalent(new SelectedTalent('Rugged Design')),
+    );
+    expect(result.starship?.missionProfileStep?.talent?.name).toBe(
+      'Rugged Design',
+    );
+  });
+
+  test('SET_STARSHIP_SERVICE_RECORD sets the service record step, preserving selection on type change', () => {
+    const starship = makeStarshipWithFrame();
+    const record = ServiceRecordList.instance.getByType(
+      ServiceRecord.AgingRelic,
+    )!;
+    const result = dispatchAll(
+      { starship },
+      setStarshipServiceRecord(record, undefined, 'Old Timer'),
+    );
+    expect(result.starship?.serviceRecordStep?.type).toBe(record);
+    expect(result.starship?.serviceRecordStep?.selection).toBe('Old Timer');
+  });
+
+  test('SET_STARSHIP_SPACEFRAME_APPEARANCE applies only to custom spaceframes', () => {
+    const custom = makeCustomFrameStarship();
+    const customResult = dispatchAll(
+      { starship: custom },
+      setStarshipSpaceframeAppearance(SpaceframeAppearance.Freighter),
+    );
+    expect(customResult.starship?.spaceframeStep?.appearance).toBe(
+      SpaceframeAppearance.Freighter,
+    );
+
+    const standard = makeStarshipWithFrame();
+    const standardResult = dispatchAll(
+      { starship: standard },
+      setStarshipSpaceframeAppearance(SpaceframeAppearance.Freighter),
+    );
+    expect(standardResult.starship?.spaceframeStep?.appearance).toBeUndefined();
+  });
+
+  test('SET_ADDITIONAL_TALENTS copies the supplied talents', () => {
+    const talent = new SelectedTalent('Bold');
+    const result = dispatchAll(
+      { starship: makeStarshipWithFrame() },
+      setAdditionalTalents([talent]),
+    );
+    expect(result.starship?.additionalTalents).toHaveLength(1);
+    expect(result.starship?.additionalTalents[0]).not.toBe(talent);
+    expect(result.starship?.additionalTalents[0].name).toBe('Bold');
+  });
+
+  test('ADD_STARSHIP_REFIT and DELETE_STARSHIP_REFIT manage the refit list', () => {
+    let result = dispatchAll(
+      { starship: makeStarshipWithFrame() },
+      addStarshipRefit(System.Engines),
+    );
+    expect(result.starship?.refits).toContain(System.Engines);
+    result = dispatchAll(result, deleteStarshipRefit(System.Engines));
+    expect(result.starship?.refits).not.toContain(System.Engines);
+  });
+
+  test('ADD_STARSHIP_WEAPON and DELETE_STARSHIP_WEAPON manage the additional weapons by identity', () => {
+    const phaser = StarshipWeaponRegistry.getWeaponByName('Phaser Banks', 2);
+    let result = dispatchAll(
+      { starship: makeStarshipWithFrame() },
+      addStarshipWeapon(phaser),
+    );
+    expect(result.starship?.additionalWeapons).toHaveLength(1);
+    expect(result.starship?.additionalWeapons[0]).toBe(phaser);
+    result = dispatchAll(result, deleteStarshipWeapon(phaser));
+    expect(result.starship?.additionalWeapons).toHaveLength(0);
+  });
+
+  test('MODIFY_STARSHIP_ADD_ADVANCEMENT adds a system advancement', () => {
+    const result = dispatchAll(
+      { starship: makeStarshipWithFrame() },
+      modifyStarshipAddAdvancement(
+        StarshipAdvancementChoice.System,
+        System.Engines,
+      ),
+    );
+    expect(result.starship?.advancementSteps).toHaveLength(1);
+    expect(result.starship?.advancementSteps[0].choice).toBe(
+      StarshipAdvancementChoice.System,
+    );
+    expect(result.starship?.advancementSteps[0].value).toBe(System.Engines);
+  });
+
+  test('MODIFY_STARSHIP_ADD_ADVANCEMENT copies a talent and records the removal', () => {
+    const talent = new SelectedTalent('Bold');
+    const remove = new SelectedTalent('Rugged Design');
+    const result = dispatchAll(
+      { starship: makeStarshipWithFrame() },
+      modifyStarshipAddAdvancement(
+        StarshipAdvancementChoice.Talent,
+        talent,
+        remove,
+      ),
+    );
+    const step = result.starship
+      ?.advancementSteps[0] as StarshipAdvancementStep;
+    expect(step.value).not.toBe(talent);
+    expect((step.value as SelectedTalent).name).toBe('Bold');
+    expect((step.removeValue as SelectedTalent).name).toBe('Rugged Design');
+  });
+
+  test('NEXT_STARSHIP_WORKFLOW_STEP advances the workflow index', () => {
+    const workflow = ShipBuildWorkflow.createSimpleBuildWorkflow();
+    const result = dispatchAll(
+      { starship: makeStarship(), workflow },
+      nextStarshipWorkflowStep(),
+    );
+    expect(result.workflow?.currentStepIndex).toBe(
+      workflow.currentStepIndex + 1,
+    );
+  });
+
+  test('REWIND_TO_STARSHIP_WORKFLOW_STEP sets the workflow index', () => {
+    const workflow = ShipBuildWorkflow.createSimpleBuildWorkflow();
+    const result = dispatchAll(
+      { starship: makeStarship(), workflow },
+      rewindToStarshipWorkflowStep(0),
+    );
+    expect(result.workflow?.currentStepIndex).toBe(0);
+  });
+
+  test('NEXT_STARSHIP_WORKFLOW_STEP with no workflow wipes the slice', () => {
+    // Historical buggy behavior locked by this characterization test:
+    // a bare `return;` produces `undefined` instead of the prior state.
+    const result = starshipReducer(
+      { starship: makeStarship(), workflow: undefined },
+      nextStarshipWorkflowStep(),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test('REWIND_TO_STARSHIP_WORKFLOW_STEP with no workflow wipes the slice', () => {
+    const result = starshipReducer(
+      { starship: makeStarship(), workflow: undefined },
+      rewindToStarshipWorkflowStep(0),
+    );
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
**Summary**

Part of the Redux refactoring plan (Plan A Phase 4): migrate the starship state slice in WebTools to the @reduxjs/toolkit `createAction`/`createSlice` pattern established in PR #452 and #453, with no behavioral change.

**What changed**

- Adds characterization tests in `tests/state/starshipReducer.test.ts` (29 tests), locking down current behavior before the migration.
- Converts all starship action creators to `createAction` (with prepare callbacks for the multi-argument creators), keeping action type strings and exported creator names identical.
- Converts the starship reducer to `createSlice` using `extraReducers` keyed on the creators; reducer case bodies keep the existing copy-mutate logic (no Immer rewrite).
- Flags and fixes the two latent bare `return;` cases (`NEXT_STARSHIP_WORKFLOW_STEP`, `REWIND_TO_STARSHIP_WORKFLOW_STEP`) that previously wiped the slice to `undefined` when no workflow was present; they now return the prior state.

**Verification**

`full_check.sh` passes from `WebTools/`: 439 tests, `tsc --noEmit`, eslint, and prettier.