### PR TITLE
Add golden output snapshot tests for VTT exporters

### DIFF
--- a/WebTools/tests/vtt/__snapshots__/fantasyGroundsVttExport.test.ts.snap
+++ b/WebTools/tests/vtt/__snapshots__/fantasyGroundsVttExport.test.ts.snap
@@ -1,0 +1,633 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FantasyGrounds XML export golden output exports a fully-populated 2e main character 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<root version="4.3" dataversion="20230221" release="2|CoreRPG:6">
+  <character>
+    <attributes>
+      <control>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">7</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">7</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </control>
+      <daring>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">11</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">11</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </daring>
+      <fitness>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">9</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">9</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </fitness>
+      <insight>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">8</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">8</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </insight>
+      <presence>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">9</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">9</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </presence>
+      <reason>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">8</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">8</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </reason>
+    </attributes>
+    <determination type="number">0</determination>
+    <career type="string">CareerType.solo.experienced.name</career>
+    <careerevent>
+      <id-0001>
+        <attributes>
+          <id-0001>
+            <name type="string">daring</name>
+          </id-0001>
+        </attributes>
+        <desc type="formattedtext">
+          <p>The ship the character was serving on was lost, destroyed during a mission, and the character was one of the few who survived.</p>
+          <p/>
+          <p>- What was the ship’s mission? Was it something routine that went horribly wrong, or was it something perilous? What destroyed the ship?</p>
+          <p>- How many survivors were there? How long did it take before they were recovered?</p>
+        </desc>
+        <disciplines>
+          <id-0001>
+            <name type="string">security</name>
+          </id-0001>
+        </disciplines>
+        <focus type="number">1</focus>
+        <link type="windowreference">
+          <class>careerevent</class>
+          <recordname>....careerevent.id-0001</recordname>
+        </link>
+        <locked type="number">0</locked>
+        <name type="string">Ship Destroyed</name>
+        <trait type="number">0</trait>
+        <value type="number">0</value>
+      </id-0001>
+      <id-0002>
+        <attributes>
+          <id-0001>
+            <name type="string">control</name>
+          </id-0001>
+        </attributes>
+        <desc type="formattedtext">
+          <p>The character was part of a delegation that helped negotiate a treaty, agreement, or alliance with a culture outside the Federation. What culture was the treaty with? What was it for?</p>
+        </desc>
+        <disciplines>
+          <id-0001>
+            <name type="string">command</name>
+          </id-0001>
+        </disciplines>
+        <focus type="number">1</focus>
+        <link type="windowreference">
+          <class>careerevent</class>
+          <recordname>....careerevent.id-0002</recordname>
+        </link>
+        <locked type="number">0</locked>
+        <name type="string">Negotiate a Treaty</name>
+        <trait type="number">0</trait>
+        <value type="number">0</value>
+      </id-0002>
+    </careerevent>
+    <careerlink type="windowreference">
+      <class>career</class>
+      <recordname>reference.career.id-0002@Star Trek Adventures Core Rulebook</recordname>
+    </careerlink>
+    <disciplines>
+      <command>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">3</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">3</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </command>
+      <conn>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">1</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">1</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </conn>
+      <security>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">2</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">2</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </security>
+      <engineering>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">4</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">4</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </engineering>
+      <science>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">2</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">2</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </science>
+      <medicine>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">2</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">2</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </medicine>
+    </disciplines>
+    <environment type="string">Environment.common.starshipOrStarbase.name</environment>
+    <environmentlink type="windowreference">
+      <class/>
+      <recordname/>
+    </environmentlink>
+    <focuslist>
+      <id-0001>
+        <name type="string">Compassion</name>
+      </id-0001>
+      <id-0002>
+        <name type="string">Engineering</name>
+      </id-0002>
+      <id-0003>
+        <name type="string">Astrophysics</name>
+      </id-0003>
+      <id-0004>
+        <name type="string">Starship Design</name>
+      </id-0004>
+      <id-0005>
+        <name type="string">Survival</name>
+      </id-0005>
+      <id-0006>
+        <name type="string">Diplomacy</name>
+      </id-0006>
+    </focuslist>
+    <hp>
+      <misc type="number">0</misc>
+      <total type="number">9</total>
+      <wounds type="number">0</wounds>
+    </hp>
+    <inventorylist>
+      <id-0001>
+        <area type="number">0</area>
+        <category type="string">Equipment</category>
+        <cost type="string"></cost>
+        <count type="number">1</count>
+        <intense type="number">0</intense>
+        <locked type="number">0</locked>
+        <name type="string">[object Object]</name>
+        <notes type="formattedtext">
+          <h>Uniform</h>
+        </notes>
+        <piercing type="number">0</piercing>
+        <viscious type="number">0</viscious>
+      </id-0001>
+      <id-0002>
+        <area type="number">0</area>
+        <category type="string">Equipment</category>
+        <cost type="string"></cost>
+        <count type="number">1</count>
+        <intense type="number">0</intense>
+        <locked type="number">0</locked>
+        <name type="string">[object Object]</name>
+        <notes type="formattedtext">
+          <h>Communicator</h>
+        </notes>
+        <piercing type="number">0</piercing>
+        <viscious type="number">0</viscious>
+      </id-0002>
+      <id-0003>
+        <area type="number">0</area>
+        <category type="string">Equipment</category>
+        <cost type="string"></cost>
+        <count type="number">1</count>
+        <intense type="number">0</intense>
+        <locked type="number">0</locked>
+        <name type="string">[object Object]</name>
+        <notes type="formattedtext">
+          <h>Tricorder</h>
+        </notes>
+        <piercing type="number">0</piercing>
+        <viscious type="number">0</viscious>
+      </id-0003>
+      <id-0004>
+        <area type="number">0</area>
+        <category type="string">Equipment</category>
+        <cost type="string"></cost>
+        <count type="number">1</count>
+        <intense type="number">0</intense>
+        <locked type="number">0</locked>
+        <name type="string">[object Object]</name>
+        <notes type="formattedtext">
+          <h>Engineering Kit</h>
+        </notes>
+        <piercing type="number">0</piercing>
+        <viscious type="number">0</viscious>
+      </id-0004>
+      <id-0005>
+        <area type="number">0</area>
+        <category type="string">Weapon</category>
+        <cost type="string">Standard Issue</cost>
+        <count type="number">1</count>
+        <damagerating type="number">2</damagerating>
+        <dmgeffect/>
+        <intense type="number">0</intense>
+        <locked type="number">0</locked>
+        <name type="string">Weapon.personal.strike.name</name>
+        <notes type="formattedtext">
+          <h>Weapon.personal.strike.name</h>
+        </notes>
+        <piercing type="number">0</piercing>
+        <size type="string">1h</size>
+        <vicious type="number">0</vicious>
+        <weapquality/>
+      </id-0005>
+      <id-0006>
+        <area type="number">0</area>
+        <category type="string">Weapon</category>
+        <cost type="string">Standard Issue</cost>
+        <count type="number">1</count>
+        <damagerating type="number">4</damagerating>
+        <dmgeffect/>
+        <intense type="number">0</intense>
+        <locked type="number">0</locked>
+        <name type="string">Weapon.personal.phaser2.name</name>
+        <notes type="formattedtext">
+          <h>Weapon.personal.phaser2.name</h>
+        </notes>
+        <piercing type="number">0</piercing>
+        <qualities type="string">Charge</qualities>
+        <size type="string">1h</size>
+        <type type="string">ranged</type>
+        <vicious type="number">0</vicious>
+        <weapquality>
+          <id-0001>
+            <name type="string">Charge</name>
+            <rank type="number">1</rank>
+          </id-0001>
+        </weapquality>
+      </id-0006>
+    </inventorylist>
+    <milestones>
+      <arc type="number">0</arc>
+      <spotlight type="number">0</spotlight>
+      <standard type="number">0</standard>
+    </milestones>
+    <name type="string">Rhea Voss</name>
+    <notes>
+      <id-0001>
+        <name type="string">Traits: Steadfast</name>
+        <text type="formattedtext">
+          <p/>
+        </text>
+      </id-0001>
+      <id-0002>
+        <name type="string">Pronouns: she/her</name>
+        <text type="formattedtext">
+          <p/>
+        </text>
+      </id-0002>
+      <id-0003>
+        <name type="string">Value: Curiosity</name>
+        <text type="formattedtext">
+          <p/>
+        </text>
+      </id-0003>
+      <id-0004>
+        <name type="string">Value: Courage</name>
+        <text type="formattedtext">
+          <p/>
+        </text>
+      </id-0004>
+      <id-0005>
+        <name type="string">Value: Harmony</name>
+        <text type="formattedtext">
+          <p/>
+        </text>
+      </id-0005>
+      <id-0006>
+        <name type="string">Value: Initiative</name>
+        <text type="formattedtext">
+          <p/>
+        </text>
+      </id-0006>
+    </notes>
+    <primary_specieslink type="windowreference">
+      <class/>
+      <recordname/>
+    </primary_specieslink>
+    <rank type="string">5</rank>
+    <reputation type="number">5</reputation>
+    <resistance>
+      <misc type="number">0</misc>
+      <total type="number">0</total>
+    </resistance>
+    <role type="string">Chief Engineer / Operations Manager</role>
+    <secondary_specieslink type="windowreference">
+      <class/>
+      <recordname/>
+    </secondary_specieslink>
+    <species type="string">Human</species>
+    <supportchars/>
+    <talent>
+      <id-0001>
+        <desc type="formattedtext">
+          <p/>
+        </desc>
+        <locked type="number">0</locked>
+        <multiple type="number">0</multiple>
+        <name type="string">Bold</name>
+        <requirement type="string">None</requirement>
+      </id-0001>
+      <id-0002>
+        <desc type="formattedtext">
+          <p/>
+        </desc>
+        <locked type="number">0</locked>
+        <multiple type="number">0</multiple>
+        <name type="string">Cautious</name>
+        <requirement type="string">None</requirement>
+      </id-0002>
+      <id-0003>
+        <desc type="formattedtext">
+          <p>The character is inexperienced, but talented and with a bright future in Starfleet. The character may not have or increase any Attribute above 11, or any Discipline above 4 while they have this Talent (and may have to adjust Attributes and Disciplines accordingly at the end of character creation). Whenever the character succeeds at a Task for which they bought one or more additional dice with either Momentum or Threat, they may roll 1CD. The character receives bonus Momentum equal to the roll, and adds one point to Threat if an Effect is rolled. The character cannot gain any higher rank than lieutenant (junior grade) while they possess this Talent.</p>
+        </desc>
+        <locked type="number">0</locked>
+        <multiple type="number">0</multiple>
+        <name type="string">Untapped Potential</name>
+        <requirement type="string">Only available to Young characters</requirement>
+      </id-0003>
+      <id-0004>
+        <desc type="formattedtext">
+          <p>Whenever you assist another character using your Command Discipline, the character being assisted may re-roll one d20.</p>
+        </desc>
+        <locked type="number">0</locked>
+        <multiple type="number">0</multiple>
+        <name type="string">Advisor</name>
+        <requirement type="string">Requires Command 2+, Main Character only</requirement>
+      </id-0004>
+      <id-0005>
+        <desc type="formattedtext">
+          <p>The ship’s Crew Support increases by one. This increase is cumulative if multiple Main Characters in the group select it.</p>
+        </desc>
+        <locked type="number">0</locked>
+        <multiple type="number">0</multiple>
+        <name type="string">Supervisor</name>
+        <requirement type="string">None</requirement>
+      </id-0005>
+    </talent>
+    <token type="token"/>
+    <training type="string">Sciences Track</training>
+    <traininglink type="windowreference">
+      <class/>
+      <recordname/>
+    </traininglink>
+    <upbringing type="string">Business or Trade</upbringing>
+    <upbringinglink type="windowreference">
+      <class>upbringing</class>
+      <recordname>reference.upbringing.id-0002@Star Trek Adventures Core Rulebook</recordname>
+    </upbringinglink>
+  </character>
+</root>"
+`;
+
+exports[`FantasyGrounds XML export golden output exports a fully-populated NPC 1`] = `
+"<?xml version="1.0" encoding="utf-8"?>
+<root version="4.3" dataversion="20230221" release="2|CoreRPG:6">
+  <npc>
+    <attacks>
+      <id-0001>
+        <area type="number">0</area>
+        <damagerating type="number">2</damagerating>
+        <intense type="number">0</intense>
+        <name type="string">Weapon.personal.strike.name</name>
+        <lethality type="string">nonlethal</lethality>
+        <piercing type="number">0</piercing>
+        <tn type="number">10</tn>
+        <vicious type="number">0</vicious>
+      </id-0001>
+      <id-0002>
+        <area type="number">0</area>
+        <damagerating type="number">4</damagerating>
+        <intense type="number">0</intense>
+        <name type="string">Weapon.personal.phaser2.name</name>
+        <piercing type="number">0</piercing>
+        <tn type="number">9</tn>
+        <type type="string">ranged</type>
+        <vicious type="number">0</vicious>
+      </id-0002>
+      <id-0003>
+        <area type="number">0</area>
+        <damagerating type="number">4</damagerating>
+        <intense type="number">0</intense>
+        <name type="string">Weapon.personal.phaser2.name</name>
+        <piercing type="number">0</piercing>
+        <tn type="number">9</tn>
+        <type type="string">ranged</type>
+        <vicious type="number">0</vicious>
+      </id-0003>
+    </attacks>
+    <attributes>
+      <control>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">7</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">7</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </control>
+      <daring>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">8</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">8</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </daring>
+      <fitness>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">7</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">7</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </fitness>
+      <insight>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">9</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">9</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </insight>
+      <presence>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">8</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">8</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </presence>
+      <reason>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">9</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">9</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </reason>
+    </attributes>
+    <description type="formattedtext">
+      <p>A Vulcan liaison aboard a starbase.</p>
+    </description>
+    <disciplines>
+      <command>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">3</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">3</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </command>
+      <conn>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">2</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">2</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </conn>
+      <security>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">2</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">2</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </security>
+      <engineering>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">1</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">1</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </engineering>
+      <science>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">1</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">1</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </science>
+      <medicine>
+        <careerevent type="number">0</careerevent>
+        <edit type="number">1</edit>
+        <environment type="number">0</environment>
+        <misc type="number">0</misc>
+        <species type="number">0</species>
+        <total type="number">1</total>
+        <training type="number">0</training>
+        <upbringing type="number">0</upbringing>
+      </medicine>
+    </disciplines>
+    <focuses type="string">Meditation, Vulcan Nerve Pinch, Science</focuses>
+    <hptotal type="number">7</hptotal>
+    <name type="string">Sub-Commander Torel</name>
+    <resistance>
+      <total type="number">0</total>
+    </resistance>
+    <specialrules>
+      <id-0001>
+        <desc type="formattedtext">
+          <p/>
+        </desc>
+        <name type="string">Bold</name>
+      </id-0001>
+      <id-0002>
+        <desc type="formattedtext">
+          <p>The character is wise and experienced, and draws upon inner reserves of willpower and determination in a more measured and considered way. Whenever the character spends a point of Determination, roll 1CD. If an Effect is rolled, immediately regain that spent point of Determination. The character has a rank of at least Lieutenant Commander.</p>
+        </desc>
+        <name type="string">Veteran</name>
+      </id-0002>
+    </specialrules>
+    <token type="token"/>
+    <traits type="string">Vulcan</traits>
+    <type type="string">Notable Character</type>
+    <values type="string">Logic, Peace</values>
+  </npc>
+</root>"
+`;

--- a/WebTools/tests/vtt/__snapshots__/foundryVttExporter.test.ts.snap
+++ b/WebTools/tests/vtt/__snapshots__/foundryVttExporter.test.ts.snap
@@ -1,0 +1,2423 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FoundryVTT export golden output exports a fully-populated 1e character 1`] = `
+"{
+    "name": "Rhea Voss",
+    "type": "character",
+    "img": "icons/svg/mystery-man.svg",
+    "system": {
+        "notes": "<p>An engineer who documented the founding days of the new frontier.</p><p><a href=\\"https://sta.bcholmes.org/view?s=eJx9VE1v2zAM_SuBzgaGbjvllibdVmBdi6brpciBlZlYqC15lGQsKPLf92g7btCPAT7YFPn4-PjkZxMTC4e0b9nMTUPOLysSsoiawozhdSLZ1swJIRZC5Bf_Td_Z4yO54BH21GjmbcU0uw8xItSxRD2cnxUmt4_i_A6PmT8bVyL1PEfnOcZruRMqGQVkLbeJcZgkc2G2weaIzAstZFYAZJUuWtfWiLw5SlSzT9phpHMe6tIcDoVpKSanoQez8KmS0IY67PaoWfzJ1AbvbDSbwlgSoF10gEHnh4Hq2QuVdZbOdVQr25TEPeakfVb0Hrk12ywuaZck5NKQ-DRDXBj4h2LA__qCv0JxaMjuX2MtQ9OQxzAgKeSfTob86RgsPHldj-J9wcCxZes4alorriHZI_NHBgaSYqJ-vBfelz66XaUAt0wRS9scBtJ-XBne7ZPOBFRvWffbc-YeZxETJK32UWUser_EyrWzFQPWq7AjidXHy5v0VMTN6fh9i6MAhbni0llFQBJWkQd5stCO3_PAkjI8CnUP40jD6DcStnAfDIptAol95yT4ZizuLXqc41r07ZEiv9r7N5fUwv935cQRZghR_QAiSnZuFmWuVXSKqhOXazRD-Pd6PbsHkSzasAWtkL3aI1b8qepvpoSaJ57LyvH22FT3yzb4EnJf6ul1O17TeEUefUX7uwawHTeT0cerTmVH2G8vA65DFZzV8N2g6jTMpO46A71zMYjqO8EAvAnjr-FDu87GnfacdZDPINaE0m2d7QnfDWA3E9hJB-E2p-Pf5-QDIJvDP2rGqUA\\">Original sheet.</a></p>",
+        "assignment": "USS Venture",
+        "attributes": {
+            "control": {
+                "label": "sta.actor.character.attribute.control",
+                "value": "7",
+                "selected": false
+            },
+            "daring": {
+                "label": "sta.actor.character.attribute.daring",
+                "value": "10",
+                "selected": false
+            },
+            "fitness": {
+                "label": "sta.actor.character.attribute.fitness",
+                "value": "8",
+                "selected": false
+            },
+            "insight": {
+                "label": "sta.actor.character.attribute.insight",
+                "value": "8",
+                "selected": false
+            },
+            "presence": {
+                "label": "sta.actor.character.attribute.presence",
+                "value": "9",
+                "selected": false
+            },
+            "reason": {
+                "label": "sta.actor.character.attribute.reason",
+                "value": "8",
+                "selected": false
+            }
+        },
+        "careerevents": "Ship Destroyed, Negotiate a Treaty",
+        "characterrole": "Chief Engineer / Operations Manager",
+        "careerpath": "CharacterType.name.starfleet / Sciences Track",
+        "determination": {
+            "value": 1,
+            "max": 3
+        },
+        "disciplines": {
+            "command": {
+                "label": "sta.actor.character.discipline.command",
+                "value": "3",
+                "selected": false
+            },
+            "conn": {
+                "label": "sta.actor.character.discipline.conn",
+                "value": "1",
+                "selected": false
+            },
+            "security": {
+                "label": "sta.actor.character.discipline.security",
+                "value": "2",
+                "selected": false
+            },
+            "engineering": {
+                "label": "sta.actor.character.discipline.engineering",
+                "value": "5",
+                "selected": false
+            },
+            "science": {
+                "label": "sta.actor.character.discipline.science",
+                "value": "1",
+                "selected": false
+            },
+            "medicine": {
+                "label": "sta.actor.character.discipline.medicine",
+                "value": "2",
+                "selected": false
+            }
+        },
+        "experience": "",
+        "milestones": "",
+        "pastimes": "Anthropology, Aquaponics",
+        "pronouns": "she/her",
+        "rank": "Lieutenant Commander",
+        "reputation": 10,
+        "stress": {
+            "value": 10,
+            "max": 10
+        },
+        "traits": "",
+        "environment": "Environment.common.starshipOrStarbase.name",
+        "species": "Human",
+        "upbringing": "Business or Trade (A)"
+    },
+    "items": [
+        {
+            "name": "Curiosity",
+            "type": "value",
+            "img": "systems/sta/assets/compendia/icons/values-core/value-core.svg",
+            "system": {
+                "description": "",
+                "used": false
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Courage",
+            "type": "value",
+            "img": "systems/sta/assets/compendia/icons/values-core/value-core.svg",
+            "system": {
+                "description": "",
+                "used": false
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Engineering",
+            "type": "focus",
+            "img": "systems/sta/assets/compendia/icons/focuses-core/focus-core.svg",
+            "system": {
+                "description": ""
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Astrophysics",
+            "type": "focus",
+            "img": "systems/sta/assets/compendia/icons/focuses-core/focus-core.svg",
+            "system": {
+                "description": ""
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Starship Design",
+            "type": "focus",
+            "img": "systems/sta/assets/compendia/icons/focuses-core/focus-core.svg",
+            "system": {
+                "description": ""
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Survival",
+            "type": "focus",
+            "img": "systems/sta/assets/compendia/icons/focuses-core/focus-core.svg",
+            "system": {
+                "description": ""
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Diplomacy",
+            "type": "focus",
+            "img": "systems/sta/assets/compendia/icons/focuses-core/focus-core.svg",
+            "system": {
+                "description": ""
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Steadfast",
+            "type": "trait",
+            "img": "systems/sta/assets/icons/VoyagerCombadgeIcon.png",
+            "system": {
+                "description": "",
+                "quantity": 1
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "a6BIWTTe2ysAI7Jm": 3
+            },
+            "flags": {},
+            "_stats": {
+                "compendiumSource": null,
+                "duplicateSource": null,
+                "coreVersion": "13.336",
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "a6BIWTTe2ysAI7Jm",
+                "exportSource": null
+            }
+        },
+        {
+            "name": "Uniform",
+            "type": "item",
+            "img": "systems/sta/assets/compendia/icons/items-core/placeholder.webp",
+            "system": {
+                "description": "",
+                "quantity": 1,
+                "opportunity": 0,
+                "escalation": 0
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Communicator",
+            "type": "item",
+            "img": "systems/sta/assets/compendia/icons/items-core/communicator.webp",
+            "system": {
+                "description": "",
+                "quantity": 1,
+                "opportunity": 0,
+                "escalation": 0
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Tricorder",
+            "type": "item",
+            "img": "systems/sta/assets/compendia/icons/items-core/tricorder.webp",
+            "system": {
+                "description": "",
+                "quantity": 1,
+                "opportunity": 0,
+                "escalation": 0
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Engineering Kit",
+            "type": "item",
+            "img": "systems/sta/assets/compendia/icons/items-core/engineering_kit.webp",
+            "system": {
+                "description": "",
+                "quantity": 1,
+                "opportunity": 0,
+                "escalation": 0
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Bold",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-core.svg",
+            "system": {
+                "description": "<p></p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Cautious",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-core.svg",
+            "system": {
+                "description": "<p></p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Supervisor",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-command.svg",
+            "system": {
+                "description": "<p>The ship’s Crew Support increases by one. This increase is cumulative if multiple Main Characters in the group select it.</p>",
+                "talenttype": {
+                    "typeenum": "discipline",
+                    "description": "Command",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Weapon.personal.strike.name",
+            "type": "characterweapon",
+            "img": "systems/sta/assets/compendia/icons/weapons-core/unarmed-strike.webp",
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "system": {
+                "description": "",
+                "damage": 1,
+                "severity": 1,
+                "range": "Melee",
+                "hands": 1,
+                "qualities": {
+                    "area": false,
+                    "intense": false,
+                    "knockdown": true,
+                    "accurate": false,
+                    "charge": false,
+                    "cumbersome": false,
+                    "deadly": false,
+                    "debilitating": false,
+                    "grenade": false,
+                    "inaccurate": false,
+                    "nonlethal": true,
+                    "hiddenx": 0,
+                    "piercingx": 0,
+                    "viciousx": 0,
+                    "opportunity": 0,
+                    "escalation": 0,
+                    "stun": true
+                },
+                "opportunity": null,
+                "escalation": null
+            },
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Weapon.personal.phaser2.name",
+            "type": "characterweapon",
+            "img": "systems/sta/assets/compendia/icons/weapons-core/phaser-type-2.webp",
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "system": {
+                "description": "",
+                "damage": 3,
+                "severity": 3,
+                "range": "Ranged",
+                "hands": 1,
+                "qualities": {
+                    "area": false,
+                    "intense": false,
+                    "knockdown": false,
+                    "accurate": false,
+                    "charge": true,
+                    "cumbersome": false,
+                    "deadly": true,
+                    "debilitating": false,
+                    "grenade": false,
+                    "inaccurate": false,
+                    "nonlethal": false,
+                    "hiddenx": 0,
+                    "piercingx": 0,
+                    "viciousx": 0,
+                    "opportunity": 0,
+                    "escalation": 0,
+                    "stun": true
+                },
+                "opportunity": null,
+                "escalation": null
+            },
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        }
+    ],
+    "effects": [],
+    "flags": {
+        "exportSource": {
+            "world": "sta-bcholmes-org",
+            "system": "sta",
+            "coreVersion": "10.291",
+            "systemVersion": "2.4.2"
+        }
+    },
+    "_stats": {
+        "systemId": "sta",
+        "systemVersion": "2.4.2",
+        "coreVersion": "10.291",
+        "createdTime": 1700000000000,
+        "modifiedTime": 1700000000000,
+        "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+    }
+}"
+`;
+
+exports[`FoundryVTT export golden output exports a fully-populated 2e character 1`] = `
+"{
+    "name": "Rhea Voss",
+    "type": "character",
+    "img": "icons/svg/mystery-man.svg",
+    "system": {
+        "notes": "<p>An engineer who documented the founding days of the new frontier.</p><p><a href=\\"https://sta.bcholmes.org/view?s=eJx9VMFu2zAM_ZVA5wDDup16S5NuK7AuRdP1UuTAyExM1JY0SjIaFPn3kYrjpG02IAeHIh_fe6T0amJCRp-2Ac2laYHctAYGK1EzNn14kYDXDWKSEDJI5Be-pO_o5E8i7yTsoNXM-xph9OhjlFCHHPXw8mJsclgxuY38zOWroUpSr3IkhzHO-YGhQikAazEklMPEGcdm7W2OknmthYgKIFkVRUuhkciHowQNuqQdejpXvqnMbjc2Fliy9EQyNqnW0pcgdeisNBSy0GSt-AHcerc9B_bbJQgBq9GdT3JC0BToADGRJjyZiUs1--Abv1GEyZ8MwTuy0SwPFK47KRVRT3sXPh9VLjJ3JDTUiJSYVjlp1xmc071Am5lS4clAaZ_4PJI4o-Dvxnv8r0f8mRT7Fuz2PdbUty048UlIMrjnE8k_CYWFA6eTV7wvIjgGtIRR0wJTC7xV37JgSFJMUOQded-4SJtaAe4RouyDtIEVNcJ-HnR7ClJhiaVS-IinZXWWarAKdP3myLd9Vv22TE7X7KRyEpPYX2-jWj4uaxtrCqMZCoXSuCc8-_cODd4r4vLUqgO5YtbY3GJFVhGWx-2Z-sywwXPbM4UsYmUSB0l7m-7Yr7GIlckLErqO2Lu2Ly435aBjzvq1gojvduQbJb1J_78cA0dZHB91d4TIWpyNtXZ6o_s4vQP0RyfeovcDOTXjxpFckkTdWT8mVUfRc7FDLdNIbnRNdPYbh9VCJOu1WyxGj1KbWXGCmOOz7oyJNX6qyzPFvsHBrWlNuD6Q041E610lQ7_R03no36x4C076srpArcB22A5Xs3_3oOpARJVhyAWuPVkNP-y1DEoHTYss6IOsAUbAW9-_k_-8YKN-swpnFXIhxFpf0ZpsIfywB7sbwE46MIacDk_xyR8BWe7-AiToBoI\\">Original sheet.</a></p>",
+        "assignment": "USS Venture",
+        "attributes": {
+            "control": {
+                "label": "sta.actor.character.attribute.control",
+                "value": "7",
+                "selected": false
+            },
+            "daring": {
+                "label": "sta.actor.character.attribute.daring",
+                "value": "11",
+                "selected": false
+            },
+            "fitness": {
+                "label": "sta.actor.character.attribute.fitness",
+                "value": "9",
+                "selected": false
+            },
+            "insight": {
+                "label": "sta.actor.character.attribute.insight",
+                "value": "8",
+                "selected": false
+            },
+            "presence": {
+                "label": "sta.actor.character.attribute.presence",
+                "value": "9",
+                "selected": false
+            },
+            "reason": {
+                "label": "sta.actor.character.attribute.reason",
+                "value": "8",
+                "selected": false
+            }
+        },
+        "careerevents": "Ship Destroyed, Negotiate a Treaty",
+        "characterrole": "Chief Engineer / Operations Manager",
+        "careerpath": "CharacterType.name.starfleet / Sciences Track",
+        "determination": {
+            "value": 1,
+            "max": 3
+        },
+        "disciplines": {
+            "command": {
+                "label": "sta.actor.character.discipline.command",
+                "value": "3",
+                "selected": false
+            },
+            "conn": {
+                "label": "sta.actor.character.discipline.conn",
+                "value": "1",
+                "selected": false
+            },
+            "security": {
+                "label": "sta.actor.character.discipline.security",
+                "value": "2",
+                "selected": false
+            },
+            "engineering": {
+                "label": "sta.actor.character.discipline.engineering",
+                "value": "4",
+                "selected": false
+            },
+            "science": {
+                "label": "sta.actor.character.discipline.science",
+                "value": "2",
+                "selected": false
+            },
+            "medicine": {
+                "label": "sta.actor.character.discipline.medicine",
+                "value": "2",
+                "selected": false
+            }
+        },
+        "experience": "CareerType.solo.experienced.name",
+        "milestones": "",
+        "pastimes": "Anthropology, Aquaponics",
+        "pronouns": "she/her",
+        "rank": "Lieutenant Commander",
+        "reputation": 5,
+        "stress": {
+            "value": 9,
+            "max": 9
+        },
+        "traits": "",
+        "environment": "Environment.common.starshipOrStarbase.name",
+        "species": "Human",
+        "upbringing": "Business or Trade (A)"
+    },
+    "items": [
+        {
+            "name": "Curiosity",
+            "type": "value",
+            "img": "systems/sta/assets/compendia/icons/values-core/value-core.svg",
+            "system": {
+                "description": "",
+                "used": false
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Courage",
+            "type": "value",
+            "img": "systems/sta/assets/compendia/icons/values-core/value-core.svg",
+            "system": {
+                "description": "",
+                "used": false
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Harmony",
+            "type": "value",
+            "img": "systems/sta/assets/compendia/icons/values-core/value-core.svg",
+            "system": {
+                "description": "",
+                "used": false
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Initiative",
+            "type": "value",
+            "img": "systems/sta/assets/compendia/icons/values-core/value-core.svg",
+            "system": {
+                "description": "",
+                "used": false
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Compassion",
+            "type": "focus",
+            "img": "systems/sta/assets/compendia/icons/focuses-core/focus-core.svg",
+            "system": {
+                "description": ""
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Engineering",
+            "type": "focus",
+            "img": "systems/sta/assets/compendia/icons/focuses-core/focus-core.svg",
+            "system": {
+                "description": ""
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Astrophysics",
+            "type": "focus",
+            "img": "systems/sta/assets/compendia/icons/focuses-core/focus-core.svg",
+            "system": {
+                "description": ""
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Starship Design",
+            "type": "focus",
+            "img": "systems/sta/assets/compendia/icons/focuses-core/focus-core.svg",
+            "system": {
+                "description": ""
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Survival",
+            "type": "focus",
+            "img": "systems/sta/assets/compendia/icons/focuses-core/focus-core.svg",
+            "system": {
+                "description": ""
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Diplomacy",
+            "type": "focus",
+            "img": "systems/sta/assets/compendia/icons/focuses-core/focus-core.svg",
+            "system": {
+                "description": ""
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Steadfast",
+            "type": "trait",
+            "img": "systems/sta/assets/icons/VoyagerCombadgeIcon.png",
+            "system": {
+                "description": "",
+                "quantity": 1
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "a6BIWTTe2ysAI7Jm": 3
+            },
+            "flags": {},
+            "_stats": {
+                "compendiumSource": null,
+                "duplicateSource": null,
+                "coreVersion": "13.336",
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "a6BIWTTe2ysAI7Jm",
+                "exportSource": null
+            }
+        },
+        {
+            "name": "Uniform",
+            "type": "item",
+            "img": "systems/sta/assets/compendia/icons/items-core/placeholder.webp",
+            "system": {
+                "description": "",
+                "quantity": 1,
+                "opportunity": 0,
+                "escalation": 0
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Communicator",
+            "type": "item",
+            "img": "systems/sta/assets/compendia/icons/items-core/communicator.webp",
+            "system": {
+                "description": "",
+                "quantity": 1,
+                "opportunity": 0,
+                "escalation": 0
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Tricorder",
+            "type": "item",
+            "img": "systems/sta/assets/compendia/icons/items-core/tricorder.webp",
+            "system": {
+                "description": "",
+                "quantity": 1,
+                "opportunity": 0,
+                "escalation": 0
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Engineering Kit",
+            "type": "item",
+            "img": "systems/sta/assets/compendia/icons/items-core/engineering_kit.webp",
+            "system": {
+                "description": "",
+                "quantity": 1,
+                "opportunity": 0,
+                "escalation": 0
+            },
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Bold",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-core.svg",
+            "system": {
+                "description": "<p></p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Cautious",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-core.svg",
+            "system": {
+                "description": "<p></p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Untapped Potential",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-career-young.svg",
+            "system": {
+                "description": "<p>The character is inexperienced, but talented and with a bright future in Starfleet. The character may not have or increase any Attribute above 11, or any Discipline above 4 while they have this Talent (and may have to adjust Attributes and Disciplines accordingly at the end of character creation). Whenever the character succeeds at a Task for which they bought one or more additional dice with either Momentum or Threat, they may roll 1CD. The character receives bonus Momentum equal to the roll, and adds one point to Threat if an Effect is rolled. The character cannot gain any higher rank than lieutenant (junior grade) while they possess this Talent.</p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Advisor",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-command.svg",
+            "system": {
+                "description": "<p>Whenever you assist another character using your Command Discipline, the character being assisted may re-roll one d20.</p>",
+                "talenttype": {
+                    "typeenum": "discipline",
+                    "description": "Command",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Supervisor",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-command.svg",
+            "system": {
+                "description": "<p>The ship’s Crew Support increases by one. This increase is cumulative if multiple Main Characters in the group select it.</p>",
+                "talenttype": {
+                    "typeenum": "discipline",
+                    "description": "Command",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "SpeciesAbility.human (Species Ability)",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-human.svg",
+            "system": {
+                "description": "<p>SpeciesAbility.human.description</p>",
+                "talenttype": {
+                    "typeenum": "Species",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Weapon.personal.strike.name",
+            "type": "characterweapon2e",
+            "img": "systems/sta/assets/compendia/icons/weapons-core/unarmed-strike.webp",
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "system": {
+                "description": "",
+                "damage": 2,
+                "severity": 2,
+                "range": "Melee",
+                "hands": 1,
+                "qualities": {
+                    "area": false,
+                    "intense": false,
+                    "knockdown": false,
+                    "accurate": false,
+                    "charge": false,
+                    "cumbersome": false,
+                    "deadly": false,
+                    "debilitating": false,
+                    "grenade": false,
+                    "inaccurate": false,
+                    "nonlethal": false,
+                    "hiddenx": 0,
+                    "piercingx": 0,
+                    "viciousx": 0,
+                    "opportunity": 0,
+                    "escalation": 0,
+                    "stun": true
+                },
+                "opportunity": null,
+                "escalation": null
+            },
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Weapon.personal.phaser2.name",
+            "type": "characterweapon2e",
+            "img": "systems/sta/assets/compendia/icons/weapons-core/phaser-type-2.webp",
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "system": {
+                "description": "",
+                "damage": 4,
+                "severity": 4,
+                "range": "Ranged",
+                "hands": 1,
+                "qualities": {
+                    "area": false,
+                    "intense": false,
+                    "knockdown": false,
+                    "accurate": false,
+                    "charge": true,
+                    "cumbersome": false,
+                    "deadly": true,
+                    "debilitating": false,
+                    "grenade": false,
+                    "inaccurate": false,
+                    "nonlethal": false,
+                    "hiddenx": 0,
+                    "piercingx": 0,
+                    "viciousx": 0,
+                    "opportunity": 0,
+                    "escalation": 0,
+                    "stun": true
+                },
+                "opportunity": null,
+                "escalation": null
+            },
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        }
+    ],
+    "effects": [],
+    "flags": {
+        "exportSource": {
+            "world": "sta-bcholmes-org",
+            "system": "sta",
+            "coreVersion": "10.291",
+            "systemVersion": "2.4.2"
+        }
+    },
+    "_stats": {
+        "systemId": "sta",
+        "systemVersion": "2.4.2",
+        "coreVersion": "10.291",
+        "createdTime": 1700000000000,
+        "modifiedTime": 1700000000000,
+        "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+    }
+}"
+`;
+
+exports[`FoundryVTT export golden output exports a fully-populated 2e starship 1`] = `
+"{
+    "name": "USS Venture",
+    "type": "starship",
+    "img": "systems/sta/assets/icons/ship_icon.png",
+    "system": {
+        "notes": "",
+        "crew": {
+            "value": 12,
+            "max": 12
+        },
+        "departments": {
+            "command": {
+                "label": "sta.actor.starship.department.command",
+                "value": "3",
+                "selected": false
+            },
+            "conn": {
+                "label": "sta.actor.starship.department.conn",
+                "value": "2",
+                "selected": false
+            },
+            "security": {
+                "label": "sta.actor.starship.department.security",
+                "value": "3",
+                "selected": false
+            },
+            "engineering": {
+                "label": "sta.actor.starship.department.engineering",
+                "value": "2",
+                "selected": false
+            },
+            "science": {
+                "label": "sta.actor.starship.department.science",
+                "value": "3",
+                "selected": false
+            },
+            "medicine": {
+                "label": "sta.actor.starship.department.medicine",
+                "value": "2",
+                "selected": false
+            }
+        },
+        "designation": "NCC-70637",
+        "missionprofile": "Battlecruiser",
+        "power": {
+            "value": 16,
+            "max": 16
+        },
+        "refit": "+1 Construct.system.engines, +1 Construct.system.weapons",
+        "resistance": 7,
+        "scale": 6,
+        "shields": {
+            "value": 19,
+            "max": 19
+        },
+        "servicedate": 2372,
+        "spaceframe": "Galaxy Class",
+        "systems": {
+            "communications": {
+                "label": "sta.actor.starship.system.communications",
+                "value": "9",
+                "selected": false
+            },
+            "computers": {
+                "label": "sta.actor.starship.system.computers",
+                "value": "10",
+                "selected": false
+            },
+            "engines": {
+                "label": "sta.actor.starship.system.engines",
+                "value": "11",
+                "selected": false
+            },
+            "sensors": {
+                "label": "sta.actor.starship.system.sensors",
+                "value": "8",
+                "selected": false
+            },
+            "structure": {
+                "label": "sta.actor.starship.system.structure",
+                "value": "10",
+                "selected": false
+            },
+            "weapons": {
+                "label": "sta.actor.starship.system.weapons",
+                "value": "12",
+                "selected": false
+            }
+        },
+        "traits": "Federation Starship, Galaxy Class, Flagship, Hero Ship"
+    },
+    "items": [
+        {
+            "name": "Abundant Personnel",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-ship.svg",
+            "system": {
+                "description": "<p></p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Saucer Separation and Reconnect",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-ship.svg",
+            "system": {
+                "description": "<p></p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Modular Laboratories",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-ship.svg",
+            "system": {
+                "description": "<p>The ship has considerable numbers of empty, multi-purpose compartments that can be converted to laboratories as and when required. At the start of an adventure, the crew may decide how the modular laboratories are configured; this configuration counts as an Advantage which applies to work performed within the laboratories.</p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Redundant Systems",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-ship.svg",
+            "system": {
+                "description": "<p>The ship has multiple additional redundancies that allow it to withstand severe damage more easily. Nominate a single System. When that system becomes Damaged or Disabled, the crew may choose to activate the backups as a Minor Action; if the System was Damaged, it is no longer Damaged. If it was Disabled, it becomes Damaged instead. A System’s backups may only be activated once per adventure, so subsequent damage will have the normal effect.</p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Ablative Armor",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-ship.svg",
+            "system": {
+                "description": "<p>The vessel’s hull plating has an additional ablative layer that disintegrates slowly under extreme temperatures, such as those caused by energy weapons and torpedo blasts, dissipating the energy, and protecting the ship. This plating is replaced periodically. The ship’s Resistance is increased by 2.</p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Secondary Reactors [x1]",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-ship.svg",
+            "system": {
+                "description": "<p>The ship has additional impulse and fusion reactors, that allow the ship to generate far greater quantities of energy. Increase the ship’s normal Power capacity by 5.</p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Redundant Systems",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-ship.svg",
+            "system": {
+                "description": "<p>The ship has multiple additional redundancies that allow it to withstand severe damage more easily. Nominate a single System. When that system becomes Damaged or Disabled, the crew may choose to activate the backups as a Minor Action; if the System was Damaged, it is no longer Damaged. If it was Disabled, it becomes Damaged instead. A System’s backups may only be activated once per adventure, so subsequent damage will have the normal effect.</p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Dedicated Personnel",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-ship.svg",
+            "system": {
+                "description": "<p>The ship gains two additional Crew Support, which may only be used to establish Supporting Characters.</p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Phaser Arrays",
+            "type": "starshipweapon",
+            "img": "systems/sta/assets/compendia/icons/starshipweapons-core/weapon-phaser-array.svg",
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "system": {
+                "description": "",
+                "damage": 0,
+                "range": "medium",
+                "qualities": {
+                    "area": false,
+                    "spread": false,
+                    "dampening": false,
+                    "calibration": false,
+                    "devastating": false,
+                    "highyield": false,
+                    "persistentx": 0,
+                    "piercingx": 0,
+                    "viciousx": 0,
+                    "hiddenx": 0,
+                    "versatilex": 2
+                },
+                "opportunity": null,
+                "escalation": null
+            },
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Phaser Arrays",
+            "type": "starshipweapon2e",
+            "sort": 1000,
+            "img": "systems/sta/assets/compendia/icons/starshipweapons-core/weapon-phaser-array.svg",
+            "system": {
+                "damage": 0,
+                "range": "medium",
+                "includescale": "energy",
+                "description": "",
+                "opportunity": 0,
+                "escalation": 0,
+                "qualities": {
+                    "energy": true,
+                    "torpedo": false,
+                    "area": false,
+                    "calibration": false,
+                    "cumbersome": false,
+                    "dampening": false,
+                    "depleting": false,
+                    "devastating": false,
+                    "highyield": false,
+                    "intense": false,
+                    "jamming": false,
+                    "persistent": false,
+                    "piercing": false,
+                    "slowing": false,
+                    "spread": false,
+                    "hiddenx": 0,
+                    "versatilex": 0
+                }
+            },
+            "effects": [],
+            "folder": null,
+            "flags": {},
+            "_stats": {
+                "coreVersion": "13.346",
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "createdTime": 1775998532666,
+                "modifiedTime": 1775998603845,
+                "lastModifiedBy": "aodUFbctO5o4nV3h"
+            }
+        },
+        {
+            "name": "Photon Torpedoes",
+            "type": "starshipweapon",
+            "img": "systems/sta/assets/compendia/icons/starshipweapons-core/weapon-photon-torpedo.svg",
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "system": {
+                "description": "",
+                "damage": 3,
+                "range": "long",
+                "qualities": {
+                    "area": false,
+                    "spread": false,
+                    "dampening": false,
+                    "calibration": false,
+                    "devastating": false,
+                    "highyield": true,
+                    "persistentx": 0,
+                    "piercingx": 0,
+                    "viciousx": 0,
+                    "hiddenx": 0,
+                    "versatilex": 0
+                },
+                "opportunity": null,
+                "escalation": null
+            },
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Photon Torpedoes",
+            "type": "starshipweapon2e",
+            "sort": 1000,
+            "img": "systems/sta/assets/compendia/icons/starshipweapons-core/weapon-photon-torpedo.svg",
+            "system": {
+                "damage": 3,
+                "range": "long",
+                "includescale": "torpedo",
+                "description": "",
+                "opportunity": 0,
+                "escalation": 0,
+                "qualities": {
+                    "energy": false,
+                    "torpedo": true,
+                    "area": false,
+                    "calibration": false,
+                    "cumbersome": false,
+                    "dampening": false,
+                    "depleting": false,
+                    "devastating": false,
+                    "highyield": true,
+                    "intense": false,
+                    "jamming": false,
+                    "persistent": false,
+                    "piercing": false,
+                    "slowing": false,
+                    "spread": false,
+                    "hiddenx": 0,
+                    "versatilex": 0
+                }
+            },
+            "effects": [],
+            "folder": null,
+            "flags": {},
+            "_stats": {
+                "coreVersion": "13.346",
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "createdTime": 1775998532666,
+                "modifiedTime": 1775998603845,
+                "lastModifiedBy": "aodUFbctO5o4nV3h"
+            }
+        }
+    ],
+    "effects": [],
+    "flags": {
+        "exportSource": {
+            "world": "sta-bcholmes-org",
+            "system": "sta",
+            "coreVersion": "10.291",
+            "systemVersion": "2.4.2"
+        }
+    },
+    "_stats": {
+        "systemId": "sta",
+        "systemVersion": "2.4.2",
+        "coreVersion": "10.291",
+        "createdTime": 1700000000000,
+        "modifiedTime": 1700000000000,
+        "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+    }
+}"
+`;
+
+exports[`FoundryVTT export golden output exports a fully-populated station 1`] = `
+"{
+    "name": "Starbase 24",
+    "type": "starship",
+    "img": "systems/sta/assets/icons/VoyagerCombadgeIcon.png",
+    "system": {
+        "notes": "",
+        "crew": {
+            "value": 12,
+            "max": 12
+        },
+        "departments": {
+            "command": {
+                "label": "sta.actor.starship.department.command",
+                "value": "5",
+                "selected": false
+            },
+            "conn": {
+                "label": "sta.actor.starship.department.conn",
+                "value": "2",
+                "selected": false
+            },
+            "security": {
+                "label": "sta.actor.starship.department.security",
+                "value": "3",
+                "selected": false
+            },
+            "engineering": {
+                "label": "sta.actor.starship.department.engineering",
+                "value": "5",
+                "selected": false
+            },
+            "science": {
+                "label": "sta.actor.starship.department.science",
+                "value": "5",
+                "selected": false
+            },
+            "medicine": {
+                "label": "sta.actor.starship.department.medicine",
+                "value": "5",
+                "selected": false
+            }
+        },
+        "designation": "Starbase 24",
+        "missionprofile": "",
+        "power": {
+            "value": 20,
+            "max": 20
+        },
+        "refit": "",
+        "resistance": 9,
+        "scale": 12,
+        "shields": {
+            "value": 33,
+            "max": 33
+        },
+        "servicedate": "",
+        "spaceframe": "",
+        "systems": {
+            "communications": {
+                "label": "sta.actor.starship.system.communications",
+                "value": "12",
+                "selected": false
+            },
+            "computers": {
+                "label": "sta.actor.starship.system.computers",
+                "value": "11",
+                "selected": false
+            },
+            "engines": {
+                "label": "sta.actor.starship.system.engines",
+                "value": "10",
+                "selected": false
+            },
+            "sensors": {
+                "label": "sta.actor.starship.system.sensors",
+                "value": "13",
+                "selected": false
+            },
+            "structure": {
+                "label": "sta.actor.starship.system.structure",
+                "value": "12",
+                "selected": false
+            },
+            "weapons": {
+                "label": "sta.actor.starship.system.weapons",
+                "value": "10",
+                "selected": false
+            }
+        },
+        "traits": "Starfleet Station, Border Post, High Capacity"
+    },
+    "items": [
+        {
+            "name": "Enhanced Defense Grid [x1]",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-core.svg",
+            "system": {
+                "description": "<p>The station’s Shields are increased by an amount equal to half the station’s Scale.</p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Rugged Design",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-ship.svg",
+            "system": {
+                "description": "<p>The ship is designed with the frontier in mind, with a durable construction and easy access to critical systems that allow repairs to be made easily. Reduce the Difficulty of all Tasks to repair the ship by 1, to a minimum of 1.</p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Secondary Reactors [x2]",
+            "type": "talent",
+            "img": "systems/sta/assets/compendia/icons/talents-core/talent-ship.svg",
+            "system": {
+                "description": "<p>The ship has additional impulse and fusion reactors, that allow the ship to generate far greater quantities of energy. Increase the ship’s normal Power capacity by 5.</p>",
+                "talenttype": {
+                    "typeenum": "general",
+                    "description": "",
+                    "minimum": 0
+                }
+            },
+            "effects": [],
+            "flags": {},
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            },
+            "folder": null,
+            "sort": 0,
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            }
+        },
+        {
+            "name": "Phaser Cannons",
+            "type": "starshipweapon",
+            "img": "systems/sta/assets/compendia/icons/starshipweapons-core/weapon-phaser-cannon.svg",
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "system": {
+                "description": "",
+                "damage": 2,
+                "range": "close",
+                "qualities": {
+                    "area": false,
+                    "spread": false,
+                    "dampening": false,
+                    "calibration": false,
+                    "devastating": false,
+                    "highyield": false,
+                    "persistentx": 0,
+                    "piercingx": 0,
+                    "viciousx": 0,
+                    "hiddenx": 0,
+                    "versatilex": 2
+                },
+                "opportunity": null,
+                "escalation": null
+            },
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Phaser Cannons",
+            "type": "starshipweapon2e",
+            "sort": 1000,
+            "img": "systems/sta/assets/compendia/icons/starshipweapons-core/weapon-phaser-cannon.svg",
+            "system": {
+                "damage": 2,
+                "range": "close",
+                "includescale": "energy",
+                "description": "",
+                "opportunity": 0,
+                "escalation": 0,
+                "qualities": {
+                    "energy": true,
+                    "torpedo": false,
+                    "area": false,
+                    "calibration": false,
+                    "cumbersome": false,
+                    "dampening": false,
+                    "depleting": false,
+                    "devastating": false,
+                    "highyield": false,
+                    "intense": false,
+                    "jamming": false,
+                    "persistent": false,
+                    "piercing": false,
+                    "slowing": false,
+                    "spread": false,
+                    "hiddenx": 0,
+                    "versatilex": 0
+                }
+            },
+            "effects": [],
+            "folder": null,
+            "flags": {},
+            "_stats": {
+                "coreVersion": "13.346",
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "createdTime": 1775998532666,
+                "modifiedTime": 1775998603845,
+                "lastModifiedBy": "aodUFbctO5o4nV3h"
+            }
+        },
+        {
+            "name": "Phaser Arrays",
+            "type": "starshipweapon",
+            "img": "systems/sta/assets/compendia/icons/starshipweapons-core/weapon-phaser-array.svg",
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "system": {
+                "description": "",
+                "damage": 0,
+                "range": "medium",
+                "qualities": {
+                    "area": false,
+                    "spread": false,
+                    "dampening": false,
+                    "calibration": false,
+                    "devastating": false,
+                    "highyield": false,
+                    "persistentx": 0,
+                    "piercingx": 0,
+                    "viciousx": 0,
+                    "hiddenx": 0,
+                    "versatilex": 2
+                },
+                "opportunity": null,
+                "escalation": null
+            },
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Phaser Arrays",
+            "type": "starshipweapon2e",
+            "sort": 1000,
+            "img": "systems/sta/assets/compendia/icons/starshipweapons-core/weapon-phaser-array.svg",
+            "system": {
+                "damage": 0,
+                "range": "medium",
+                "includescale": "energy",
+                "description": "",
+                "opportunity": 0,
+                "escalation": 0,
+                "qualities": {
+                    "energy": true,
+                    "torpedo": false,
+                    "area": false,
+                    "calibration": false,
+                    "cumbersome": false,
+                    "dampening": false,
+                    "depleting": false,
+                    "devastating": false,
+                    "highyield": false,
+                    "intense": false,
+                    "jamming": false,
+                    "persistent": false,
+                    "piercing": false,
+                    "slowing": false,
+                    "spread": false,
+                    "hiddenx": 0,
+                    "versatilex": 0
+                }
+            },
+            "effects": [],
+            "folder": null,
+            "flags": {},
+            "_stats": {
+                "coreVersion": "13.346",
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "createdTime": 1775998532666,
+                "modifiedTime": 1775998603845,
+                "lastModifiedBy": "aodUFbctO5o4nV3h"
+            }
+        },
+        {
+            "name": "Photon Torpedoes",
+            "type": "starshipweapon",
+            "img": "systems/sta/assets/compendia/icons/starshipweapons-core/weapon-photon-torpedo.svg",
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "system": {
+                "description": "",
+                "damage": 3,
+                "range": "long",
+                "qualities": {
+                    "area": false,
+                    "spread": false,
+                    "dampening": false,
+                    "calibration": false,
+                    "devastating": false,
+                    "highyield": true,
+                    "persistentx": 0,
+                    "piercingx": 0,
+                    "viciousx": 0,
+                    "hiddenx": 0,
+                    "versatilex": 0
+                },
+                "opportunity": null,
+                "escalation": null
+            },
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Photon Torpedoes",
+            "type": "starshipweapon2e",
+            "sort": 1000,
+            "img": "systems/sta/assets/compendia/icons/starshipweapons-core/weapon-photon-torpedo.svg",
+            "system": {
+                "damage": 3,
+                "range": "long",
+                "includescale": "torpedo",
+                "description": "",
+                "opportunity": 0,
+                "escalation": 0,
+                "qualities": {
+                    "energy": false,
+                    "torpedo": true,
+                    "area": false,
+                    "calibration": false,
+                    "cumbersome": false,
+                    "dampening": false,
+                    "depleting": false,
+                    "devastating": false,
+                    "highyield": true,
+                    "intense": false,
+                    "jamming": false,
+                    "persistent": false,
+                    "piercing": false,
+                    "slowing": false,
+                    "spread": false,
+                    "hiddenx": 0,
+                    "versatilex": 0
+                }
+            },
+            "effects": [],
+            "folder": null,
+            "flags": {},
+            "_stats": {
+                "coreVersion": "13.346",
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "createdTime": 1775998532666,
+                "modifiedTime": 1775998603845,
+                "lastModifiedBy": "aodUFbctO5o4nV3h"
+            }
+        },
+        {
+            "name": "Tractor Beam",
+            "type": "starshipweapon",
+            "img": "systems/sta/assets/compendia/icons/starshipweapons-core/weapon-tractor-beam.svg",
+            "effects": [],
+            "folder": null,
+            "sort": 0,
+            "system": {
+                "description": "",
+                "damage": 0,
+                "range": null,
+                "qualities": {
+                    "area": false,
+                    "spread": false,
+                    "dampening": false,
+                    "calibration": false,
+                    "devastating": false,
+                    "highyield": false,
+                    "persistentx": 0,
+                    "piercingx": 0,
+                    "viciousx": 0,
+                    "hiddenx": 0,
+                    "versatilex": 0
+                },
+                "opportunity": null,
+                "escalation": null
+            },
+            "ownership": {
+                "default": 0,
+                "xuN9JpdcyRd60ZEJ": 3
+            },
+            "_stats": {
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "coreVersion": "10.291",
+                "createdTime": 1700000000000,
+                "modifiedTime": 1700000000000,
+                "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+            }
+        },
+        {
+            "name": "Tractor Beam",
+            "type": "starshipweapon2e",
+            "sort": 1000,
+            "img": "systems/sta/assets/compendia/icons/starshipweapons-core/weapon-tractor-beam.svg",
+            "system": {
+                "damage": 0,
+                "range": null,
+                "includescale": "energy",
+                "description": "",
+                "opportunity": 0,
+                "escalation": 0,
+                "qualities": {
+                    "energy": false,
+                    "torpedo": false,
+                    "area": false,
+                    "calibration": false,
+                    "cumbersome": false,
+                    "dampening": false,
+                    "depleting": false,
+                    "devastating": false,
+                    "highyield": false,
+                    "intense": false,
+                    "jamming": false,
+                    "persistent": false,
+                    "piercing": false,
+                    "slowing": false,
+                    "spread": false,
+                    "hiddenx": 0,
+                    "versatilex": 0
+                }
+            },
+            "effects": [],
+            "folder": null,
+            "flags": {},
+            "_stats": {
+                "coreVersion": "13.346",
+                "systemId": "sta",
+                "systemVersion": "2.4.2",
+                "createdTime": 1775998532666,
+                "modifiedTime": 1775998603845,
+                "lastModifiedBy": "aodUFbctO5o4nV3h"
+            }
+        }
+    ],
+    "effects": [],
+    "flags": {
+        "exportSource": {
+            "world": "sta-bcholmes-org",
+            "system": "sta",
+            "coreVersion": "10.291",
+            "systemVersion": "2.4.2"
+        }
+    },
+    "_stats": {
+        "systemId": "sta",
+        "systemVersion": "2.4.2",
+        "coreVersion": "10.291",
+        "createdTime": 1700000000000,
+        "modifiedTime": 1700000000000,
+        "lastModifiedBy": "xuN9JpdcyRd60ZEJ"
+    }
+}"
+`;

--- a/WebTools/tests/vtt/__snapshots__/roll20VttExporter.test.ts.snap
+++ b/WebTools/tests/vtt/__snapshots__/roll20VttExporter.test.ts.snap
@@ -1,0 +1,1368 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Roll20 JSON export golden output exports a fully-populated 2e character 1`] = `
+"{
+    "schema_version": 3,
+    "type": "character",
+    "character": {
+        "oldId": "-Nzzzzzzzzzzzzzzzzzz",
+        "name": "Rhea Voss (she/her)",
+        "avatar": "",
+        "bio": "",
+        "gmnotes": "",
+        "defaulttoken": "",
+        "tags": "[]",
+        "controlledby": "",
+        "inplayerjournals": "",
+        "attribs": [
+            {
+                "name": "sheet_color",
+                "current": "black",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz0"
+            },
+            {
+                "name": "attributeName",
+                "current": false,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz1"
+            },
+            {
+                "name": "disciplineName",
+                "current": false,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz2"
+            },
+            {
+                "name": "systemName",
+                "current": "COMMAND",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz3"
+            },
+            {
+                "name": "departmentName",
+                "current": false,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz4"
+            },
+            {
+                "name": "ask_whisper",
+                "current": "Whisper to GM?",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz5"
+            },
+            {
+                "name": "ask_public_roll",
+                "current": "Public Roll",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz6"
+            },
+            {
+                "name": "ask_whisper_roll",
+                "current": "Whisper Roll",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz7"
+            },
+            {
+                "name": "diceRoll",
+                "current": "{{dice1=[[d20<@{target}cf>@{complication}cs<@{focus}]]}}{{dice2=[[d20<@{target}cf>@{complication}cs<@{focus}]]}}",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz8"
+            },
+            {
+                "name": "crew_diceRoll",
+                "current": "{{dice1=[[d20<@{crew_target}cf>@{ship_complication}cs<@{crew_discipline}]]}}{{dice2=[[d20<@{crew_target}cf>@{ship_complication}cs<@{crew_discipline}]]}}",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz9"
+            },
+            {
+                "name": "ship_diceRoll",
+                "current": "{{dice1=[[d20<@{ship_target}cf>@{ship_complication}cs<@{department}]]}}{{dice2=[[d20<@{ship_target}cf>@{ship_complication}cs<@{department}]]}}",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0a"
+            },
+            {
+                "name": "focus",
+                "current": "1",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0b"
+            },
+            {
+                "name": "complication",
+                "current": "20",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0c"
+            },
+            {
+                "name": "version",
+                "current": 1.6,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0d"
+            },
+            {
+                "name": "settings_toggle",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0e"
+            },
+            {
+                "name": "privilege",
+                "current": 4,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0f"
+            },
+            {
+                "name": "responsibility",
+                "current": 17,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0g"
+            },
+            {
+                "name": "species",
+                "current": "Human",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0h"
+            },
+            {
+                "name": "rank",
+                "current": "Lieutenant Commander",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0i"
+            },
+            {
+                "name": "upbringing",
+                "current": "Business or Trade (A)",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0j"
+            },
+            {
+                "name": "environment",
+                "current": "Environment.common.starshipOrStarbase.name",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0k"
+            },
+            {
+                "name": "assignment",
+                "current": "Chief Engineer / Operations Manager, USS Venture",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0l"
+            },
+            {
+                "name": "rankSelect",
+                "current": "Lieutenant Commander",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0m"
+            },
+            {
+                "name": "command",
+                "current": 3,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0n"
+            },
+            {
+                "name": "conn",
+                "current": 1,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0o"
+            },
+            {
+                "name": "security",
+                "current": 2,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0p"
+            },
+            {
+                "name": "engineering",
+                "current": 4,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0q"
+            },
+            {
+                "name": "science",
+                "current": 2,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0r"
+            },
+            {
+                "name": "medicine",
+                "current": 2,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0s"
+            },
+            {
+                "name": "control",
+                "current": 7,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0t"
+            },
+            {
+                "name": "daring",
+                "current": 11,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0u"
+            },
+            {
+                "name": "fitness",
+                "current": 9,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0v"
+            },
+            {
+                "name": "insight",
+                "current": 8,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0w"
+            },
+            {
+                "name": "presence",
+                "current": 9,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0x"
+            },
+            {
+                "name": "reason",
+                "current": 8,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0y"
+            },
+            {
+                "name": "stress",
+                "current": "",
+                "max": 9,
+                "id": "-Nzzzzzzzzzzzzzzzz0z"
+            },
+            {
+                "name": "reputation",
+                "current": 5,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz00"
+            },
+            {
+                "name": "resistance",
+                "current": 0,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz01"
+            },
+            {
+                "name": "values",
+                "current": "Curiosity\\nCourage\\nHarmony\\nInitiative",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz02"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz03_focus_name",
+                "current": "Compassion",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz04"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz03_focus_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz05"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz03_focus_show_description",
+                "current": "off",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz06"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz07_focus_name",
+                "current": "Engineering",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz08"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz07_focus_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz09"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz07_focus_show_description",
+                "current": "off",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1a"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz1b_focus_name",
+                "current": "Astrophysics",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1c"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz1b_focus_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1d"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz1b_focus_show_description",
+                "current": "off",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1e"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz1f_focus_name",
+                "current": "Starship Design",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1g"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz1f_focus_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1h"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz1f_focus_show_description",
+                "current": "off",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1i"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz1j_focus_name",
+                "current": "Survival",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1k"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz1j_focus_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1l"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz1j_focus_show_description",
+                "current": "off",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1m"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz1n_focus_name",
+                "current": "Diplomacy",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1o"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz1n_focus_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1p"
+            },
+            {
+                "name": "repeating_focuses_-Nzzzzzzzzzzzzzzzz1n_focus_show_description",
+                "current": "off",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1q"
+            },
+            {
+                "name": "repeating_equipmentks_-Nzzzzzzzzzzzzzzzz1r_equipment_name",
+                "current": "Uniform",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1s"
+            },
+            {
+                "name": "repeating_equipmentks_-Nzzzzzzzzzzzzzzzz1r_equipment_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1t"
+            },
+            {
+                "name": "repeating_equipmentks_-Nzzzzzzzzzzzzzzzz1u_equipment_name",
+                "current": "Communicator",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1v"
+            },
+            {
+                "name": "repeating_equipmentks_-Nzzzzzzzzzzzzzzzz1u_equipment_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1w"
+            },
+            {
+                "name": "repeating_equipmentks_-Nzzzzzzzzzzzzzzzz1u_equipment_description",
+                "current": "A communicator is a communications device used by many species for person-to-person, inter-ship communications.",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1x"
+            },
+            {
+                "name": "repeating_equipmentks_-Nzzzzzzzzzzzzzzzz1y_equipment_name",
+                "current": "Tricorder",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1z"
+            },
+            {
+                "name": "repeating_equipmentks_-Nzzzzzzzzzzzzzzzz1y_equipment_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz10"
+            },
+            {
+                "name": "repeating_equipmentks_-Nzzzzzzzzzzzzzzzz1y_equipment_description",
+                "current": "A tricorder is an advanced multi-function hand held computing and scanning device used to gather, analyze, and record data, with many specialized abilities which made it an asset to crews aboard starships and space stations as well as on away missions.",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz11"
+            },
+            {
+                "name": "repeating_equipmentks_-Nzzzzzzzzzzzzzzzz12_equipment_name",
+                "current": "Engineering Kit",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz13"
+            },
+            {
+                "name": "repeating_equipmentks_-Nzzzzzzzzzzzzzzzz12_equipment_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz14"
+            },
+            {
+                "name": "repeating_equipmentks_-Nzzzzzzzzzzzzzzzz12_equipment_description",
+                "current": "An engineering kit is a collection of tools used in engineering.",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz15"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz16_talent_name",
+                "current": "Bold",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz17"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz16_talent_description",
+                "current": "",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz18"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz16_talent_requirements",
+                "current": "",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz19"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz16_talent_category",
+                "current": "General",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2a"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz16_talent_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2b"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2c_talent_name",
+                "current": "Cautious",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2d"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2c_talent_description",
+                "current": "",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2e"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2c_talent_requirements",
+                "current": "",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2f"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2c_talent_category",
+                "current": "General",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2g"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2c_talent_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2h"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2i_talent_name",
+                "current": "Untapped Potential",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2j"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2i_talent_description",
+                "current": "The character is inexperienced, but talented and with a bright future in Starfleet. The character may not have or increase any Attribute above 11, or any Discipline above 4 while they have this Talent (and may have to adjust Attributes and Disciplines accordingly at the end of character creation). Whenever the character succeeds at a Task for which they bought one or more additional dice with either Momentum or Threat, they may roll 1[D]. The character receives bonus Momentum equal to the roll, and adds one point to Threat if an Effect is rolled. The character cannot gain any higher rank than lieutenant (junior grade) while they possess this Talent.",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2k"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2i_talent_requirements",
+                "current": "Only available to Young characters",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2l"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2i_talent_category",
+                "current": "Career",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2m"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2i_talent_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2n"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2o_talent_name",
+                "current": "Advisor",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2p"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2o_talent_description",
+                "current": "Whenever you assist another character using your Command Discipline, the character being assisted may re-roll one d20.",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2q"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2o_talent_requirements",
+                "current": "Requires Command 2+, Main Character only",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2r"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2o_talent_category",
+                "current": "Command",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2s"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2o_talent_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2t"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2u_talent_name",
+                "current": "Supervisor",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2v"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2u_talent_description",
+                "current": "The ship’s Crew Support increases by one. This increase is cumulative if multiple Main Characters in the group select it.",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2w"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2u_talent_requirements",
+                "current": "",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2x"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2u_talent_category",
+                "current": "Command",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2y"
+            },
+            {
+                "name": "repeating_talents_-Nzzzzzzzzzzzzzzzz2u_talent_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2z"
+            },
+            {
+                "name": "repeating_traits_-Nzzzzzzzzzzzzzzzz20_trait_name",
+                "current": "Steadfast",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz21"
+            },
+            {
+                "name": "repeating_traits_-Nzzzzzzzzzzzzzzzz20_trait_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz22"
+            },
+            {
+                "name": "repeating_traits_-Nzzzzzzzzzzzzzzzz20_trait_description",
+                "current": "Humans are adaptable and resilient, and their resolve and ambition often allow them to resist great hardship and triumph despite great adversity. However, Humans can also be reckless and stubborn, irrational, and unpredictable.",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz23"
+            },
+            {
+                "name": "repeating_traits_-Nzzzzzzzzzzzzzzzz24_trait_name",
+                "current": "Human",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz25"
+            },
+            {
+                "name": "repeating_traits_-Nzzzzzzzzzzzzzzzz24_trait_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz26"
+            },
+            {
+                "name": "repeating_traits_-Nzzzzzzzzzzzzzzzz27_trait_name",
+                "current": "Dark Secrets",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz28"
+            },
+            {
+                "name": "repeating_traits_-Nzzzzzzzzzzzzzzzz27_trait_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz29"
+            },
+            {
+                "name": "repeating_traits_-Nzzzzzzzzzzzzzzzz3a_trait_name",
+                "current": "Professional",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz3b"
+            },
+            {
+                "name": "repeating_traits_-Nzzzzzzzzzzzzzzzz3a_trait_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz3c"
+            },
+            {
+                "name": "repeating_weapons_-Nzzzzzzzzzzzzzzzz3d_weapon_name",
+                "current": "Weapon.personal.strike.name",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz3e"
+            },
+            {
+                "name": "repeating_weapons_-Nzzzzzzzzzzzzzzzz3d_weapon_quality",
+                "current": "",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz3f"
+            },
+            {
+                "name": "repeating_weapons_-Nzzzzzzzzzzzzzzzz3d_weapon_effects",
+                "current": "",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz3g"
+            },
+            {
+                "name": "repeating_weapons_-Nzzzzzzzzzzzzzzzz3d_weapon_damage",
+                "current": 2,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz3h"
+            },
+            {
+                "name": "repeating_weapons_-Nzzzzzzzzzzzzzzzz3d_damageRoll",
+                "current": "{{cdice1=[[1d6]]}}{{cdice2=[[1d6]]}}{{cdice3=[[1d6]]}}{{cdice4=[[1d6]]}}",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz3i"
+            },
+            {
+                "name": "repeating_weapons_-Nzzzzzzzzzzzzzzzz3d_weapon_type",
+                "current": "Melee",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz3j"
+            },
+            {
+                "name": "repeating_weapons_-Nzzzzzzzzzzzzzzzz3k_weapon_name",
+                "current": "Weapon.personal.phaser2.name",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz3l"
+            },
+            {
+                "name": "repeating_weapons_-Nzzzzzzzzzzzzzzzz3k_weapon_quality",
+                "current": "Charge",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz3m"
+            },
+            {
+                "name": "repeating_weapons_-Nzzzzzzzzzzzzzzzz3k_weapon_effects",
+                "current": "",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz3n"
+            },
+            {
+                "name": "repeating_weapons_-Nzzzzzzzzzzzzzzzz3k_weapon_damage",
+                "current": 4,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz3o"
+            },
+            {
+                "name": "repeating_weapons_-Nzzzzzzzzzzzzzzzz3k_damageRoll",
+                "current": "{{cdice1=[[1d6]]}}{{cdice2=[[1d6]]}}{{cdice3=[[1d6]]}}{{cdice4=[[1d6]]}}{{cdice5=[[1d6]]}}{{cdice6=[[1d6]]}}",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz3p"
+            },
+            {
+                "name": "repeating_weapons_-Nzzzzzzzzzzzzzzzz3k_weapon_type",
+                "current": "Ranged",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz3q"
+            }
+        ],
+        "abilities": []
+    }
+}"
+`;
+
+exports[`Roll20 JSON export golden output exports a fully-populated 2e starship 1`] = `
+"{
+    "schema_version": 3,
+    "type": "character",
+    "character": {
+        "oldId": "-Nzzzzzzzzzzzzzzzzzz",
+        "name": "USS Venture",
+        "avatar": "",
+        "bio": "",
+        "gmnotes": "",
+        "defaulttoken": "",
+        "tags": "[]",
+        "controlledby": "",
+        "inplayerjournals": "",
+        "attribs": [
+            {
+                "name": "sheet_color",
+                "current": "black",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz0"
+            },
+            {
+                "name": "attributeName",
+                "current": false,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz1"
+            },
+            {
+                "name": "disciplineName",
+                "current": false,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz2"
+            },
+            {
+                "name": "systemName",
+                "current": "COMMAND",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz3"
+            },
+            {
+                "name": "departmentName",
+                "current": false,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz4"
+            },
+            {
+                "name": "ask_whisper",
+                "current": "Whisper to GM?",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz5"
+            },
+            {
+                "name": "ask_public_roll",
+                "current": "Public Roll",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz6"
+            },
+            {
+                "name": "ask_whisper_roll",
+                "current": "Whisper Roll",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz7"
+            },
+            {
+                "name": "diceRoll",
+                "current": "{{dice1=[[d20<@{target}cf>@{complication}cs<@{focus}]]}}{{dice2=[[d20<@{target}cf>@{complication}cs<@{focus}]]}}",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz8"
+            },
+            {
+                "name": "crew_diceRoll",
+                "current": "{{dice1=[[d20<@{crew_target}cf>@{ship_complication}cs<@{crew_discipline}]]}}{{dice2=[[d20<@{crew_target}cf>@{ship_complication}cs<@{crew_discipline}]]}}",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzzz9"
+            },
+            {
+                "name": "ship_diceRoll",
+                "current": "{{dice1=[[d20<@{ship_target}cf>@{ship_complication}cs<@{department}]]}}{{dice2=[[d20<@{ship_target}cf>@{ship_complication}cs<@{department}]]}}",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0a"
+            },
+            {
+                "name": "focus",
+                "current": "1",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0b"
+            },
+            {
+                "name": "complication",
+                "current": "20",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0c"
+            },
+            {
+                "name": "version",
+                "current": 1.6,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0d"
+            },
+            {
+                "name": "settings_toggle",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0e"
+            },
+            {
+                "name": "sheet_type",
+                "current": "starship",
+                "max": "",
+                "id": "-Nz_YFXyrBCoNytnAbXI"
+            },
+            {
+                "name": "ship-environment",
+                "current": "Galaxy Class",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0f"
+            },
+            {
+                "name": "ship_ship-mission-profile",
+                "current": "Battlecruiser",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0g"
+            },
+            {
+                "name": "ship-designation",
+                "current": "NCC-70637",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0h"
+            },
+            {
+                "name": "ship-rank",
+                "current": "2372",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0i"
+            },
+            {
+                "name": "ship-refit",
+                "current": "+1 Construct.system.engines, +1 Construct.system.weapons",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0j"
+            },
+            {
+                "name": "shields",
+                "current": "",
+                "max": 19,
+                "id": "-Nzzzzzzzzzzzzzzzz0k"
+            },
+            {
+                "name": "ship_resistance",
+                "current": "7",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0l"
+            },
+            {
+                "name": "ship_scale",
+                "current": "6",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0m"
+            },
+            {
+                "name": "crew",
+                "current": "0",
+                "max": 12,
+                "id": "-Nzzzzzzzzzzzzzzzz0n"
+            },
+            {
+                "name": "power",
+                "current": "0",
+                "max": 16,
+                "id": "-Nzzzzzzzzzzzzzzzz0o"
+            },
+            {
+                "name": "ship_command",
+                "current": 3,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0p"
+            },
+            {
+                "name": "ship_conn",
+                "current": 2,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0q"
+            },
+            {
+                "name": "ship_security",
+                "current": 3,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0r"
+            },
+            {
+                "name": "ship_engineering",
+                "current": 2,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0s"
+            },
+            {
+                "name": "ship_science",
+                "current": 3,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0t"
+            },
+            {
+                "name": "ship_medicine",
+                "current": 2,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0u"
+            },
+            {
+                "name": "ship_communcation",
+                "current": 9,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0v"
+            },
+            {
+                "name": "ship_computers",
+                "current": 10,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0w"
+            },
+            {
+                "name": "ship_engines",
+                "current": 11,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0x"
+            },
+            {
+                "name": "ship_sensors",
+                "current": 8,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0y"
+            },
+            {
+                "name": "ship_structure",
+                "current": 10,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz0z"
+            },
+            {
+                "name": "ship_weapons",
+                "current": 12,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz00"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz01_stalent_name",
+                "current": "Abundant Personnel",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz02"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz01_stalent_description",
+                "current": "",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz03"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz01_stalent_requirements",
+                "current": "None",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz04"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz01_stalent_category",
+                "current": "Starship",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz05"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz01_stalent_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz06"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz07_stalent_name",
+                "current": "Saucer Separation and Reconnect",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz08"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz07_stalent_description",
+                "current": "",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz09"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz07_stalent_requirements",
+                "current": "None",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1a"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz07_stalent_category",
+                "current": "Starship",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1b"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz07_stalent_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1c"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1d_stalent_name",
+                "current": "Modular Laboratories",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1e"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1d_stalent_description",
+                "current": "The ship has considerable numbers of empty, multi-purpose compartments that can be converted to laboratories as and when required. At the start of an adventure, the crew may decide how the modular laboratories are configured; this configuration counts as an Advantage which applies to work performed within the laboratories.",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1f"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1d_stalent_requirements",
+                "current": "Requires Science 2+",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1g"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1d_stalent_category",
+                "current": "Starship",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1h"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1d_stalent_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1i"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1j_stalent_name",
+                "current": "Redundant Systems",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1k"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1j_stalent_description",
+                "current": "The ship has multiple additional redundancies that allow it to withstand severe damage more easily. Nominate a single System. When that system becomes Damaged or Disabled, the crew may choose to activate the backups as a Minor Action; if the System was Damaged, it is no longer Damaged. If it was Disabled, it becomes Damaged instead. A System’s backups may only be activated once per adventure, so subsequent damage will have the normal effect.",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1l"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1j_stalent_requirements",
+                "current": "None",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1m"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1j_stalent_category",
+                "current": "Starship",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1n"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1j_stalent_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1o"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1p_stalent_name",
+                "current": "Ablative Armor",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1q"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1p_stalent_description",
+                "current": "The vessel’s hull plating has an additional ablative layer that disintegrates slowly under extreme temperatures, such as those caused by energy weapons and torpedo blasts, dissipating the energy, and protecting the ship. This plating is replaced periodically. The ship’s Resistance is increased by 2.",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1r"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1p_stalent_requirements",
+                "current": "2371 or later",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1s"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1p_stalent_category",
+                "current": "Starship",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1t"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1p_stalent_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1u"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1v_stalent_name",
+                "current": "Secondary Reactors [x1]",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1w"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1v_stalent_description",
+                "current": "The ship has additional impulse and fusion reactors, that allow the ship to generate far greater quantities of energy. Increase the ship’s normal Power capacity by 5.",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1x"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1v_stalent_requirements",
+                "current": "None",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1y"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1v_stalent_category",
+                "current": "Starship",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz1z"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz1v_stalent_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz10"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz11_stalent_name",
+                "current": "Redundant Systems",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz12"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz11_stalent_description",
+                "current": "The ship has multiple additional redundancies that allow it to withstand severe damage more easily. Nominate a single System. When that system becomes Damaged or Disabled, the crew may choose to activate the backups as a Minor Action; if the System was Damaged, it is no longer Damaged. If it was Disabled, it becomes Damaged instead. A System’s backups may only be activated once per adventure, so subsequent damage will have the normal effect.",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz13"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz11_stalent_requirements",
+                "current": "None",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz14"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz11_stalent_category",
+                "current": "Starship",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz15"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz11_stalent_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz16"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz17_stalent_name",
+                "current": "Dedicated Personnel",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz18"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz17_stalent_description",
+                "current": "The ship gains two additional Crew Support, which may only be used to establish Supporting Characters.",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz19"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz17_stalent_requirements",
+                "current": "None",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2a"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz17_stalent_category",
+                "current": "Starship",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2b"
+            },
+            {
+                "name": "repeating_stalents_-Nzzzzzzzzzzzzzzzz17_stalent_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2c"
+            },
+            {
+                "name": "repeating_straits_-Nzzzzzzzzzzzzzzzz2d_strait_name",
+                "current": "Federation Starship",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2e"
+            },
+            {
+                "name": "repeating_straits_-Nzzzzzzzzzzzzzzzz2d_strait_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2f"
+            },
+            {
+                "name": "repeating_straits_-Nzzzzzzzzzzzzzzzz2g_strait_name",
+                "current": "Galaxy Class",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2h"
+            },
+            {
+                "name": "repeating_straits_-Nzzzzzzzzzzzzzzzz2g_strait_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2i"
+            },
+            {
+                "name": "repeating_straits_-Nzzzzzzzzzzzzzzzz2j_strait_name",
+                "current": "Flagship",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2k"
+            },
+            {
+                "name": "repeating_straits_-Nzzzzzzzzzzzzzzzz2j_strait_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2l"
+            },
+            {
+                "name": "repeating_straits_-Nzzzzzzzzzzzzzzzz2m_strait_name",
+                "current": "Hero Ship",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2n"
+            },
+            {
+                "name": "repeating_straits_-Nzzzzzzzzzzzzzzzz2m_strait_settings",
+                "current": "0",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2o"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz2p_weapon_name",
+                "current": "Phaser Arrays",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2q"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz2p_weapon_quality",
+                "current": "Weapon.quality.versatile.name",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2r"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz2p_weapon_effect",
+                "current": "AreaOrSpread",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2s"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz2p_weapon_damage",
+                "current": 0,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2t"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz2p_damageRoll",
+                "current": "",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2u"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz2p_weapon_type",
+                "current": "Energy",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2v"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz2w_weapon_name",
+                "current": "Photon Torpedoes",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2x"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz2w_weapon_quality",
+                "current": "HighYield",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2y"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz2w_weapon_effect",
+                "current": "",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz2z"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz2w_weapon_damage",
+                "current": 3,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz20"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz2w_damageRoll",
+                "current": "{{cdice1=[[1d6]]}}{{cdice2=[[1d6]]}}{{cdice3=[[1d6]]}}{{cdice4=[[1d6]]}}{{cdice5=[[1d6]]}}{{cdice6=[[1d6]]}}",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz21"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz2w_weapon_type",
+                "current": "Torpedo",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz22"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz23_weapon_name",
+                "current": "Tractor Beam",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz24"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz23_weapon_quality",
+                "current": "",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz25"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz23_weapon_effect",
+                "current": "",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz26"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz23_weapon_damage",
+                "current": 0,
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz27"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz23_damageRoll",
+                "current": "{{cdice1=[[1d6]]}}{{cdice2=[[1d6]]}}{{cdice3=[[1d6]]}}{{cdice4=[[1d6]]}}{{cdice5=[[1d6]]}}",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz28"
+            },
+            {
+                "name": "repeating_ship_-Nzzzzzzzzzzzzzzzz23_weapon_type",
+                "current": "Energy",
+                "max": "",
+                "id": "-Nzzzzzzzzzzzzzzzz29"
+            }
+        ],
+        "abilities": []
+    }
+}"
+`;
+
+exports[`Roll20 JSON export golden output exports a fully-populated 2e starship as a handout 1`] = `
+"{
+    "schema_version": 3,
+    "type": "handout",
+    "handout": {
+        "archived": false,
+        "avatar": "",
+        "controlledby": "",
+        "inplayerjournals": "",
+        "name": "USS Venture, NCC-70637",
+        "tags": "[]",
+        "gmnotes": "",
+        "notes": "<p><strong>Traits:</strong> Federation Starship, Galaxy Class, Flagship, Hero Ship</p>\\n<h2>Construct.other.systems</h2>\\n<table>\\n<thead>\\n<tr>\\n<th>Construct.system.comms</th>\\n<th>Construct.system.computer</th>\\n<th>Construct.system.engines</th>\\n<th>Construct.system.sensors</th>\\n<th>Construct.system.structure</th>\\n<th>Construct.system.weapons</th>\\n</tr>\\n</thead>\\n<tbody><tr>\\n<td>9</td>\\n<td>10</td>\\n<td>11</td>\\n<td>8</td>\\n<td>10</td>\\n<td>12</td>\\n</tr>\\n</tbody>\\n</table>\\n<h2>Construct.other.departments</h2>\\n<table>\\n<thead>\\n<tr>\\n<th>Construct.department.command</th>\\n<th>Construct.department.conn</th>\\n<th>Construct.department.security</th>\\n<th>Construct.department.engineering</th>\\n<th>Construct.department.science</th>\\n<th>Construct.department.medicine</th>\\n</tr>\\n</thead>\\n<tbody><tr>\\n<td>3</td>\\n<td>2</td>\\n<td>3</td>\\n<td>2</td>\\n<td>3</td>\\n<td>2</td>\\n</tr>\\n</tbody>\\n</table>\\n<p><strong>Construct.other.power:</strong> 16<br /><strong>Construct.other.scale:</strong> 6<br /><strong>Construct.other.shields:</strong> 19<br /><strong>Construct.other.crewSupport:</strong> 12</p><p><strong>Construct.other.attacks</strong></p>\\n<ul>\\n<li><p>Phaser Arrays (Energy Weapon, Range Medium, 0<img src=\\"https://s3.amazonaws.com/files.d20.io/images/239862759/6uRVM0G3z6g119ymlL1VLg/med.png?1628984150\\" height=\\"18\\" width=\\"13\\"> Weapon.quality.versatile.name, AreaOrSpread)</p></li><li><p>Photon Torpedoes (Torpedo, Range Long, 3<img src=\\"https://s3.amazonaws.com/files.d20.io/images/239862759/6uRVM0G3z6g119ymlL1VLg/med.png?1628984150\\" height=\\"18\\" width=\\"13\\"> HighYield)</p></li><li><p>Tractor Beam (Strength 5 )</p></li></ul>\\n<p><strong>Construct.other.talents</strong></p>\\n<ul>\\n<li><p><b>Modular Laboratories:</b> The ship has considerable numbers of empty, multi-purpose compartments that can be converted to laboratories as and when required. At the start of an adventure, the crew may decide how the modular laboratories are configured; this configuration counts as an Advantage which applies to work performed within the laboratories.</p></li>\\n<li><p><b>Redundant Systems:</b> The ship has multiple additional redundancies that allow it to withstand severe damage more easily. Nominate a single System. When that system becomes Damaged or Disabled, the crew may choose to activate the backups as a Minor Action; if the System was Damaged, it is no longer Damaged. If it was Disabled, it becomes Damaged instead. A System’s backups may only be activated once per adventure, so subsequent damage will have the normal effect.</p></li>\\n<li><p><b>Ablative Armor:</b> The vessel’s hull plating has an additional ablative layer that disintegrates slowly under extreme temperatures, such as those caused by energy weapons and torpedo blasts, dissipating the energy, and protecting the ship. This plating is replaced periodically. The ship’s Resistance is increased by 2.</p></li>\\n<li><p><b>Secondary Reactors [x1]:</b> The ship has additional impulse and fusion reactors, that allow the ship to generate far greater quantities of energy. Increase the ship’s normal Power capacity by 5.</p></li>\\n<li><p><b>Dedicated Personnel:</b> The ship gains two additional Crew Support, which may only be used to establish Supporting Characters.</p></li>\\n</ul>\\n<p><strong>Construct.other.specialRules</strong></p>\\n<ul>\\n<li><p><b>Abundant Personnel:</b> </p></li>\\n<li><p><b>Saucer Separation and Reconnect:</b> </p></li>\\n</ul>\\n"
+    }
+}"
+`;

--- a/WebTools/tests/vtt/fantasyGroundsVttExport.test.ts
+++ b/WebTools/tests/vtt/fantasyGroundsVttExport.test.ts
@@ -1,0 +1,47 @@
+import { test, expect, describe } from '@jest/globals';
+import '../../src/helpers/species';
+import { FantasyGroupsVttExporter } from '../../src/vtt/fantasyGroundsVttExport';
+import { makePopulatedMainCharacter, makePopulatedNpc } from './vttFixtures';
+
+jest.mock('i18next', () => {
+  const mockI18n: any = (key: string) => key;
+  mockI18n.t = (key: string) => key;
+  mockI18n.use = function () {
+    return this;
+  };
+  mockI18n.init = function () {
+    return this;
+  };
+  mockI18n.on = function () {
+    return this;
+  };
+  mockI18n.changeLanguage = function () {
+    return Promise.resolve();
+  };
+  return mockI18n;
+});
+
+jest.mock('../../src/state/store', () => {
+  const core2ndEdition = 1; // Source.Core2ndEdition
+  return {
+    store: {
+      getState: () => ({ context: { sources: [core2ndEdition] } }),
+      dispatch: () => undefined,
+    },
+  };
+});
+
+describe('FantasyGrounds XML export golden output', () => {
+  test('exports a fully-populated 2e main character', () => {
+    const result = FantasyGroupsVttExporter.instance.exportCharacter(
+      makePopulatedMainCharacter(2),
+    );
+    expect(result).toMatchSnapshot();
+  });
+
+  test('exports a fully-populated NPC', () => {
+    const result =
+      FantasyGroupsVttExporter.instance.exportCharacter(makePopulatedNpc());
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/WebTools/tests/vtt/foundryVttExporter.test.ts
+++ b/WebTools/tests/vtt/foundryVttExporter.test.ts
@@ -1,4 +1,11 @@
-import { test, expect, describe } from '@jest/globals';
+import {
+  test,
+  expect,
+  describe,
+  beforeEach,
+  afterEach,
+  jest,
+} from '@jest/globals';
 import '../../src/helpers/species';
 import { Character } from '../../src/common/character';
 import { CharacterType } from '../../src/common/characterType';
@@ -6,6 +13,11 @@ import { Era } from '../../src/helpers/erasEnum';
 import { Role, RolesHelper } from '../../src/helpers/roles';
 import { FoundryVttExporter } from '../../src/vtt/foundryVttExporter';
 import { FoundryPluginType } from '../../src/vtt/foundryPluginType';
+import {
+  makePopulatedMainCharacter,
+  makePopulatedStarship,
+  makePopulatedStation,
+} from './vttFixtures';
 
 jest.mock('i18next', () => {
   const mockI18n: any = (key: string) => key;
@@ -92,5 +104,47 @@ describe('FoundryVTT character export (#257)', () => {
     expect(result.system.characterrole).toBe(expectedRole);
     expect(result.system.assignment).not.toContain('Chief');
     expect(result.system.characterrole).not.toContain('Enterprise');
+  });
+});
+
+describe('FoundryVTT export golden output', () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(1700000000000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('exports a fully-populated 2e character', () => {
+    const result = FoundryVttExporter.instance.exportCharacter(
+      makePopulatedMainCharacter(2),
+      FoundryPluginType.Standard,
+    );
+    expect(JSON.stringify(result, null, 4)).toMatchSnapshot();
+  });
+
+  test('exports a fully-populated 1e character', () => {
+    const result = FoundryVttExporter.instance.exportCharacter(
+      makePopulatedMainCharacter(1),
+      FoundryPluginType.Standard,
+    );
+    expect(JSON.stringify(result, null, 4)).toMatchSnapshot();
+  });
+
+  test('exports a fully-populated 2e starship', () => {
+    const result = FoundryVttExporter.instance.exportStarship(
+      makePopulatedStarship(),
+      FoundryPluginType.Standard,
+    );
+    expect(JSON.stringify(result, null, 4)).toMatchSnapshot();
+  });
+
+  test('exports a fully-populated station', () => {
+    const result = FoundryVttExporter.instance.exportStation(
+      makePopulatedStation(),
+      FoundryPluginType.Standard,
+    );
+    expect(JSON.stringify(result, null, 4)).toMatchSnapshot();
   });
 });

--- a/WebTools/tests/vtt/roll20VttExporter.test.ts
+++ b/WebTools/tests/vtt/roll20VttExporter.test.ts
@@ -1,0 +1,77 @@
+import { test, expect, describe, afterEach, jest } from '@jest/globals';
+import '../../src/helpers/species';
+import { Roll20VttExporter } from '../../src/vtt/roll20VttExporter';
+import {
+  makePopulatedMainCharacter,
+  makePopulatedStarship,
+} from './vttFixtures';
+
+jest.mock('i18next', () => {
+  const mockI18n: any = (key: string) => key;
+  mockI18n.t = (key: string) => key;
+  mockI18n.use = function () {
+    return this;
+  };
+  mockI18n.init = function () {
+    return this;
+  };
+  mockI18n.on = function () {
+    return this;
+  };
+  mockI18n.changeLanguage = function () {
+    return Promise.resolve();
+  };
+  return mockI18n;
+});
+
+jest.mock('../../src/state/store', () => {
+  const core2ndEdition = 1; // Source.Core2ndEdition
+  return {
+    store: {
+      getState: () => ({ context: { sources: [core2ndEdition] } }),
+      dispatch: () => undefined,
+    },
+  };
+});
+
+beforeEach(() => {
+  jest.spyOn(Math, 'random').mockReturnValue(0.7);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('Roll20 JSON export golden output', () => {
+  test('exports a fully-populated 2e character', () => {
+    const result = Roll20VttExporter.instance.exportCharacter(
+      makePopulatedMainCharacter(2),
+    );
+    expect(JSON.stringify(result, null, 4)).toMatchSnapshot();
+  });
+
+  test('exports a fully-populated 2e starship', () => {
+    const result = Roll20VttExporter.instance.exportStarship(
+      makePopulatedStarship(),
+    );
+    expect(JSON.stringify(result, null, 4)).toMatchSnapshot();
+  });
+
+  test('exports a fully-populated 2e starship as a handout', () => {
+    const result = Roll20VttExporter.instance.exportStarshipAsHandout(
+      makePopulatedStarship(),
+    );
+    expect(JSON.stringify(result, null, 4)).toMatchSnapshot();
+  });
+});
+
+describe('Roll20 export known divergences', () => {
+  test('uses the misspelled "communcation" attrib key', () => {
+    const result: any = Roll20VttExporter.instance.exportStarship(
+      makePopulatedStarship(),
+    );
+    const attribNames = result.character.attribs.map((a) => a.name);
+    expect(attribNames).toEqual(expect.arrayContaining(['ship_communcation']));
+    expect(attribNames).not.toContain('ship_communications');
+  });
+});

--- a/WebTools/tests/vtt/vttFixtures.ts
+++ b/WebTools/tests/vtt/vttFixtures.ts
@@ -1,0 +1,244 @@
+import {
+  CareerEventStep,
+  CareerStep,
+  Character,
+  CharacterAdvancementStep,
+  CharacterRank,
+  EducationStep,
+  EnvironmentStep,
+  FinishingStep,
+  NpcGenerationStep,
+  Promotion,
+  ReputationChangeStep,
+  SpeciesAbilityOptions,
+  SpeciesStep,
+  UpbringingStep,
+} from '../../src/common/character';
+import { CharacterType } from '../../src/common/characterType';
+import { SelectedTalent } from '../../src/common/selectedTalent';
+import {
+  Station,
+  StandardStationSpaceframeStep,
+  StationMissionProfileStep,
+} from '../../src/common/station';
+import { MissionProfileStep, Starship } from '../../src/common/starship';
+import { SpaceframeHelper } from '../../src/helpers/spaceframes';
+import { Attribute } from '../../src/helpers/attributes';
+import { Department } from '../../src/helpers/department';
+import { Environment } from '../../src/helpers/environments';
+import { EarlyOutlook, UpbringingsHelper } from '../../src/helpers/upbringings';
+import { Track } from '../../src/helpers/trackEnum';
+import { Career } from '../../src/helpers/careerEnum';
+import { Species } from '../../src/helpers/speciesEnum';
+import { SpeciesAbilityList } from '../../src/helpers/speciesAbility';
+import { Era } from '../../src/helpers/erasEnum';
+import { Role } from '../../src/helpers/roles';
+import { Rank, RanksHelper } from '../../src/helpers/ranks';
+import { NpcType } from '../../src/npc/model/npcType';
+import { ModificationType } from '../../src/modify/model/modificationType';
+import { CharacterAdvancementChoice } from '../../src/modify/model/characterAdvancementChoice';
+import { Spaceframe } from '../../src/helpers/spaceframeEnum';
+import { StationFrame } from '../../src/helpers/stationFrame';
+import {
+  MissionProfile,
+  MissionProfiles,
+} from '../../src/helpers/missionProfiles';
+import { System } from '../../src/helpers/systems';
+import { EquipmentType } from '../../src/helpers/equipment';
+import { PersonalWeaponType } from '../../src/helpers/weapons';
+
+export function makePopulatedMainCharacter(version: 1 | 2): Character {
+  const character = Character.createMainCharacter(
+    CharacterType.Starfleet,
+    Era.NextGeneration,
+    version,
+  );
+  character.name = 'Rhea Voss';
+  character.pronouns = 'she/her';
+  character.pastime = ['Anthropology', 'Aquaponics'];
+  character.additionalTraits = 'Professional';
+  character.description =
+    'An engineer who documented the founding days of the new frontier.';
+
+  const speciesStep = new SpeciesStep(Species.Human);
+  speciesStep.attributes = [
+    Attribute.Daring,
+    Attribute.Insight,
+    Attribute.Reason,
+  ];
+  if (version === 2) {
+    speciesStep.ability = SpeciesAbilityList.instance.getBySpecies(
+      Species.Human,
+    );
+    const abilityOptions = new SpeciesAbilityOptions();
+    abilityOptions.focuses = ['Compassion'];
+    speciesStep.abilityOptions = abilityOptions;
+  }
+  character.speciesStep = speciesStep;
+
+  const environmentStep = new EnvironmentStep(Environment.StarshipOrStarbase);
+  environmentStep.attribute = Attribute.Fitness;
+  environmentStep.discipline = Department.Engineering;
+  environmentStep.value = 'Curiosity';
+  character.environmentStep = environmentStep;
+
+  const upbringing = UpbringingsHelper.getUpbringing(
+    EarlyOutlook.BusinessOrTrade,
+  )!;
+  const upbringingStep = new UpbringingStep(upbringing, true);
+  upbringingStep.discipline = Department.Engineering;
+  upbringingStep.focus = 'Engineering';
+  upbringingStep.talent = new SelectedTalent('Bold');
+  character.upbringingStep = upbringingStep;
+
+  const educationStep = new EducationStep(Track.Sciences);
+  educationStep.primaryDiscipline = Department.Engineering;
+  educationStep.enlisted = false;
+  educationStep.disciplines = [Department.Command, Department.Medicine];
+  educationStep.focuses = ['Astrophysics', 'Starship Design'];
+  educationStep.value = 'Courage';
+  educationStep.talent = new SelectedTalent('Cautious');
+  character.educationStep = educationStep;
+
+  if (version === 2) {
+    const careerStep = new CareerStep(Career.Experienced);
+    careerStep.value = 'Harmony';
+    careerStep.talent = new SelectedTalent('Untapped Potential');
+    character.careerStep = careerStep;
+
+    const finishingStep = new FinishingStep();
+    finishingStep.attributes = [Attribute.Daring, Attribute.Fitness];
+    finishingStep.disciplines = [Department.Engineering, Department.Science];
+    finishingStep.value = 'Initiative';
+    finishingStep.talent = new SelectedTalent('Advisor');
+    character.finishingStep = finishingStep;
+  }
+
+  const firstEvent = new CareerEventStep(1);
+  firstEvent.attribute = Attribute.Daring;
+  firstEvent.discipline = Department.Security;
+  firstEvent.focus = 'Survival';
+  firstEvent.trait = 'Dark Secrets';
+  character.careerEvents.push(firstEvent);
+
+  const secondEvent = new CareerEventStep(4);
+  secondEvent.discipline = Department.Command;
+  secondEvent.focus = 'Diplomacy';
+  character.careerEvents.push(secondEvent);
+
+  character.addTrait('Steadfast');
+
+  const advancement = new CharacterAdvancementStep();
+  advancement.choice = CharacterAdvancementChoice.Talent;
+  advancement.value = new SelectedTalent('Supervisor');
+  const promotion = new Promotion(
+    new CharacterRank(
+      RanksHelper.instance().getRank(Rank.LtCommander)?.localizedName ?? '',
+      Rank.LtCommander,
+    ),
+    ModificationType.Promotion,
+  );
+  const reputation = new ReputationChangeStep(2);
+  character.improvements = [advancement, promotion, reputation];
+
+  character.rankValue = new CharacterRank(
+    RanksHelper.instance().getRank(Rank.Lieutenant)?.localizedName ?? '',
+    Rank.Lieutenant,
+  );
+  character.role = Role.ChiefEngineer;
+  character.secondaryRole = Role.OperationsManager;
+  character.assignedShip = 'USS Venture';
+  character.jobAssignment = '';
+
+  return character;
+}
+
+export function makePopulatedNpc(): Character {
+  const character = Character.createNpcCharacter(
+    Era.NextGeneration,
+    2,
+    NpcType.Notable,
+    CharacterType.Starfleet,
+  );
+  character.name = 'Sub-Commander Torel';
+  character.description = 'A Vulcan liaison aboard a starbase.';
+
+  const speciesStep = new SpeciesStep(Species.Vulcan);
+  speciesStep.attributes = [
+    Attribute.Reason,
+    Attribute.Insight,
+    Attribute.Presence,
+  ];
+  character.speciesStep = speciesStep;
+
+  const npcGenerationStep =
+    character.npcGenerationStep ?? new NpcGenerationStep(NpcType.Notable);
+  npcGenerationStep.type = NpcType.Notable;
+  npcGenerationStep.values = ['Logic', 'Peace'];
+  npcGenerationStep.talents = [
+    new SelectedTalent('Bold'),
+    new SelectedTalent('Veteran'),
+  ];
+  npcGenerationStep.attributes = [0, 1, 0, 1, 0, 1];
+  npcGenerationStep.departments = [3, 2, 2, 1, 1, 1];
+  npcGenerationStep.focuses = ['Meditation', 'Vulcan Nerve Pinch', 'Science'];
+  npcGenerationStep.weapons = [PersonalWeaponType.Phaser2];
+  npcGenerationStep.equipment = [EquipmentType.Communicator];
+  character.npcGenerationStep = npcGenerationStep;
+
+  character.rankValue = new CharacterRank('Commander', Rank.Commander);
+  return character;
+}
+
+export function makePopulatedStarship(): Starship {
+  const starship = Starship.createStandardStarship(
+    Era.NextGeneration,
+    CharacterType.Starfleet,
+    2,
+  );
+  starship.name = 'USS Venture';
+  starship.spaceframeModel = SpaceframeHelper.instance().getSpaceframe(
+    Spaceframe.Galaxy_2E,
+  );
+  starship.registry = 'NCC-70637';
+  starship.serviceYear = 2372;
+  starship.traits = 'Flagship, Hero Ship';
+
+  const missionProfile =
+    MissionProfiles.instance.getMissionProfiles(starship)[0];
+  if (missionProfile) {
+    const missionProfileStep = new MissionProfileStep(missionProfile);
+    missionProfileStep.system = missionProfile.systems[0];
+    missionProfileStep.talent = missionProfile.talents.length
+      ? new SelectedTalent(missionProfile.talents[0].name)
+      : undefined;
+    starship.missionProfileStep = missionProfileStep;
+  }
+
+  starship.additionalTalents = [
+    new SelectedTalent('Secondary Reactors'),
+    new SelectedTalent('Redundant Systems'),
+    new SelectedTalent('Dedicated Personnel'),
+  ];
+  starship.refits = [System.Engines, System.Weapons];
+
+  return starship;
+}
+
+export function makePopulatedStation(): Station {
+  const station = Station.create(
+    CharacterType.Starfleet,
+    2,
+    Era.NextGeneration,
+  );
+  station.name = 'Starbase 24';
+  station.stationFrameStep = new StandardStationSpaceframeStep(
+    StationFrame.FederationStarbase,
+  );
+  station.missionProfileStep = new StationMissionProfileStep(
+    MissionProfile.ResearchStation,
+  );
+  station.traits = ['Border Post', 'High Capacity'];
+  station.additionalTalents = [new SelectedTalent('Secondary Reactors')];
+  return station;
+}


### PR DESCRIPTION
Plan B Phase 1 of the VTT exporter refactor: lock current exporter output with golden snapshot tests before the shared-helper extraction phases.

- New shared fixture builder `tests/vtt/vttFixtures.ts` (fully-populated 1e/2e main characters, NPC, Galaxy-2E starship, Federation Starbase)
- New `fantasyGroundsVttExport.test.ts`: raw-XML snapshots (main character + NPC)
- New `roll20VttExporter.test.ts`: JSON snapshots (character, starship, handout) with `Math.random` stubbed for deterministic `IdHelper` IDs; locks the misspelled `ship_communcation` attrib key
- Extended `foundryVttExporter.test.ts`: JSON snapshots (2e/1e character, starship, station) with `Date.now` stubbed

Full check green: 420 tests, 9 snapshots, typecheck, eslint, prettier.