### PR TITLE
Refactor character state slice to RTK createAction/createSlice

### DIFF
--- a/WebTools/src/state/characterActions.ts
+++ b/WebTools/src/state/characterActions.ts
@@ -1,3 +1,4 @@
+import { createAction } from '@reduxjs/toolkit';
 import type { Character, CharacterRank } from '../common/character';
 import type { CharacterType } from '../common/characterType';
 import type { Age } from '../helpers/age';
@@ -108,542 +109,364 @@ export enum StepContext {
   FinishingTouches,
 }
 
-export function setCharacter(character: Character, replacementHash?: number) {
-  const payload = { character: character, replacementHash: replacementHash };
-  return {
-    type: SET_CHARACTER,
-    payload: payload,
-  };
-}
+export const setCharacter = createAction(
+  SET_CHARACTER,
+  (character: Character, replacementHash?: number) => ({
+    payload: { character, replacementHash },
+  }),
+);
 
-export function addCharacterBorgImplant(type: BorgImplantType) {
-  const payload = { type: type };
-  return {
-    type: ADD_CHARACTER_BORG_IMPLANT,
-    payload: payload,
-  };
-}
+export const addCharacterBorgImplant = createAction(
+  ADD_CHARACTER_BORG_IMPLANT,
+  (type: BorgImplantType) => ({ payload: { type } }),
+);
 
-export function addCharacterBorgImplantSpeciesOption(type: BorgImplantType) {
-  const payload = { type: type };
-  return {
-    type: ADD_CHARACTER_BORG_IMPLANT_SPECIES_OPTION,
-    payload: payload,
-  };
-}
+export const addCharacterBorgImplantSpeciesOption = createAction(
+  ADD_CHARACTER_BORG_IMPLANT_SPECIES_OPTION,
+  (type: BorgImplantType) => ({ payload: { type } }),
+);
 
-export function addCharacterUntappedPotentialAttribute(attribute: Attribute) {
-  const payload = { attribute: attribute };
-  return {
-    type: ADD_CHARACTER_UNTAPPED_POTENTIAL_ATTRIBUTE,
-    payload: payload,
-  };
-}
+export const addCharacterUntappedPotentialAttribute = createAction(
+  ADD_CHARACTER_UNTAPPED_POTENTIAL_ATTRIBUTE,
+  (attribute: Attribute) => ({ payload: { attribute } }),
+);
 
-export function removeCharacterBorgImplant(type: BorgImplantType) {
-  const payload = { type: type };
-  return {
-    type: REMOVE_CHARACTER_BORG_IMPLANT,
-    payload: payload,
-  };
-}
+export const removeCharacterBorgImplant = createAction(
+  REMOVE_CHARACTER_BORG_IMPLANT,
+  (type: BorgImplantType) => ({ payload: { type } }),
+);
 
-export function removeCharacterBorgImplantSpeciesOption(type: BorgImplantType) {
-  const payload = { type: type };
-  return {
-    type: REMOVE_CHARACTER_BORG_IMPLANT_SPECIES_OPTION,
-    payload: payload,
-  };
-}
+export const removeCharacterBorgImplantSpeciesOption = createAction(
+  REMOVE_CHARACTER_BORG_IMPLANT_SPECIES_OPTION,
+  (type: BorgImplantType) => ({ payload: { type } }),
+);
 
-export function setCharacterSpecies(
-  species: Species,
-  attributes: Attribute[] = [],
-  mixedSpecies?: Species,
-  originalSpecies?: Species,
-  customSpeciesName?: string,
-  decrementAttributes: Attribute[] = [],
-) {
-  const payload = {
-    species: species,
-    attributes: attributes,
-    mixedSpecies: mixedSpecies,
-    originalSpecies: originalSpecies,
-    customSpeciesName: customSpeciesName,
-    decrementAttributes: decrementAttributes,
-  };
-  const ability = SpeciesAbilityList.instance.getBySpecies(species);
-  if (ability && (ability.source == null || hasSource(ability.source))) {
-    payload['ability'] = ability;
-  }
-  return {
-    type: SET_CHARACTER_SPECIES,
-    payload: payload,
-  };
-}
+export const setCharacterSpecies = createAction(
+  SET_CHARACTER_SPECIES,
+  (
+    species: Species,
+    attributes: Attribute[] = [],
+    mixedSpecies?: Species,
+    originalSpecies?: Species,
+    customSpeciesName?: string,
+    decrementAttributes: Attribute[] = [],
+  ) => {
+    const payload: any = {
+      species,
+      attributes,
+      mixedSpecies,
+      originalSpecies,
+      customSpeciesName,
+      decrementAttributes,
+    };
+    const ability = SpeciesAbilityList.instance.getBySpecies(species);
+    if (ability && (ability.source == null || hasSource(ability.source))) {
+      payload['ability'] = ability;
+    }
+    return { payload };
+  },
+);
 
-export function setSupportingCharacterSupervisory(supervisory: boolean) {
-  const payload = { supervisory: supervisory };
-  return {
-    type: SET_SUPPORTING_CHARACTER_SUPERVISORY,
-    payload: payload,
-  };
-}
+export const setSupportingCharacterSupervisory = createAction(
+  SET_SUPPORTING_CHARACTER_SUPERVISORY,
+  (supervisory: boolean) => ({ payload: { supervisory } }),
+);
 
-export function setSupportingCharacterDepartments(disciplines: Department[]) {
-  const payload = { disciplines: disciplines };
-  return {
-    type: SET_SUPPORTING_CHARACTER_DISCIPLINES,
-    payload: payload,
-  };
-}
+export const setSupportingCharacterDepartments = createAction(
+  SET_SUPPORTING_CHARACTER_DISCIPLINES,
+  (disciplines: Department[]) => ({ payload: { disciplines } }),
+);
 
-export function setNpcCharacterDepartments(departments: number[]) {
-  const payload = { departments: departments };
-  return {
-    type: SET_NPC_CHARACTER_DEPARTMENTS,
-    payload: payload,
-  };
-}
+export const setNpcCharacterDepartments = createAction(
+  SET_NPC_CHARACTER_DEPARTMENTS,
+  (departments: number[]) => ({ payload: { departments } }),
+);
 
-export function setNpcCharacterAttributes(attributes: number[]) {
-  const payload = { attributes: attributes };
-  return {
-    type: SET_NPC_CHARACTER_ATTRIBUTES,
-    payload: payload,
-  };
-}
+export const setNpcCharacterAttributes = createAction(
+  SET_NPC_CHARACTER_ATTRIBUTES,
+  (attributes: number[]) => ({ payload: { attributes } }),
+);
 
-export function setNpcCharacterTalents(talents: SelectedTalent[]) {
-  const payload = { talents: talents };
-  return {
-    type: SET_NPC_CHARACTER_TALENTS,
-    payload: payload,
-  };
-}
+export const setNpcCharacterTalents = createAction(
+  SET_NPC_CHARACTER_TALENTS,
+  (talents: SelectedTalent[]) => ({ payload: { talents } }),
+);
 
-export function addNpcCharacterEquipment(
-  equipment: EquipmentType | EquipmentModel,
-) {
-  const payload = { equipment: equipment };
-  return {
-    type: ADD_NPC_CHARACTER_EQUIPMENT,
-    payload: payload,
-  };
-}
+export const addNpcCharacterEquipment = createAction(
+  ADD_NPC_CHARACTER_EQUIPMENT,
+  (equipment: EquipmentType | EquipmentModel) => ({ payload: { equipment } }),
+);
 
-export function addNpcCharacterWeapon(weapon: PersonalWeaponType) {
-  const payload = { weapon: weapon };
-  return {
-    type: ADD_NPC_CHARACTER_WEAPON,
-    payload: payload,
-  };
-}
+export const addNpcCharacterWeapon = createAction(
+  ADD_NPC_CHARACTER_WEAPON,
+  (weapon: PersonalWeaponType) => ({ payload: { weapon } }),
+);
 
-export function removeNpcCharacterEquipment(
-  equipment: EquipmentType | EquipmentModel,
-) {
-  const payload = { equipment: equipment };
-  return {
-    type: REMOVE_NPC_CHARACTER_EQUIPMENT,
-    payload: payload,
-  };
-}
+export const removeNpcCharacterEquipment = createAction(
+  REMOVE_NPC_CHARACTER_EQUIPMENT,
+  (equipment: EquipmentType | EquipmentModel) => ({ payload: { equipment } }),
+);
 
-export function removeNpcCharacterWeapon(weapon: PersonalWeaponType) {
-  const payload = { weapon: weapon };
-  return {
-    type: REMOVE_NPC_CHARACTER_WEAPON,
-    payload: payload,
-  };
-}
+export const removeNpcCharacterWeapon = createAction(
+  REMOVE_NPC_CHARACTER_WEAPON,
+  (weapon: PersonalWeaponType) => ({ payload: { weapon } }),
+);
 
-export function setSupportingCharacterAttributes(attributes: Attribute[]) {
-  const payload = { attributes: attributes };
-  return {
-    type: SET_SUPPORTING_CHARACTER_ATTRIBUTES,
-    payload: payload,
-  };
-}
+export const setSupportingCharacterAttributes = createAction(
+  SET_SUPPORTING_CHARACTER_ATTRIBUTES,
+  (attributes: Attribute[]) => ({ payload: { attributes } }),
+);
 
-export function setCharacterEnvironment(
-  environment: Environment,
-  otherSpecies?: Species,
-) {
-  const payload = { environment: environment, otherSpecies: otherSpecies };
-  return {
-    type: SET_CHARACTER_ENVIRONMENT,
-    payload: payload,
-  };
-}
+export const setCharacterEnvironment = createAction(
+  SET_CHARACTER_ENVIRONMENT,
+  (environment: Environment, otherSpecies?: Species) => ({
+    payload: { environment, otherSpecies },
+  }),
+);
 
-export function setCharacterEducation(track: Track, enlisted: boolean = false) {
-  const payload = { track: track, enlisted: enlisted };
-  return {
-    type: SET_CHARACTER_EDUCATION,
-    payload: payload,
-  };
-}
+export const setCharacterEducation = createAction(
+  SET_CHARACTER_EDUCATION,
+  (track: Track, enlisted: boolean = false) => ({
+    payload: { track, enlisted },
+  }),
+);
 
-export function setCharacterFinishingTouches() {
-  return {
-    type: SET_CHARACTER_FINISHING_TOUCHES,
-  };
-}
+export const setCharacterFinishingTouches = createAction(
+  SET_CHARACTER_FINISHING_TOUCHES,
+  () => ({ payload: {} }),
+);
 
-export function addCharacterCareerEvent(
-  eventId: number,
-  context: StepContext,
-  attribute?: Attribute,
-  discipline?: Department,
-) {
-  const payload = {
-    eventId: eventId,
-    attribute: attribute,
-    discipline: discipline,
-    context: context,
-  };
-  return {
-    type: ADD_CHARACTER_CAREER_EVENT,
-    payload: payload,
-  };
-}
+export const addCharacterCareerEvent = createAction(
+  ADD_CHARACTER_CAREER_EVENT,
+  (
+    eventId: number,
+    context: StepContext,
+    attribute?: Attribute,
+    discipline?: Department,
+  ) => ({
+    payload: { eventId, attribute, discipline, context },
+  }),
+);
 
-export function setCharacterEarlyOutlook(
-  earlyOutlook: EarlyOutlookModel,
-  accepted: boolean = true,
-) {
-  const payload = { earlyOutlook: earlyOutlook, accepted: accepted };
-  return {
-    type: SET_CHARACTER_EARLY_OUTLOOK,
-    payload: payload,
-  };
-}
+export const setCharacterEarlyOutlook = createAction(
+  SET_CHARACTER_EARLY_OUTLOOK,
+  (earlyOutlook: EarlyOutlookModel, accepted: boolean = true) => ({
+    payload: { earlyOutlook, accepted },
+  }),
+);
 
-export function setCharacterFocus(
-  focus: string,
-  context: StepContext,
-  index: number = 0,
-) {
-  const payload = { focus: focus, context: context, index: index };
-  return {
-    type: SET_CHARACTER_FOCUS,
-    payload: payload,
-  };
-}
+export const setCharacterFocus = createAction(
+  SET_CHARACTER_FOCUS,
+  (focus: string, context: StepContext, index: number = 0) => ({
+    payload: { focus, context, index },
+  }),
+);
 
-export function addCharacterTalentFocus(
-  focus: string,
-  talent: string,
-  index: number = 0,
-) {
-  const payload = { focus: focus, talent: talent, index: index };
-  return {
-    type: ADD_CHARACTER_TALENT_FOCUS,
-    payload: payload,
-  };
-}
+export const addCharacterTalentFocus = createAction(
+  ADD_CHARACTER_TALENT_FOCUS,
+  (focus: string, talent: string, index: number = 0) => ({
+    payload: { focus, talent, index },
+  }),
+);
 
-export function setCharacterSpeciesAbilityFocus(
-  focus: string,
-  index: number = 0,
-) {
-  const payload = { focus: focus, index: index };
-  return {
-    type: ADD_CHARACTER_SPECIES_ABILITY_FOCUS,
-    payload: payload,
-  };
-}
+export const setCharacterSpeciesAbilityFocus = createAction(
+  ADD_CHARACTER_SPECIES_ABILITY_FOCUS,
+  (focus: string, index: number = 0) => ({ payload: { focus, index } }),
+);
 
-export function setCharacterSpeciesAbilityChoice(
-  choice?: SpeciesAbilityChoice,
-) {
-  const payload = { choice: choice };
-  return {
-    type: SET_CHARACTER_SPECIES_ABILITY_CHOICE,
-    payload: payload,
-  };
-}
+export const setCharacterSpeciesAbilityChoice = createAction(
+  SET_CHARACTER_SPECIES_ABILITY_CHOICE,
+  (choice?: SpeciesAbilityChoice) => ({ payload: { choice } }),
+);
 
-export function addCharacterLogEntry(logEntry: LogEntry) {
-  const payload = { logEntry: logEntry };
-  return {
-    type: ADD_CHARACTER_LOG_ENTRY,
-    payload: payload,
-  };
-}
+export const addCharacterLogEntry = createAction(
+  ADD_CHARACTER_LOG_ENTRY,
+  (logEntry: LogEntry) => ({ payload: { logEntry } }),
+);
 
-export function addCharacterTalentValue(
-  value: string,
-  talent: string | ITalent,
-) {
-  const talentName =
-    typeof talent === 'string' ? (talent as string) : (talent as ITalent).name;
-  const payload = { value: value, talent: talentName };
-  return {
-    type: ADD_CHARACTER_TALENT_VALUE,
-    payload: payload,
-  };
-}
+export const addCharacterTalentValue = createAction(
+  ADD_CHARACTER_TALENT_VALUE,
+  (value: string, talent: string | ITalent) => {
+    const talentName =
+      typeof talent === 'string'
+        ? (talent as string)
+        : (talent as ITalent).name;
+    return { payload: { value, talent: talentName } };
+  },
+);
 
-export function addCharacterTalent(
-  talent: ITalent | SelectedTalent,
-  context: StepContext,
-) {
-  const payload = { talent: talent, context: context };
-  return {
-    type: ADD_CHARACTER_TALENT,
-    payload: payload,
-  };
-}
+export const addCharacterTalent = createAction(
+  ADD_CHARACTER_TALENT,
+  (talent: ITalent | SelectedTalent, context: StepContext) => ({
+    payload: { talent, context },
+  }),
+);
 
-export function setCharacterValue(value: string, context: StepContext) {
-  const payload = { value: value, context: context };
-  return {
-    type: SET_CHARACTER_VALUE,
-    payload: payload,
-  };
-}
+export const setCharacterValue = createAction(
+  SET_CHARACTER_VALUE,
+  (value: string, context: StepContext) => ({ payload: { value, context } }),
+);
 
-export function updateCharacterGeneralEditValueChange(
-  oldValue: ValueAssembly,
-  newValue: string,
-) {
-  const payload = { oldValue: oldValue, newValue: newValue };
-  return {
-    type: UPDATE_CHARACTER_GENERAL_EDIT_VALUE,
-    payload: payload,
-  };
-}
+export const updateCharacterGeneralEditValueChange = createAction(
+  UPDATE_CHARACTER_GENERAL_EDIT_VALUE,
+  (oldValue: ValueAssembly, newValue: string) => ({
+    payload: { oldValue, newValue },
+  }),
+);
 
-export function updateCharacterGeneralEditFocusChange(
-  oldValue: FocusAssembly,
-  newValue: string,
-) {
-  const payload = { oldValue: oldValue, newValue: newValue };
-  return {
-    type: UPDATE_CHARACTER_GENERAL_EDIT_FOCUS,
-    payload: payload,
-  };
-}
+export const updateCharacterGeneralEditFocusChange = createAction(
+  UPDATE_CHARACTER_GENERAL_EDIT_FOCUS,
+  (oldValue: FocusAssembly, newValue: string) => ({
+    payload: { oldValue, newValue },
+  }),
+);
 
-export function updateCharacterGeneralEditTalentChange(
-  oldValue: TalentAssembly,
-  newValue: SelectedTalent,
-) {
-  const payload = { oldValue: oldValue, newValue: newValue };
-  return {
-    type: UPDATE_CHARACTER_GENERAL_EDIT_TALENT,
-    payload: payload,
-  };
-}
+export const updateCharacterGeneralEditTalentChange = createAction(
+  UPDATE_CHARACTER_GENERAL_EDIT_TALENT,
+  (oldValue: TalentAssembly, newValue: SelectedTalent) => ({
+    payload: { oldValue, newValue },
+  }),
+);
 
-export function updateCharacterGeneralEditSpeciesAbility(species: Species) {
-  const payload = {};
-  const ability = SpeciesAbilityList.instance.getBySpecies(species);
-  if (ability && (ability.source == null || hasSource(ability.source))) {
-    payload['ability'] = ability;
-  }
+export const updateCharacterGeneralEditSpeciesAbility = createAction(
+  UPDATE_CHARACTER_GENERAL_EDIT_SPECIES_ABILITY,
+  (species: Species) => {
+    const payload: any = {};
+    const ability = SpeciesAbilityList.instance.getBySpecies(species);
+    if (ability && (ability.source == null || hasSource(ability.source))) {
+      payload['ability'] = ability;
+    }
+    return { payload };
+  },
+);
 
-  return {
-    type: UPDATE_CHARACTER_GENERAL_EDIT_SPECIES_ABILITY,
-    payload: payload,
-  };
-}
+export const addNpcCharacterValue = createAction(
+  ADD_NPC_CHARACTER_VALUE,
+  (value: string, index: number) => ({ payload: { value, index } }),
+);
 
-export function addNpcCharacterValue(value: string, index: number) {
-  const payload = { value: value, index: index };
-  return {
-    type: ADD_NPC_CHARACTER_VALUE,
-    payload: payload,
-  };
-}
+export const setCharacterName = createAction(SET_CHARACTER_NAME, (name) => ({
+  payload: { name },
+}));
 
-export function setCharacterName(name: string) {
-  const payload = { name: name };
-  return {
-    type: SET_CHARACTER_NAME,
-    payload: payload,
-  };
-}
+export const setCharacterPastime = createAction(
+  SET_CHARACTER_PASTIME,
+  (pastime: string) => ({ payload: { pastime } }),
+);
 
-export function setCharacterPastime(pastime: string) {
-  const payload = { pastime: pastime };
-  return {
-    type: SET_CHARACTER_PASTIME,
-    payload: payload,
-  };
-}
+export const setCharacterAge = createAction(SET_CHARACTER_AGE, (age: Age) => ({
+  payload: { age },
+}));
 
-export function setCharacterAge(age: Age) {
-  const payload = { age: age };
-  return {
-    type: SET_CHARACTER_AGE,
-    payload: payload,
-  };
-}
+export const setCharacterLineage = createAction(
+  SET_CHARACTER_LINEAGE,
+  (lineage: string) => ({ payload: { lineage } }),
+);
 
-export function setCharacterLineage(lineage: string) {
-  const payload = { lineage: lineage };
-  return {
-    type: SET_CHARACTER_LINEAGE,
-    payload: payload,
-  };
-}
+export const setCharacterHouse = createAction(
+  SET_CHARACTER_HOUSE,
+  (house: string) => ({ payload: { house } }),
+);
 
-export function setCharacterHouse(house: string) {
-  const payload = { house: house };
-  return {
-    type: SET_CHARACTER_HOUSE,
-    payload: payload,
-  };
-}
+export const setCharacterCareerEventTrait = createAction(
+  SET_CHARACTER_CAREER_EVENT_TRAIT,
+  (trait: string, context: StepContext) => ({ payload: { trait, context } }),
+);
 
-export function setCharacterCareerEventTrait(
-  trait: string,
-  context: StepContext,
-) {
-  const payload = { trait: trait, context: context };
-  return {
-    type: SET_CHARACTER_CAREER_EVENT_TRAIT,
-    payload: payload,
-  };
-}
+export const setCharacterAdditionalTraits = createAction(
+  SET_CHARACTER_ADDITIONAL_TRAITS,
+  (traits: string) => ({ payload: { traits } }),
+);
 
-export function setCharacterAdditionalTraits(traits: string) {
-  const payload = { traits: traits };
-  return {
-    type: SET_CHARACTER_ADDITIONAL_TRAITS,
-    payload: payload,
-  };
-}
+export const setCharacterRank = createAction(
+  SET_CHARACTER_RANK,
+  (name: string, rank?: Rank) => ({ payload: { name, rank } }),
+);
 
-export function setCharacterRank(name: string, rank?: Rank) {
-  const payload = { name: name, rank: rank };
-  return {
-    type: SET_CHARACTER_RANK,
-    payload: payload,
-  };
-}
+export const setCharacterAssignment = createAction(
+  SET_CHARACTER_ROLE,
+  (role?: string | Role, secondaryRole?: Role) => ({
+    payload: { role, secondaryRole },
+  }),
+);
 
-export function setCharacterAssignment(
-  role?: string | Role,
-  secondaryRole?: Role,
-) {
-  const payload = { role: role, secondaryRole: secondaryRole };
-  return {
-    type: SET_CHARACTER_ROLE,
-    payload: payload,
-  };
-}
+export const setCharacterAssignedShip = createAction(
+  SET_CHARACTER_ASSIGNED_SHIP,
+  (assignedShip: string) => ({ payload: { assignedShip } }),
+);
 
-export function setCharacterAssignedShip(assignedShip: string) {
-  const payload = { assignedShip: assignedShip };
-  return {
-    type: SET_CHARACTER_ASSIGNED_SHIP,
-    payload: payload,
-  };
-}
+export const setCharacterPronouns = createAction(
+  SET_CHARACTER_PRONOUNS,
+  (pronouns: string) => ({ payload: { pronouns } }),
+);
 
-export function setCharacterPronouns(pronouns: string) {
-  const payload = { pronouns: pronouns };
-  return {
-    type: SET_CHARACTER_PRONOUNS,
-    payload: payload,
-  };
-}
+export const setCharacterType = createAction(
+  SET_CHARACTER_TYPE,
+  (type: CharacterType) => ({ payload: { type } }),
+);
 
-export function setCharacterType(type: CharacterType) {
-  const payload = { type: type };
-  return {
-    type: SET_CHARACTER_TYPE,
-    payload: payload,
-  };
-}
+export const setCharacterCareerLength = createAction(
+  SET_CHARACTER_CAREER_LENGTH,
+  (careerLength: Career) => ({ payload: { careerLength } }),
+);
 
-export function setCharacterCareerLength(careerLength: Career) {
-  const payload = { careerLength: careerLength };
-  return {
-    type: SET_CHARACTER_CAREER_LENGTH,
-    payload: payload,
-  };
-}
+export const modifyCharacterAttribute = createAction(
+  MODIFY_CHARACTER_ATTRIBUTE,
+  (
+    attribute: Attribute,
+    context: StepContext,
+    positive: boolean = true,
+    forceDecrement: boolean = false,
+  ) => ({ payload: { attribute, context, positive, forceDecrement } }),
+);
 
-export function modifyCharacterAttribute(
-  attribute: Attribute,
-  context: StepContext,
-  positive: boolean = true,
-  forceDecrement: boolean = false,
-) {
-  const payload = {
-    attribute: attribute,
-    context: context,
-    positive: positive,
-    forceDecrement: forceDecrement,
-  };
-  return {
-    type: MODIFY_CHARACTER_ATTRIBUTE,
-    payload: payload,
-  };
-}
+export const modifyCharacterDiscipline = createAction(
+  MODIFY_CHARACTER_DISCIPLINE,
+  (
+    discipline: Department,
+    context: StepContext,
+    positive: boolean = true,
+    primaryDisciplines: Department[] = [],
+    forceDecrement: boolean = false,
+  ) => ({
+    payload: {
+      discipline,
+      context,
+      positive,
+      primaryDisciplines,
+      forceDecrement,
+    },
+  }),
+);
 
-export function modifyCharacterDiscipline(
-  discipline: Department,
-  context: StepContext,
-  positive: boolean = true,
-  primaryDisciplines: Department[] = [],
-  forceDecrement: boolean = false,
-) {
-  const payload = {
-    discipline: discipline,
-    context: context,
-    positive: positive,
-    primaryDisciplines: primaryDisciplines,
-    forceDecrement: forceDecrement,
-  };
-  return {
-    type: MODIFY_CHARACTER_DISCIPLINE,
-    payload: payload,
-  };
-}
+export const modifyCharacterReputation = createAction(
+  MODIFY_CHARACTER_REPUTATION,
+  (delta: number) => ({ payload: { delta } }),
+);
 
-export function modifyCharacterReputation(delta: number) {
-  const payload = { delta: delta };
-  return {
-    type: MODIFY_CHARACTER_REPUTATION,
-    payload: payload,
-  };
-}
+export const modifyCharacterRank = createAction(
+  MODIFY_CHARACTER_RANK,
+  (
+    rank: CharacterRank,
+    type: ModificationType.Promotion | ModificationType.Demotion,
+  ) => ({
+    payload: { rank, type },
+  }),
+);
 
-export function modifyCharacterRank(
-  rank: CharacterRank,
-  type: ModificationType.Promotion | ModificationType.Demotion,
-) {
-  const payload = { rank: rank, type: type };
-  return {
-    type: MODIFY_CHARACTER_RANK,
-    payload: payload,
-  };
-}
-
-export function modifyCharacterAddAdvancement(
-  type: CharacterAdvancementChoice,
-  value: string | Attribute | Department | SelectedTalent,
-  removeValue?: string | Attribute | Department | SelectedTalent,
-  logEntry?: LogEntry,
-  logEntryCallback?: LogEntry,
-) {
-  const payload = {
-    type: type,
-    value: value,
-    logEntry: logEntry,
-    logEntryCallback: logEntryCallback,
-  };
-  if (removeValue != null) {
-    payload['remove'] = removeValue;
-  }
-  return {
-    type: MODIFY_CHARACTER_ADD_ADVANCEMENT,
-    payload: payload,
-  };
-}
+export const modifyCharacterAddAdvancement = createAction(
+  MODIFY_CHARACTER_ADD_ADVANCEMENT,
+  (
+    type: CharacterAdvancementChoice,
+    value: string | Attribute | Department | SelectedTalent,
+    removeValue?: string | Attribute | Department | SelectedTalent,
+    logEntry?: LogEntry,
+    logEntryCallback?: LogEntry,
+  ) => {
+    const payload: any = { type, value, logEntry, logEntryCallback };
+    if (removeValue != null) {
+      payload['remove'] = removeValue;
+    }
+    return { payload };
+  },
+);

--- a/WebTools/src/state/characterReducer.ts
+++ b/WebTools/src/state/characterReducer.ts
@@ -1,3 +1,4 @@
+import { createSlice } from '@reduxjs/toolkit';
 import {
   CareerEventStep,
   CareerStep,
@@ -37,67 +38,72 @@ import {
 import { Track } from '../helpers/trackEnum';
 import { CharacterAdvancementChoice } from '../modify/model/characterAdvancementChoice';
 import {
-  ADD_CHARACTER_BORG_IMPLANT,
-  ADD_CHARACTER_BORG_IMPLANT_SPECIES_OPTION,
-  ADD_CHARACTER_CAREER_EVENT,
-  ADD_CHARACTER_LOG_ENTRY,
-  ADD_CHARACTER_SPECIES_ABILITY_FOCUS,
-  ADD_CHARACTER_TALENT,
-  ADD_CHARACTER_TALENT_FOCUS,
-  ADD_CHARACTER_TALENT_VALUE,
-  ADD_CHARACTER_UNTAPPED_POTENTIAL_ATTRIBUTE,
-  ADD_NPC_CHARACTER_EQUIPMENT,
-  ADD_NPC_CHARACTER_VALUE,
-  ADD_NPC_CHARACTER_WEAPON,
-  MODIFY_CHARACTER_ADD_ADVANCEMENT,
-  MODIFY_CHARACTER_ATTRIBUTE,
-  MODIFY_CHARACTER_DISCIPLINE,
-  MODIFY_CHARACTER_RANK,
-  MODIFY_CHARACTER_REPUTATION,
-  REMOVE_CHARACTER_BORG_IMPLANT,
-  REMOVE_CHARACTER_BORG_IMPLANT_SPECIES_OPTION,
-  REMOVE_NPC_CHARACTER_EQUIPMENT,
-  REMOVE_NPC_CHARACTER_WEAPON,
-  SET_CHARACTER,
-  SET_CHARACTER_ADDITIONAL_TRAITS,
-  SET_CHARACTER_AGE,
-  SET_CHARACTER_ASSIGNED_SHIP,
-  SET_CHARACTER_CAREER_EVENT_TRAIT,
-  SET_CHARACTER_CAREER_LENGTH,
-  SET_CHARACTER_EARLY_OUTLOOK,
-  SET_CHARACTER_EDUCATION,
-  SET_CHARACTER_ENVIRONMENT,
-  SET_CHARACTER_FINISHING_TOUCHES,
-  SET_CHARACTER_FOCUS,
-  SET_CHARACTER_HOUSE,
-  SET_CHARACTER_LINEAGE,
-  SET_CHARACTER_NAME,
-  SET_CHARACTER_PASTIME,
-  SET_CHARACTER_PRONOUNS,
-  SET_CHARACTER_RANK,
-  SET_CHARACTER_ROLE,
-  SET_CHARACTER_SPECIES,
-  SET_CHARACTER_SPECIES_ABILITY_CHOICE,
-  SET_CHARACTER_TYPE,
-  SET_CHARACTER_VALUE,
-  SET_NPC_CHARACTER_ATTRIBUTES,
-  SET_NPC_CHARACTER_DEPARTMENTS,
-  SET_NPC_CHARACTER_TALENTS,
-  SET_SUPPORTING_CHARACTER_ATTRIBUTES,
-  SET_SUPPORTING_CHARACTER_DISCIPLINES,
-  SET_SUPPORTING_CHARACTER_SUPERVISORY,
+  addCharacterBorgImplant,
+  addCharacterBorgImplantSpeciesOption,
+  addCharacterCareerEvent,
+  addCharacterLogEntry,
+  addCharacterTalent,
+  addCharacterTalentFocus,
+  addCharacterTalentValue,
+  addCharacterUntappedPotentialAttribute,
+  addNpcCharacterEquipment,
+  addNpcCharacterValue,
+  addNpcCharacterWeapon,
+  modifyCharacterAddAdvancement,
+  modifyCharacterAttribute,
+  modifyCharacterDiscipline,
+  modifyCharacterRank,
+  modifyCharacterReputation,
+  removeCharacterBorgImplant,
+  removeCharacterBorgImplantSpeciesOption,
+  removeNpcCharacterEquipment,
+  removeNpcCharacterWeapon,
+  setCharacter,
+  setCharacterAdditionalTraits,
+  setCharacterAge,
+  setCharacterAssignedShip,
+  setCharacterAssignment,
+  setCharacterCareerEventTrait,
+  setCharacterCareerLength,
+  setCharacterEarlyOutlook,
+  setCharacterEducation,
+  setCharacterEnvironment,
+  setCharacterFinishingTouches,
+  setCharacterFocus,
+  setCharacterHouse,
+  setCharacterLineage,
+  setCharacterName,
+  setCharacterPastime,
+  setCharacterPronouns,
+  setCharacterRank,
+  setCharacterSpecies,
+  setCharacterSpeciesAbilityChoice,
+  setCharacterSpeciesAbilityFocus,
+  setCharacterType,
+  setCharacterValue,
+  setNpcCharacterAttributes,
+  setNpcCharacterDepartments,
+  setNpcCharacterTalents,
+  setSupportingCharacterAttributes,
+  setSupportingCharacterDepartments,
+  setSupportingCharacterSupervisory,
   StepContext,
-  UPDATE_CHARACTER_GENERAL_EDIT_FOCUS,
-  UPDATE_CHARACTER_GENERAL_EDIT_SPECIES_ABILITY,
-  UPDATE_CHARACTER_GENERAL_EDIT_TALENT,
-  UPDATE_CHARACTER_GENERAL_EDIT_VALUE,
+  updateCharacterGeneralEditFocusChange,
+  updateCharacterGeneralEditSpeciesAbility,
+  updateCharacterGeneralEditTalentChange,
+  updateCharacterGeneralEditValueChange,
 } from './characterActions';
 
 interface CharacterState {
   currentCharacter?: Character;
   isModified: boolean;
-  replacementHash?: string;
+  replacementHash?: number;
 }
+
+const initialState: CharacterState = {
+  currentCharacter: undefined,
+  isModified: false,
+};
 
 const trackDefaults = (track: Track, step: EducationStep) => {
   switch (track) {
@@ -124,7 +130,7 @@ const trackDefaults = (track: Track, step: EducationStep) => {
 };
 
 const withCharacter = (
-  state: CharacterState,
+  state: any,
   action: any,
   mutate: (temp: Character, action: any) => void,
 ): CharacterState => {
@@ -137,12 +143,12 @@ const withCharacter = (
   };
 };
 
-export const characterReducer = (
-  state: CharacterState = { currentCharacter: undefined, isModified: false },
-  action,
-) => {
-  switch (action.type) {
-    case SET_CHARACTER: {
+export const characterSlice = createSlice({
+  name: 'character',
+  initialState: initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(setCharacter, (state, action) => {
       const temp = action.payload.character.copy();
       return {
         ...state,
@@ -150,8 +156,8 @@ export const characterReducer = (
         isModified: false,
         replacementHash: action.payload.replacementHash,
       };
-    }
-    case SET_CHARACTER_SPECIES:
+    });
+    builder.addCase(setCharacterSpecies, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const originalStep = temp.speciesStep;
         temp.speciesStep = new SpeciesStep(action.payload.species);
@@ -205,18 +211,21 @@ export const characterReducer = (
           temp.speciesStep.customSpeciesName = action.payload.customSpeciesName;
         }
       });
-    case SET_CHARACTER_AGE:
+    });
+    builder.addCase(setCharacterAge, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         temp.age = action.payload.age;
         if (temp.educationStep == null) {
           temp.educationStep = new EducationStep();
         }
       });
-    case SET_CHARACTER_CAREER_LENGTH:
+    });
+    builder.addCase(setCharacterCareerLength, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         temp.careerStep = new CareerStep(action.payload.careerLength);
       });
-    case SET_CHARACTER_EDUCATION:
+    });
+    builder.addCase(setCharacterEducation, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const originalStep = temp.educationStep;
         temp.educationStep = new EducationStep(
@@ -239,7 +248,8 @@ export const characterReducer = (
           }
         }
       });
-    case SET_CHARACTER_FINISHING_TOUCHES:
+    });
+    builder.addCase(setCharacterFinishingTouches, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const originalStep = temp.finishingStep;
         temp.finishingStep = new FinishingStep();
@@ -257,7 +267,8 @@ export const characterReducer = (
           }
         }
       });
-    case SET_CHARACTER_ENVIRONMENT:
+    });
+    builder.addCase(setCharacterEnvironment, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const originalStep = temp.environmentStep;
         temp.environmentStep = new EnvironmentStep(
@@ -276,7 +287,8 @@ export const characterReducer = (
           }
         }
       });
-    case SET_CHARACTER_EARLY_OUTLOOK:
+    });
+    builder.addCase(setCharacterEarlyOutlook, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const originalStep = temp.upbringingStep;
         temp.upbringingStep = new UpbringingStep(
@@ -293,7 +305,8 @@ export const characterReducer = (
           temp.upbringingStep.talent = originalStep.talent?.copy();
         }
       });
-    case MODIFY_CHARACTER_ATTRIBUTE:
+    });
+    builder.addCase(modifyCharacterAttribute, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const attribute = action.payload.attribute;
         const positive = action.payload.positive;
@@ -385,7 +398,8 @@ export const characterReducer = (
           }
         }
       });
-    case SET_SUPPORTING_CHARACTER_SUPERVISORY:
+    });
+    builder.addCase(setSupportingCharacterSupervisory, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (temp.supportingStep == null) {
           temp.supportingStep = new SupportingStep();
@@ -404,28 +418,32 @@ export const characterReducer = (
           temp.supportingStep.focuses.splice(3);
         }
       });
-    case SET_SUPPORTING_CHARACTER_DISCIPLINES:
+    });
+    builder.addCase(setSupportingCharacterDepartments, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (temp.supportingStep == null) {
           temp.supportingStep = new SupportingStep();
         }
         temp.supportingStep.disciplines = [...action.payload.disciplines];
       });
-    case SET_NPC_CHARACTER_DEPARTMENTS:
+    });
+    builder.addCase(setNpcCharacterDepartments, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (temp.npcGenerationStep == null) {
           temp.npcGenerationStep = new NpcGenerationStep();
         }
         temp.npcGenerationStep.departments = [...action.payload.departments];
       });
-    case SET_NPC_CHARACTER_ATTRIBUTES:
+    });
+    builder.addCase(setNpcCharacterAttributes, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (temp.npcGenerationStep == null) {
           temp.npcGenerationStep = new NpcGenerationStep();
         }
         temp.npcGenerationStep.attributes = [...action.payload.attributes];
       });
-    case SET_NPC_CHARACTER_TALENTS:
+    });
+    builder.addCase(setNpcCharacterTalents, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (temp.npcGenerationStep == null) {
           temp.npcGenerationStep = new NpcGenerationStep();
@@ -434,14 +452,16 @@ export const characterReducer = (
           ...action.payload.talents.map((t) => t.copy()),
         ];
       });
-    case ADD_CHARACTER_LOG_ENTRY:
+    });
+    builder.addCase(addCharacterLogEntry, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (temp.improvements == null) {
           temp.improvements = [];
         }
         temp.improvements.push(action.payload.logEntry);
       });
-    case ADD_NPC_CHARACTER_EQUIPMENT:
+    });
+    builder.addCase(addNpcCharacterEquipment, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (temp.npcGenerationStep == null) {
           temp.npcGenerationStep = new NpcGenerationStep();
@@ -449,7 +469,8 @@ export const characterReducer = (
 
         temp.npcGenerationStep.equipment.push(action.payload.equipment);
       });
-    case ADD_NPC_CHARACTER_WEAPON:
+    });
+    builder.addCase(addNpcCharacterWeapon, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (temp.npcGenerationStep == null) {
           temp.npcGenerationStep = new NpcGenerationStep();
@@ -457,7 +478,8 @@ export const characterReducer = (
 
         temp.npcGenerationStep.weapons.push(action.payload.weapon);
       });
-    case REMOVE_NPC_CHARACTER_EQUIPMENT:
+    });
+    builder.addCase(removeNpcCharacterEquipment, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const equipment = action.payload.equipment;
         if (temp.npcGenerationStep?.equipment != null) {
@@ -478,7 +500,8 @@ export const characterReducer = (
             });
         }
       });
-    case REMOVE_NPC_CHARACTER_WEAPON:
+    });
+    builder.addCase(removeNpcCharacterWeapon, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const weapon = action.payload.weapon;
         if (temp.npcGenerationStep?.weapons != null) {
@@ -486,14 +509,16 @@ export const characterReducer = (
             temp.npcGenerationStep.weapons.filter((e) => e !== weapon);
         }
       });
-    case SET_SUPPORTING_CHARACTER_ATTRIBUTES:
+    });
+    builder.addCase(setSupportingCharacterAttributes, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (temp.supportingStep == null) {
           temp.supportingStep = new SupportingStep();
         }
         temp.supportingStep.attributes = [...action.payload.attributes];
       });
-    case ADD_CHARACTER_CAREER_EVENT:
+    });
+    builder.addCase(addCharacterCareerEvent, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const event = new CareerEventStep(action.payload.eventId);
         if (action.payload.attribute != null) {
@@ -523,7 +548,8 @@ export const characterReducer = (
           }
         }
       });
-    case SET_CHARACTER_TYPE:
+    });
+    builder.addCase(setCharacterType, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const originalType = temp.type;
         temp.type = action.payload.type;
@@ -548,14 +574,16 @@ export const characterReducer = (
           temp.supportingStep.supervisory = false;
         }
       });
-    case ADD_CHARACTER_UNTAPPED_POTENTIAL_ATTRIBUTE:
+    });
+    builder.addCase(addCharacterUntappedPotentialAttribute, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const talent = temp.getTalentByName(TALENT_NAME_UNTAPPED_POTENTIAL);
         if (talent) {
           talent.attribute = action.payload.attribute;
         }
       });
-    case ADD_CHARACTER_BORG_IMPLANT:
+    });
+    builder.addCase(addCharacterBorgImplant, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const talent = temp.getTalentByName(TALENT_NAME_BORG_IMPLANTS);
         if (talent) {
@@ -565,7 +593,8 @@ export const characterReducer = (
           }
         }
       });
-    case ADD_CHARACTER_BORG_IMPLANT_SPECIES_OPTION:
+    });
+    builder.addCase(addCharacterBorgImplantSpeciesOption, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (
           temp.speciesStep != null &&
@@ -578,7 +607,8 @@ export const characterReducer = (
           temp.speciesStep?.abilityOptions?.implants.splice(0, 1);
         }
       });
-    case REMOVE_CHARACTER_BORG_IMPLANT:
+    });
+    builder.addCase(removeCharacterBorgImplant, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const talent = temp.getTalentByName(TALENT_NAME_BORG_IMPLANTS);
         if (talent) {
@@ -588,21 +618,26 @@ export const characterReducer = (
           }
         }
       });
-    case REMOVE_CHARACTER_BORG_IMPLANT_SPECIES_OPTION:
-      return withCharacter(state, action, (temp, action) => {
-        if (
-          temp.speciesStep != null &&
-          temp.speciesStep?.abilityOptions != null
-        ) {
-          const index = temp.speciesStep?.abilityOptions?.implants?.indexOf(
-            action.payload.type,
-          );
-          if (index >= 0) {
-            temp.speciesStep?.abilityOptions?.implants?.splice(index, 1);
+    });
+    builder.addCase(
+      removeCharacterBorgImplantSpeciesOption,
+      (state, action) => {
+        return withCharacter(state, action, (temp, action) => {
+          if (
+            temp.speciesStep != null &&
+            temp.speciesStep?.abilityOptions != null
+          ) {
+            const index = temp.speciesStep?.abilityOptions?.implants?.indexOf(
+              action.payload.type,
+            );
+            if (index >= 0) {
+              temp.speciesStep?.abilityOptions?.implants?.splice(index, 1);
+            }
           }
-        }
-      });
-    case ADD_CHARACTER_SPECIES_ABILITY_FOCUS:
+        });
+      },
+    );
+    builder.addCase(setCharacterSpeciesAbilityFocus, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (
           temp.speciesStep != null &&
@@ -621,7 +656,8 @@ export const characterReducer = (
           temp.speciesStep.abilityOptions.focuses[index] = focus;
         }
       });
-    case SET_CHARACTER_SPECIES_ABILITY_CHOICE:
+    });
+    builder.addCase(setCharacterSpeciesAbilityChoice, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (
           temp.speciesStep != null &&
@@ -633,7 +669,8 @@ export const characterReducer = (
           temp.speciesStep.abilityOptions.choice = action.payload.choice;
         }
       });
-    case ADD_CHARACTER_TALENT_FOCUS:
+    });
+    builder.addCase(addCharacterTalentFocus, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const talent = temp.getTalentByName(action.payload.talent);
         if (talent) {
@@ -644,14 +681,16 @@ export const characterReducer = (
           talent.focuses[index] = action.payload.focus;
         }
       });
-    case ADD_CHARACTER_TALENT_VALUE:
+    });
+    builder.addCase(addCharacterTalentValue, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const talent = temp.getTalentByName(action.payload.talent);
         if (talent) {
           talent.value = action.payload.value;
         }
       });
-    case ADD_CHARACTER_TALENT:
+    });
+    builder.addCase(addCharacterTalent, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const t = action.payload.talent;
         let talent = undefined;
@@ -682,38 +721,46 @@ export const characterReducer = (
           temp.finishingStep.talent = talent;
         }
       });
-    case SET_CHARACTER_NAME:
+    });
+    builder.addCase(setCharacterName, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         temp.name = action.payload.name;
       });
-    case SET_CHARACTER_PASTIME:
+    });
+    builder.addCase(setCharacterPastime, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         temp.pastime = [action.payload.pastime];
       });
-    case SET_CHARACTER_LINEAGE:
+    });
+    builder.addCase(setCharacterLineage, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         temp.lineage = action.payload.lineage;
       });
-    case SET_CHARACTER_HOUSE:
+    });
+    builder.addCase(setCharacterHouse, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         temp.house = action.payload.house;
       });
-    case SET_CHARACTER_ASSIGNED_SHIP:
+    });
+    builder.addCase(setCharacterAssignedShip, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         temp.assignedShip = action.payload.assignedShip;
       });
-    case SET_CHARACTER_ADDITIONAL_TRAITS:
+    });
+    builder.addCase(setCharacterAdditionalTraits, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         temp.additionalTraits = action.payload.traits;
       });
-    case SET_CHARACTER_RANK:
+    });
+    builder.addCase(setCharacterRank, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         temp.rankValue = new CharacterRank(
           action.payload.name,
           action.payload.rank ?? undefined,
         );
       });
-    case SET_CHARACTER_ROLE:
+    });
+    builder.addCase(setCharacterAssignment, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (action.payload.role != null) {
           if (typeof action.payload.role === 'string') {
@@ -736,11 +783,13 @@ export const characterReducer = (
           temp.jobAssignment = undefined;
         }
       });
-    case SET_CHARACTER_PRONOUNS:
+    });
+    builder.addCase(setCharacterPronouns, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         temp.pronouns = action.payload.pronouns;
       });
-    case SET_CHARACTER_VALUE:
+    });
+    builder.addCase(setCharacterValue, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (temp.stereotype === Stereotype.SupportingCharacter) {
           if (temp.supportingStep == null) {
@@ -769,12 +818,17 @@ export const characterReducer = (
           temp.finishingStep.value = action.payload.value;
         }
       });
-    case UPDATE_CHARACTER_GENERAL_EDIT_SPECIES_ABILITY:
-      return withCharacter(state, action, (temp, action) => {
-        temp.speciesStep.ability = action.payload.ability;
-        temp.speciesStep.talent = undefined;
-      });
-    case UPDATE_CHARACTER_GENERAL_EDIT_VALUE:
+    });
+    builder.addCase(
+      updateCharacterGeneralEditSpeciesAbility,
+      (state, action) => {
+        return withCharacter(state, action, (temp, action) => {
+          temp.speciesStep.ability = action.payload.ability;
+          temp.speciesStep.talent = undefined;
+        });
+      },
+    );
+    builder.addCase(updateCharacterGeneralEditValueChange, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const oldValue = action.payload.oldValue as ValueAssembly;
 
@@ -818,7 +872,8 @@ export const characterReducer = (
           }
         }
       });
-    case UPDATE_CHARACTER_GENERAL_EDIT_FOCUS:
+    });
+    builder.addCase(updateCharacterGeneralEditFocusChange, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const oldValue = action.payload.oldValue as FocusAssembly;
 
@@ -857,7 +912,8 @@ export const characterReducer = (
           }
         }
       });
-    case UPDATE_CHARACTER_GENERAL_EDIT_TALENT:
+    });
+    builder.addCase(updateCharacterGeneralEditTalentChange, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const oldValue = action.payload.oldValue as TalentAssembly;
 
@@ -893,7 +949,8 @@ export const characterReducer = (
           }
         }
       });
-    case ADD_NPC_CHARACTER_VALUE:
+    });
+    builder.addCase(addNpcCharacterValue, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (temp.stereotype === Stereotype.Npc) {
           if (temp.npcGenerationStep == null) {
@@ -906,7 +963,8 @@ export const characterReducer = (
           temp.npcGenerationStep.values[index] = action.payload.value;
         }
       });
-    case SET_CHARACTER_FOCUS:
+    });
+    builder.addCase(setCharacterFocus, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (temp.stereotype === Stereotype.SupportingCharacter) {
           if (temp.supportingStep == null) {
@@ -950,7 +1008,8 @@ export const characterReducer = (
           temp.careerEvents[1].focus = action.payload.focus;
         }
       });
-    case SET_CHARACTER_CAREER_EVENT_TRAIT:
+    });
+    builder.addCase(setCharacterCareerEventTrait, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (
           action.payload.context === StepContext.CareerEvent1 &&
@@ -964,7 +1023,8 @@ export const characterReducer = (
           temp.careerEvents[1].trait = action.payload.trait;
         }
       });
-    case MODIFY_CHARACTER_DISCIPLINE:
+    });
+    builder.addCase(modifyCharacterDiscipline, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         const discipline = action.payload.discipline;
         const positive = action.payload.positive;
@@ -1086,7 +1146,8 @@ export const characterReducer = (
           }
         }
       });
-    case MODIFY_CHARACTER_RANK:
+    });
+    builder.addCase(modifyCharacterRank, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (temp.improvements == null) {
           temp.improvements = [];
@@ -1095,14 +1156,16 @@ export const characterReducer = (
           new Promotion(action.payload.rank, action.payload.type),
         );
       });
-    case MODIFY_CHARACTER_REPUTATION:
+    });
+    builder.addCase(modifyCharacterReputation, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (temp.improvements == null) {
           temp.improvements = [];
         }
         temp.improvements.push(new ReputationChangeStep(action.payload.delta));
       });
-    case MODIFY_CHARACTER_ADD_ADVANCEMENT:
+    });
+    builder.addCase(modifyCharacterAddAdvancement, (state, action) => {
       return withCharacter(state, action, (temp, action) => {
         if (temp.improvements == null) {
           temp.improvements = [];
@@ -1127,8 +1190,8 @@ export const characterReducer = (
         improvement.log = action.payload.logEntry?.id;
         improvement.logCallback = action.payload.logEntryCallback?.id;
       });
+    });
+  },
+});
 
-    default:
-      return state;
-  }
-};
+export const characterReducer = characterSlice.reducer;

--- a/WebTools/tests/state/characterReducer.test.ts
+++ b/WebTools/tests/state/characterReducer.test.ts
@@ -1,0 +1,799 @@
+import '../../src/helpers/species';
+import {
+  Character,
+  SpeciesStep,
+  EnvironmentStep,
+  UpbringingStep,
+  EducationStep,
+  FinishingStep,
+  Promotion,
+  CharacterRank,
+} from '../../src/common/character';
+import {
+  TALENT_NAME_BORG_IMPLANTS,
+  TALENT_NAME_UNTAPPED_POTENTIAL,
+} from '../../src/helpers/talents';
+import { Department } from '../../src/helpers/department';
+import { Environment } from '../../src/helpers/environments';
+import { Attribute } from '../../src/helpers/attributes';
+import { Species } from '../../src/helpers/speciesEnum';
+import { Track } from '../../src/helpers/trackEnum';
+import { Career } from '../../src/helpers/careerEnum';
+import { SelectedTalent } from '../../src/common/selectedTalent';
+import {
+  setCharacter,
+  addCharacterBorgImplant,
+  setCharacterSpecies,
+  setSupportingCharacterSupervisory,
+  setCharacterEducation,
+  setCharacterFinishingTouches,
+  addCharacterCareerEvent,
+  setCharacterEarlyOutlook,
+  setCharacterFocus,
+  setCharacterSpeciesAbilityFocus,
+  setCharacterSpeciesAbilityChoice,
+  setCharacterType,
+  setCharacterEnvironment,
+  setCharacterCareerEventTrait,
+  modifyCharacterAttribute,
+  modifyCharacterDiscipline,
+  setCharacterValue,
+  updateCharacterGeneralEditValueChange,
+  addNpcCharacterValue,
+  addCharacterTalent,
+  addCharacterTalentFocus,
+  addCharacterTalentValue,
+  addCharacterLogEntry,
+  setCharacterAge,
+  setCharacterLineage,
+  setCharacterHouse,
+  setCharacterAdditionalTraits,
+  setCharacterCareerLength,
+  setCharacterName,
+  setCharacterPastime,
+  setCharacterRank,
+  setCharacterAssignment,
+  setCharacterAssignedShip,
+  setCharacterPronouns,
+  StepContext,
+  setNpcCharacterDepartments,
+  setNpcCharacterAttributes,
+  setNpcCharacterTalents,
+  addNpcCharacterEquipment,
+  addNpcCharacterWeapon,
+  removeNpcCharacterEquipment,
+  removeNpcCharacterWeapon,
+  addCharacterUntappedPotentialAttribute,
+  setSupportingCharacterAttributes,
+  setSupportingCharacterDepartments,
+  modifyCharacterReputation,
+  modifyCharacterRank,
+} from '../../src/state/characterActions';
+import { LogEntry } from '../../src/common/logEntry';
+import { NpcType } from '../../src/npc/model/npcType';
+import { Role } from '../../src/helpers/roles';
+import { Rank } from '../../src/helpers/ranks';
+import { Era } from '../../src/helpers/erasEnum';
+import { ModificationType } from '../../src/modify/model/modificationType';
+import {
+  AssemblyContext,
+  ValueAssembly,
+} from '../../src/common/characterAssembly';
+import { UpbringingsHelper } from '../../src/helpers/upbringings';
+import { CharacterType } from '../../src/common/characterType';
+import { SpeciesAbilityChoice } from '../../src/helpers/speciesAbility';
+import { characterReducer } from '../../src/state/characterReducer';
+
+jest.mock('i18next');
+jest.mock('../../src/state/store', () => ({
+  store: {
+    getState: jest.fn(() => ({
+      context: {
+        sources: [1],
+      },
+    })),
+  },
+}));
+
+const makeCharacter = () =>
+  Character.createMainCharacter(CharacterType.Starfleet, Era.NextGeneration, 2);
+
+const makeSupportingCharacter = () =>
+  Character.createSupportingCharacter(Era.NextGeneration, 2);
+
+const makeNpcCharacter = () =>
+  Character.createNpcCharacter(
+    Era.NextGeneration,
+    2,
+    NpcType.Major,
+    CharacterType.Starfleet,
+  );
+
+const stateWithCharacter = (char: Character) => ({
+  currentCharacter: char,
+  isModified: false,
+});
+
+describe('character reducer', () => {
+  describe('SET_CHARACTER', () => {
+    it('copies the character and stores the replacement hash', () => {
+      const char = makeCharacter();
+      const result = characterReducer(
+        stateWithCharacter(makeCharacter()) as any,
+        setCharacter(char, 42),
+      );
+      expect(result.currentCharacter).not.toBe(char);
+      expect(result.currentCharacter).toEqual(char.copy());
+      expect(result.isModified).toBe(false);
+      expect(result.replacementHash).toBe(42);
+    });
+  });
+
+  describe('MODIFY_CHARACTER_ATTRIBUTE', () => {
+    it('adds, limits, and removes species attributes', () => {
+      const char = makeCharacter();
+      char.speciesStep = new SpeciesStep(Species.Human);
+      let state = stateWithCharacter(char) as any;
+      for (let i = 0; i < 5; i++) {
+        state = characterReducer(
+          state,
+          modifyCharacterAttribute(
+            Attribute.Control,
+            StepContext.Species,
+            true,
+          ),
+        );
+      }
+      expect(state.currentCharacter.speciesStep.attributes).toEqual([
+        Attribute.Control,
+        Attribute.Control,
+        Attribute.Control,
+      ]);
+      const removed = characterReducer(
+        state,
+        modifyCharacterAttribute(Attribute.Control, StepContext.Species, false),
+      );
+      expect(removed.currentCharacter.speciesStep.attributes).toEqual([
+        Attribute.Control,
+        Attribute.Control,
+      ]);
+    });
+
+    it('sets the environment attribute', () => {
+      const char = makeCharacter();
+      char.environmentStep = new EnvironmentStep(Environment.Homeworld);
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        modifyCharacterAttribute(
+          Attribute.Daring,
+          StepContext.Environment,
+          true,
+        ),
+      );
+      expect(result.currentCharacter.environmentStep.attribute).toBe(
+        Attribute.Daring,
+      );
+    });
+
+    it('sets the finishing touches attribute', () => {
+      const char = makeCharacter();
+      char.finishingStep = new FinishingStep();
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        modifyCharacterAttribute(
+          Attribute.Reason,
+          StepContext.FinishingTouches,
+          true,
+        ),
+      );
+      expect(result.currentCharacter.finishingStep.attributes).toEqual([
+        Attribute.Reason,
+      ]);
+    });
+  });
+
+  describe('MODIFY_CHARACTER_DISCIPLINE', () => {
+    it('adds education disciplines', () => {
+      const char = makeCharacter();
+      char.educationStep = new EducationStep(Track.Command);
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        modifyCharacterDiscipline(
+          Department.Command,
+          StepContext.Education,
+          true,
+        ),
+      );
+      expect(result.currentCharacter.educationStep.disciplines).toEqual([
+        Department.Command,
+      ]);
+    });
+  });
+
+  describe('SET_CHARACTER_SPECIES', () => {
+    it('sets the species and its attributes', () => {
+      const char = makeCharacter();
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterSpecies(Species.Human, [
+          Attribute.Control,
+          Attribute.Daring,
+        ]),
+      );
+      expect(result.currentCharacter.speciesStep.species).toBe(Species.Human);
+      expect(result.currentCharacter.speciesStep.attributes).toEqual([
+        Attribute.Control,
+        Attribute.Daring,
+      ]);
+    });
+
+    it('re-selecting the same species preserves the talent', () => {
+      const char = makeCharacter();
+      char.speciesStep = new SpeciesStep(Species.Human);
+      char.speciesStep.talent = new SelectedTalent('Bold');
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterSpecies(Species.Human),
+      );
+      expect(result.currentCharacter.speciesStep.talent).toEqual(
+        new SelectedTalent('Bold'),
+      );
+      expect(result.currentCharacter.speciesStep).not.toBe(char.speciesStep);
+    });
+
+    it('replaces the species and resets attributes when changing species', () => {
+      const char = makeCharacter();
+      char.speciesStep = new SpeciesStep(Species.Betazoid);
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterSpecies(Species.Human, [Attribute.Reason]),
+      );
+      expect(result.currentCharacter.speciesStep.species).toBe(Species.Human);
+      expect(result.currentCharacter.speciesStep.attributes).toEqual([
+        Attribute.Reason,
+      ]);
+    });
+  });
+
+  describe('SET_CHARACTER_ENVIRONMENT', () => {
+    it('re-selecting the same environment preserves the discipline', () => {
+      const char = makeCharacter();
+      char.environmentStep = new EnvironmentStep(Environment.BusyColony);
+      char.environmentStep.discipline = Department.Security;
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterEnvironment(Environment.BusyColony),
+      );
+      expect(result.currentCharacter.environmentStep.discipline).toBe(
+        Department.Security,
+      );
+    });
+
+    it('clears the discipline when the environment changes', () => {
+      const char = makeCharacter();
+      char.environmentStep = new EnvironmentStep(Environment.BusyColony);
+      char.environmentStep.discipline = Department.Security;
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterEnvironment(Environment.Homeworld),
+      );
+      expect(result.currentCharacter.environmentStep.discipline).toBe(
+        undefined,
+      );
+    });
+  });
+
+  describe('SET_CHARACTER_EDUCATION', () => {
+    it('re-selecting the same track preserves the selections', () => {
+      const char = makeCharacter();
+      char.educationStep = new EducationStep(Track.Command);
+      char.educationStep.attributes = [Attribute.Control];
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterEducation(Track.Command),
+      );
+      expect(result.currentCharacter.educationStep.attributes).toEqual([
+        Attribute.Control,
+      ]);
+    });
+  });
+
+  describe('SET_CHARACTER_EARLY_OUTLOOK', () => {
+    it('re-selecting the same upbringing preserves the selections', () => {
+      const outlook = UpbringingsHelper.getAllUpbringings(
+        CharacterType.Starfleet,
+      )[0];
+      const char = makeCharacter();
+      char.upbringingStep = new UpbringingStep(outlook);
+      char.upbringingStep.discipline = Department.Command;
+      char.upbringingStep.focus = 'Leadership';
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterEarlyOutlook(outlook),
+      );
+      expect(result.currentCharacter.upbringingStep.discipline).toBe(
+        Department.Command,
+      );
+      expect(result.currentCharacter.upbringingStep.focus).toBe('Leadership');
+    });
+  });
+
+  describe('SET_CHARACTER_FOCUS', () => {
+    it('sets the early outlook focus', () => {
+      const outlook = UpbringingsHelper.getAllUpbringings(
+        CharacterType.Starfleet,
+      )[0];
+      const char = makeCharacter();
+      char.upbringingStep = new UpbringingStep(outlook);
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterFocus('Leadership', StepContext.EarlyOutlook),
+      );
+      expect(result.currentCharacter.upbringingStep.focus).toBe('Leadership');
+    });
+  });
+
+  describe('SET_CHARACTER_FINISHING_TOUCHES', () => {
+    it('preserves the value and talent but resets low-total attributes', () => {
+      const char = makeCharacter();
+      char.finishingStep = new FinishingStep();
+      char.finishingStep.attributes = [Attribute.Control];
+      char.finishingStep.value = 'Worn with Age';
+      char.finishingStep.talent = new SelectedTalent('Bold');
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterFinishingTouches(),
+      );
+      expect(result.currentCharacter.finishingStep.value).toBe('Worn with Age');
+      expect(result.currentCharacter.finishingStep.talent).toEqual(
+        new SelectedTalent('Bold'),
+      );
+      expect(result.currentCharacter.finishingStep.attributes).toEqual([]);
+    });
+  });
+
+  describe('ADD_CHARACTER_BORG_IMPLANT', () => {
+    it('caps the implants at three', () => {
+      const char = makeCharacter();
+      char.speciesStep = new SpeciesStep(Species.Human);
+      char.speciesStep.talent = new SelectedTalent(TALENT_NAME_BORG_IMPLANTS);
+      let state = stateWithCharacter(char) as any;
+      for (let i = 0; i < 5; i++) {
+        state = characterReducer(state, addCharacterBorgImplant(i));
+      }
+      const talent = state.currentCharacter.getTalentByName(
+        TALENT_NAME_BORG_IMPLANTS,
+      );
+      expect(talent.implants).toEqual([2, 3, 4]);
+    });
+  });
+
+  describe('ADD_CHARACTER_TALENT / ADD_CHARACTER_TALENT_FOCUS / ADD_CHARACTER_TALENT_VALUE', () => {
+    it('adds a talent to the species step', () => {
+      const char = makeCharacter();
+      char.speciesStep = new SpeciesStep(Species.Human);
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        addCharacterTalent(
+          new SelectedTalent('Shield Operator'),
+          StepContext.Species,
+        ),
+      );
+      expect(result.currentCharacter.speciesStep.talent).toEqual(
+        new SelectedTalent('Shield Operator'),
+      );
+    });
+
+    it('adds a focus to an existing talent', () => {
+      const char = makeCharacter();
+      char.speciesStep = new SpeciesStep(Species.Human);
+      char.speciesStep.talent = new SelectedTalent('Shield Operator');
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        addCharacterTalentFocus('Fit', 'Shield Operator', 0),
+      );
+      expect(result.currentCharacter.speciesStep.talent.focuses).toEqual([
+        'Fit',
+      ]);
+    });
+
+    it('sets a value on an existing talent', () => {
+      const char = makeCharacter();
+      char.speciesStep = new SpeciesStep(Species.Human);
+      char.speciesStep.talent = new SelectedTalent('Integrity');
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        addCharacterTalentValue('Worn with Age', 'Integrity'),
+      );
+      expect(result.currentCharacter.speciesStep.talent.value).toBe(
+        'Worn with Age',
+      );
+    });
+
+    it('sets the untapped potential attribute', () => {
+      const char = makeCharacter();
+      char.speciesStep = new SpeciesStep(Species.Human);
+      char.speciesStep.talent = new SelectedTalent(
+        TALENT_NAME_UNTAPPED_POTENTIAL,
+      );
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        addCharacterUntappedPotentialAttribute(Attribute.Reason),
+      );
+      expect(result.currentCharacter.speciesStep.talent.attribute).toBe(
+        Attribute.Reason,
+      );
+    });
+  });
+
+  describe('ADD_CHARACTER_CAREER_EVENT', () => {
+    it('adds career events', () => {
+      const char = makeCharacter();
+      let state = characterReducer(
+        stateWithCharacter(char) as any,
+        addCharacterCareerEvent(1, StepContext.CareerEvent1),
+      );
+      state = characterReducer(
+        state as any,
+        addCharacterCareerEvent(2, StepContext.CareerEvent2),
+      );
+      expect(state.currentCharacter.careerEvents.length).toBe(2);
+      expect(state.currentCharacter.careerEvents[0].id).toBe(1);
+      expect(state.currentCharacter.careerEvents[1].id).toBe(2);
+    });
+  });
+
+  describe('ADD_CHARACTER_LOG_ENTRY', () => {
+    it('records the log entry as an improvement', () => {
+      const char = makeCharacter();
+      const logEntry = new LogEntry(3);
+      logEntry.adventureTitle = 'Skirmish';
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        addCharacterLogEntry(logEntry),
+      );
+      expect(result.currentCharacter.improvements).toEqual([logEntry]);
+    });
+  });
+
+  describe('supporting characters', () => {
+    it('handles the supervisory flag and value', () => {
+      const char = makeSupportingCharacter();
+      char.supportingStep.value = 'The Needs of the Many';
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setSupportingCharacterSupervisory(true),
+      );
+      expect(result.currentCharacter.supportingStep.supervisory).toBe(true);
+      expect(result.currentCharacter.supportingStep.value).toBe(
+        'The Needs of the Many',
+      );
+    });
+
+    it('sets supporting character departments and attributes', () => {
+      const char = makeSupportingCharacter();
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setSupportingCharacterDepartments([Department.Command]),
+      );
+      const attributesResult = characterReducer(
+        result as any,
+        setSupportingCharacterAttributes([Attribute.Control, Attribute.Daring]),
+      );
+      expect(result.currentCharacter.supportingStep.disciplines).toEqual([
+        Department.Command,
+      ]);
+      expect(
+        attributesResult.currentCharacter.supportingStep.attributes,
+      ).toEqual([Attribute.Control, Attribute.Daring]);
+    });
+  });
+
+  describe('NPC characters', () => {
+    it('sets the NPC departments and attributes', () => {
+      const char = makeNpcCharacter();
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setNpcCharacterDepartments([3, 2, 1, 0, 0, 0]),
+      );
+      expect(result.currentCharacter.npcGenerationStep.departments).toEqual([
+        3, 2, 1, 0, 0, 0,
+      ]);
+      const attributesResult = characterReducer(
+        result as any,
+        setNpcCharacterAttributes([8, 8, 8, 7, 7, 7]),
+      );
+      expect(
+        attributesResult.currentCharacter.npcGenerationStep.attributes,
+      ).toEqual([8, 8, 8, 7, 7, 7]);
+    });
+
+    it('adds values via the SET_NPC_CHARACTER_VALUE action', () => {
+      const char = makeNpcCharacter();
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        addNpcCharacterValue('Cunning', 2),
+      );
+      expect(result.currentCharacter.npcGenerationStep.values[2]).toBe(
+        'Cunning',
+      );
+    });
+
+    it('adds and removes equipment', () => {
+      const char = makeNpcCharacter();
+      const equipment = {
+        type: undefined,
+        name: 'Type-2 Phaser',
+        protection: 0,
+      };
+      let result = characterReducer(
+        stateWithCharacter(char) as any,
+        addNpcCharacterEquipment(equipment as any),
+      );
+      expect(result.currentCharacter.npcGenerationStep.equipment).toEqual([
+        equipment,
+      ]);
+      result = characterReducer(
+        result as any,
+        removeNpcCharacterEquipment(equipment as any),
+      );
+      expect(result.currentCharacter.npcGenerationStep.equipment).toEqual([]);
+    });
+
+    it('adds and removes weapons', () => {
+      const char = makeNpcCharacter();
+      const weapon = {};
+      let result = characterReducer(
+        stateWithCharacter(char) as any,
+        addNpcCharacterWeapon(weapon as any),
+      );
+      expect(result.currentCharacter.npcGenerationStep.weapons).toEqual([
+        weapon,
+      ]);
+      result = characterReducer(
+        result as any,
+        removeNpcCharacterWeapon(weapon as any),
+      );
+      expect(result.currentCharacter.npcGenerationStep.weapons).toEqual([]);
+    });
+
+    it('copies the NPC talents', () => {
+      const char = makeNpcCharacter();
+      const talent = new SelectedTalent('Bold');
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setNpcCharacterTalents([talent]),
+      );
+      expect(result.currentCharacter.npcGenerationStep.talents).toEqual([
+        talent,
+      ]);
+      expect(result.currentCharacter.npcGenerationStep.talents[0]).not.toBe(
+        talent,
+      );
+    });
+  });
+
+  describe('reputation and rank', () => {
+    it('modifies reputation', () => {
+      const char = makeCharacter();
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        modifyCharacterReputation(1),
+      );
+      expect(result.currentCharacter.reputation).toBe(4);
+    });
+
+    it('records a promotion', () => {
+      const char = makeCharacter();
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        modifyCharacterRank(
+          new CharacterRank('Commander', Rank.Commander),
+          ModificationType.Promotion,
+        ),
+      );
+      expect(result.currentCharacter.improvements[0]).toBeInstanceOf(Promotion);
+      expect(
+        (result.currentCharacter.improvements[0] as Promotion).rank.name,
+      ).toBe('Commander');
+    });
+  });
+
+  describe('simple setters', () => {
+    const cases: [string, any, (c: Character) => any][] = [
+      ['name', setCharacterName('Jean-Luc Picard'), (c) => c.name],
+      ['pastime', setCharacterPastime('Chess'), (c) => c.pastime],
+      ['lineage', setCharacterLineage('Family'), (c) => c.lineage],
+      ['house', setCharacterHouse('House of Mogh'), (c) => c.house],
+      ['pronouns', setCharacterPronouns('they/them'), (c) => c.pronouns],
+      [
+        'additionalTraits',
+        setCharacterAdditionalTraits('Brave'),
+        (c) => c.additionalTraits,
+      ],
+      [
+        'rankValue',
+        setCharacterRank('Captain', Rank.Captain),
+        (c) => c.rankValue,
+      ],
+      [
+        'assignedShip',
+        setCharacterAssignedShip('USS Enterprise'),
+        (c) => c.assignedShip,
+      ],
+    ];
+
+    it.each(cases)('sets the %s', (_label, action, selector) => {
+      const char = makeCharacter();
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        action,
+      ) as any;
+      switch (_label) {
+        case 'name':
+          expect(selector(result.currentCharacter)).toBe('Jean-Luc Picard');
+          break;
+        case 'pastime':
+          expect(selector(result.currentCharacter)).toEqual(['Chess']);
+          break;
+        case 'lineage':
+          expect(selector(result.currentCharacter)).toBe('Family');
+          break;
+        case 'house':
+          expect(selector(result.currentCharacter)).toBe('House of Mogh');
+          break;
+        case 'pronouns':
+          expect(selector(result.currentCharacter)).toBe('they/them');
+          break;
+        case 'additionalTraits':
+          expect(selector(result.currentCharacter)).toBe('Brave');
+          break;
+        case 'rankValue':
+          expect(selector(result.currentCharacter).name).toBe('Captain');
+          break;
+        case 'assignedShip':
+          expect(selector(result.currentCharacter)).toBe('USS Enterprise');
+          break;
+      }
+    });
+
+    it.each([
+      [
+        'age',
+        setCharacterAge(makeCharacter().age),
+        (c: Character) => c.age,
+      ] as any,
+    ])('sets the %s', (_label, action, selector) => {
+      const source = makeCharacter();
+      const char = makeCharacter();
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterAge(source.age),
+      ) as any;
+      expect(result.currentCharacter.age).toBe(source.age);
+    });
+  });
+
+  describe('role/assignment and career length', () => {
+    it('sets the role via SET_CHARACTER_ROLE', () => {
+      const char = makeCharacter();
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterAssignment(Role.CommandingOfficer),
+      );
+      expect(result.currentCharacter.role).toBe(Role.CommandingOfficer);
+    });
+
+    it('sets the job assignment when given a string role', () => {
+      const char = makeCharacter();
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterAssignment('Chief Engineer'),
+      );
+      expect(result.currentCharacter.jobAssignment).toBe('Chief Engineer');
+    });
+
+    it('sets the career length', () => {
+      const char = makeCharacter();
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterCareerLength(Career.Veteran),
+      );
+      expect(result.currentCharacter.careerStep?.career).toBe(Career.Veteran);
+    });
+  });
+
+  describe('character type changes', () => {
+    it('sets the character type to Cadet', () => {
+      const char = makeCharacter();
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterType(CharacterType.Cadet),
+      );
+      expect(result.currentCharacter.type).toBe(CharacterType.Cadet);
+    });
+  });
+
+  describe('value and career event updates', () => {
+    it('sets a value via SET_CHARACTER_VALUE', () => {
+      const char = makeCharacter();
+      char.environmentStep = new EnvironmentStep(Environment.Homeworld);
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterValue('The Needs of the Many', StepContext.Environment),
+      );
+      expect(result.currentCharacter.environmentStep?.value).toBe(
+        'The Needs of the Many',
+      );
+    });
+
+    it('sets the career event trait', () => {
+      const char = makeCharacter();
+      let state = characterReducer(
+        stateWithCharacter(char) as any,
+        addCharacterCareerEvent(1, StepContext.CareerEvent1),
+      );
+      state = characterReducer(
+        state as any,
+        setCharacterCareerEventTrait('Anomaly', StepContext.CareerEvent1),
+      );
+      expect(state.currentCharacter.careerEvents[0].trait).toBe('Anomaly');
+    });
+  });
+
+  describe('general edit updates', () => {
+    it('updates a value via UPDATE_CHARACTER_GENERAL_EDIT_VALUE', () => {
+      const char = makeCharacter();
+      char.educationStep = new EducationStep(Track.Command);
+      char.educationStep.value = 'Old Value';
+      const result = characterReducer(
+        stateWithCharacter(char) as any,
+        updateCharacterGeneralEditValueChange(
+          new ValueAssembly('Old Value', AssemblyContext.Education, 0),
+          'New Value',
+        ),
+      );
+      expect(result.currentCharacter.educationStep?.value).toBe('New Value');
+    });
+  });
+
+  describe('species ability', () => {
+    it('adds a species ability focus', () => {
+      const char = makeCharacter();
+      let state = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterSpecies(Species.Human),
+      );
+      state = characterReducer(
+        state as any,
+        setCharacterSpeciesAbilityFocus('Navigation, Spaceflight'),
+      );
+      expect(state.currentCharacter.speciesStep.abilityOptions.focuses[0]).toBe(
+        'Navigation, Spaceflight',
+      );
+    });
+
+    it('sets the species ability choice', () => {
+      const char = makeCharacter();
+      let state = characterReducer(
+        stateWithCharacter(char) as any,
+        setCharacterSpecies(Species.Human),
+      );
+      state = characterReducer(
+        state as any,
+        setCharacterSpeciesAbilityChoice(SpeciesAbilityChoice.Choice2),
+      );
+      expect(state.currentCharacter.speciesStep.abilityOptions.choice).toBe(
+        SpeciesAbilityChoice.Choice2,
+      );
+    });
+  });
+
+  it('uses the default state when state is undefined', () => {
+    const result = characterReducer(
+      undefined as any,
+      setCharacter(makeCharacter()),
+    );
+    expect(result.currentCharacter).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
Migrates the character state slice to Redux Toolkit, following the pattern established by PR #452/#453/#454.

## Changes
- **characterActions.ts**: convert the manual action-type string constants + function creators to RTK `createAction`. Preserves:
  - all creator function names (no importer changes needed)
  - the type-string constants
  - the `StepContext` enum
  - conditional `payload['ability']` (species ability) and `payload['remove']` (advancement) keys
  - the `addNpcCharacterValue` literal `'SET_NPC_CHARACTER_VALUE'` constant mismatch (bug preserved — locked by characterization test)
- **characterReducer.ts**: convert the `switch`/case reducer to `createSlice` + `extraReducers` builder. Still exports `characterReducer` (not `characterSlice`) so `store.ts` is untouched.
- Fixes a latent type bug: `CharacterState.replacementHash` was typed `string` but all consumers pass a number — previously masked by the untyped reducer function.

## Testing
- Added characterization test suite (49 tests) for the character reducer — commit 1.
- `full_check.sh` passes (tests + typecheck + lint + prettier).