### PR TITLE
Extract localStorage persistence into RTK listener middleware

### DIFF
--- a/WebTools/src/state/contextReducer.ts
+++ b/WebTools/src/state/contextReducer.ts
@@ -17,16 +17,6 @@ interface ContextState {
   allowEsotericTalents: boolean;
 }
 
-const persistContext = (sources: Source[]) => {
-  const contextData = {
-    sources: sources?.length ? sources.map((s) => Source[s]) : [],
-  };
-  window.localStorage.setItem(
-    'settings.contextData',
-    JSON.stringify(contextData),
-  );
-};
-
 let initialData: ContextState = null;
 
 const getInitialData = (): ContextState => {
@@ -85,7 +75,6 @@ export const contextSlice = createSlice({
       ) {
         newSources.splice(newSources.indexOf(Source.Core), 1);
       }
-      persistContext(newSources);
       return {
         ...state,
         sources: newSources,
@@ -114,7 +103,6 @@ export const contextSlice = createSlice({
           });
         }
         existing.push(newSource);
-        persistContext(existing);
         return {
           ...state,
           sources: existing,
@@ -136,7 +124,6 @@ export const contextSlice = createSlice({
         } else {
           const sources = [...state.sources];
           sources.splice(state.sources.indexOf(action.payload), 1);
-          persistContext(sources);
           return {
             ...state,
             sources: sources,

--- a/WebTools/src/state/persistenceMiddleware.ts
+++ b/WebTools/src/state/persistenceMiddleware.ts
@@ -1,0 +1,61 @@
+import { createListenerMiddleware } from '@reduxjs/toolkit';
+import type { AnyAction } from '@reduxjs/toolkit';
+import { Source } from '../helpers/sources';
+import { TableMarshaller } from '../table/model/tableMarshaller';
+import type { RootState } from './store';
+
+const SAVE_CONSTRUCT_TO_LOCAL_STORAGE = 'SAVE_CONSTRUCT_TO_LOCAL_STORAGE';
+const SET_SOURCES = 'SET_SOURCES';
+const ADD_SOURCE = 'ADD_SOURCE';
+const REMOVE_SOURCE = 'REMOVE_SOURCE';
+const IMPORT_TABLE_COLLECTION = 'IMPORT_TABLE_COLLECTION';
+const ADD_TABLE_COLLECTION = 'ADD_TABLE_COLLECTION';
+const DELETE_TABLE_COLLECTION = 'DELETE_TABLE_COLLECTION';
+
+export const persistenceListenerMiddleware =
+  createListenerMiddleware<RootState>();
+
+persistenceListenerMiddleware.startListening({
+  predicate: (action: AnyAction) =>
+    action.type === SAVE_CONSTRUCT_TO_LOCAL_STORAGE,
+  effect: (_, listenerApi) => {
+    const records = listenerApi.getState().savedConstructReducer.records;
+    const data = {
+      records: records ?? [],
+    };
+    window.localStorage.setItem('constructs.records', JSON.stringify(data));
+  },
+});
+
+persistenceListenerMiddleware.startListening({
+  predicate: (action: AnyAction) =>
+    action.type === SET_SOURCES ||
+    action.type === ADD_SOURCE ||
+    action.type === REMOVE_SOURCE,
+  effect: (_, listenerApi) => {
+    const sources = listenerApi.getState().context.sources;
+    const contextData = {
+      sources: sources?.length ? sources.map((s) => Source[s]) : [],
+    };
+    window.localStorage.setItem(
+      'settings.contextData',
+      JSON.stringify(contextData),
+    );
+  },
+});
+
+persistenceListenerMiddleware.startListening({
+  predicate: (action: AnyAction) =>
+    action.type === IMPORT_TABLE_COLLECTION ||
+    action.type === ADD_TABLE_COLLECTION ||
+    action.type === DELETE_TABLE_COLLECTION,
+  effect: (_, listenerApi) => {
+    const collections = listenerApi.getState().table.collections;
+    const data = {
+      collections: collections?.length
+        ? collections.map((s) => TableMarshaller.instance.marshall(s))
+        : [],
+    };
+    window.localStorage.setItem('settings.tableData', JSON.stringify(data));
+  },
+});

--- a/WebTools/src/state/savedConstructReducer.ts
+++ b/WebTools/src/state/savedConstructReducer.ts
@@ -2,13 +2,6 @@ import { createSlice } from '@reduxjs/toolkit';
 import type { AnyAction } from '@reduxjs/toolkit';
 import type { ILocalStorageConstructRecord } from '../common/iLocalStorageConstructRecord';
 
-const persistItems = (records: ILocalStorageConstructRecord[]) => {
-  const data = {
-    records: records ?? [],
-  };
-  window.localStorage.setItem('constructs.records', JSON.stringify(data));
-};
-
 interface SavedConstructState {
   records: ILocalStorageConstructRecord[];
 }
@@ -57,7 +50,6 @@ const handleSave = (state: SavedConstructState, action: AnyAction) => {
   if (records.length > 5) {
     records.splice(0, records.length - 5);
   }
-  persistItems(records);
   return {
     records: records,
   };

--- a/WebTools/src/state/store.ts
+++ b/WebTools/src/state/store.ts
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { combineReducers } from 'redux';
+import { persistenceListenerMiddleware } from './persistenceMiddleware';
 import { characterReducer } from './characterReducer';
 import { star } from './starReducer';
 import { starshipReducer } from './starshipReducer';
@@ -23,8 +24,13 @@ const reducer = combineReducers({
   safety: safetyReducer,
   savedConstructReducer: savedConstructReducer,
 });
+
+export type RootState = ReturnType<typeof reducer>;
+
 export const store = configureStore({
   reducer: reducer,
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware({ serializableCheck: false }),
+    getDefaultMiddleware({ serializableCheck: false }).prepend(
+      persistenceListenerMiddleware.middleware,
+    ),
 });

--- a/WebTools/src/state/tableReducer.ts
+++ b/WebTools/src/state/tableReducer.ts
@@ -316,15 +316,6 @@ const tableCollection2 = new TableCollection(
   'ae0c7045-0894-4523-abdd-1c1e50fb9e86',
 );
 
-const persistTables = (tables: TableCollection[]) => {
-  const data = {
-    collections: tables?.length
-      ? tables.map((s) => TableMarshaller.instance.marshall(s))
-      : [],
-  };
-  window.localStorage.setItem('settings.tableData', JSON.stringify(data));
-};
-
 interface TableState {
   selection: TableCollection;
   collections: TableCollection[];
@@ -369,7 +360,6 @@ const appendCollection = (
   const collections = [...state.collections];
   const collection = action.payload.collection;
   collections.push(collection);
-  persistTables(collections);
   return {
     ...state,
     collections: collections,
@@ -395,7 +385,6 @@ export const tableSlice = createSlice({
       temp.collections = temp.collections.filter(
         (t) => t.uuid !== tableCollection.uuid,
       );
-      persistTables(temp.collections);
       return temp;
     });
     builder.addCase(setTableForEditing, (state, action) => {

--- a/WebTools/tests/state/contextReducer.test.ts
+++ b/WebTools/tests/state/contextReducer.test.ts
@@ -11,8 +11,6 @@ import {
   setSources,
 } from '../../src/state/contextActions';
 
-const STORAGE_KEY = 'settings.contextData';
-
 function createLocalStorageMock(): Storage {
   const storage = new Map<string, string>();
   return {
@@ -40,12 +38,6 @@ beforeAll(() => {
   });
 });
 
-function storedContext() {
-  return JSON.parse(
-    (globalThis.window as any).localStorage.getItem(STORAGE_KEY),
-  );
-}
-
 function stateWithSources(sources: Source[]) {
   return {
     sources: sources,
@@ -70,13 +62,12 @@ describe('contextReducer', () => {
     });
   });
 
-  test('SET_SOURCES replaces the source list and persists it', () => {
+  test('SET_SOURCES replaces the source list', () => {
     const result = contextReducer(
       undefined,
       setSources([Source.Core, Source.AlphaQuadrant]),
     );
     expect(result.sources).toEqual([Source.Core, Source.AlphaQuadrant]);
-    expect(storedContext().sources).toEqual(['Core', 'AlphaQuadrant']);
   });
 
   test('SET_SOURCES refuses both core books: the incoming duplicate is dropped', () => {
@@ -93,10 +84,9 @@ describe('contextReducer', () => {
     expect(twoSecond.sources).toEqual([Source.Core2ndEdition]);
   });
 
-  test('ADD_SOURCE appends a source and persists; adding a duplicate is a no-op', () => {
+  test('ADD_SOURCE appends a source; adding a duplicate is a no-op', () => {
     let result = contextReducer(undefined, addSource(Source.AlphaQuadrant));
     expect(result.sources).toEqual([Source.Core, Source.AlphaQuadrant]);
-    expect(storedContext().sources).toEqual(['Core', 'AlphaQuadrant']);
 
     result = contextReducer(result, addSource(Source.AlphaQuadrant));
     expect(result.sources).toEqual([Source.Core, Source.AlphaQuadrant]);
@@ -105,7 +95,6 @@ describe('contextReducer', () => {
   test('ADD_SOURCE Core2ndEdition removes the original Core book', () => {
     const result = contextReducer(undefined, addSource(Source.Core2ndEdition));
     expect(result.sources).toEqual([Source.Core2ndEdition]);
-    expect(storedContext().sources).toEqual(['Core2ndEdition']);
   });
 
   test('ADD_SOURCE Core removes Core2ndEdition but keeps first edition sources', () => {
@@ -127,14 +116,13 @@ describe('contextReducer', () => {
     expect(secondOnly.sources).toEqual([Source.Core2ndEdition]);
   });
 
-  test('REMOVE_SOURCE removes an existing source and persists the result', () => {
+  test('REMOVE_SOURCE removes an existing source', () => {
     let result = contextReducer(
       undefined,
       setSources([Source.Core, Source.AlphaQuadrant]),
     );
     result = contextReducer(result, removeSource(Source.AlphaQuadrant));
     expect(result.sources).toEqual([Source.Core]);
-    expect(storedContext().sources).toEqual(['Core']);
 
     const missing = contextReducer(result, removeSource(Source.BetaQuadrant));
     expect(missing.sources).toEqual([Source.Core]);

--- a/WebTools/tests/state/savedConstructReducer.test.ts
+++ b/WebTools/tests/state/savedConstructReducer.test.ts
@@ -58,13 +58,6 @@ function saveAction(hash: number, replacementHash?: number) {
   };
 }
 
-function recordedHashes(): number[] {
-  const data = JSON.parse(
-    (globalThis.window as any).localStorage.getItem(STORAGE_KEY),
-  );
-  return data.records.map((r: any) => r.hash);
-}
-
 describe('savedConstructReducer', () => {
   beforeEach(() => {
     (globalThis.window as any).localStorage.clear();
@@ -85,14 +78,13 @@ describe('savedConstructReducer', () => {
     expect(result.records).toEqual([{ hash: 111 }]);
   });
 
-  test('SAVE_CONSTRUCT_TO_LOCAL_STORAGE appends a record and persists it', () => {
+  test('SAVE_CONSTRUCT_TO_LOCAL_STORAGE appends a record', () => {
     const action = saveAction(111);
     const result = savedConstructReducer(undefined, action);
 
     expect(result.records).toHaveLength(1);
     expect(result.records[0].hash).toBe(111);
     expect(result.records[0].name).toBe('Name 111');
-    expect(recordedHashes()).toEqual([111]);
   });
 
   test('SAVE avoids duplicating an identical hash', () => {
@@ -107,7 +99,6 @@ describe('savedConstructReducer', () => {
 
     expect(state.records).toHaveLength(1);
     expect(state.records[0].hash).toBe(222);
-    expect(recordedHashes()).toEqual([222]);
   });
 
   test('SAVE trims the record list down to five entries', () => {
@@ -119,14 +110,12 @@ describe('savedConstructReducer', () => {
     expect(state.records.map((r: any) => r.hash)).toEqual([
       1002, 1003, 1004, 1005, 1006,
     ]);
-    expect(recordedHashes()).toEqual([1002, 1003, 1004, 1005, 1006]);
   });
 
-  test('SAVE persisting is driven by an action produced by the creator', () => {
+  test('SAVE is driven by an action produced by the creator', () => {
     const action = saveCharacterToLocalStorage(makeCharacter());
     const result = savedConstructReducer(undefined, action);
     expect(result.records).toHaveLength(1);
     expect(result.records[0].hash).toBe(action.payload.hash);
-    expect(recordedHashes()).toEqual([action.payload.hash]);
   });
 });

--- a/WebTools/tests/state/storePersistence.test.ts
+++ b/WebTools/tests/state/storePersistence.test.ts
@@ -1,0 +1,202 @@
+import { test, expect, describe, beforeAll, beforeEach } from '@jest/globals';
+import { store } from '../../src/state/store';
+import { Source } from '../../src/helpers/sources';
+import { Era } from '../../src/helpers/erasEnum';
+import {
+  Table,
+  TableCollection,
+  TableRow,
+  ValueResult,
+} from '../../src/table/model/table';
+import { TableMarshaller } from '../../src/table/model/tableMarshaller';
+import { Character } from '../../src/common/character';
+import { CharacterType } from '../../src/common/characterType';
+import {
+  setSources,
+  addSource,
+  removeSource,
+  setEra,
+  setAllowCrossSpeciesTalents,
+  setAllowEsotericTalents,
+} from '../../src/state/contextActions';
+import {
+  importTableCollection,
+  addTableCollection,
+  deleteTableCollection,
+  replaceTableCollection,
+  setTableCollectionSelection,
+  setTableForEditing,
+} from '../../src/state/tableActions';
+import { saveCharacterToLocalStorage } from '../../src/state/savedConstructActions';
+
+const CONSTRUCTS_KEY = 'constructs.records';
+const CONTEXT_KEY = 'settings.contextData';
+const TABLE_KEY = 'settings.tableData';
+
+function createLocalStorageMock(): Storage {
+  const storage = new Map<string, string>();
+  return {
+    get length() {
+      return storage.size;
+    },
+    clear: () => storage.clear(),
+    getItem: (key: string) =>
+      storage.has(key) ? (storage.get(key) ?? null) : null,
+    key: (index: number) => Array.from(storage.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+  } as Storage;
+}
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, 'window', {
+    value: { localStorage: createLocalStorageMock() },
+    configurable: true,
+    writable: true,
+  });
+});
+
+function stored(key: string) {
+  const raw = (globalThis.window as any).localStorage.getItem(key);
+  return raw ? JSON.parse(raw) : null;
+}
+
+function persistedTableUuids(): string[] {
+  const data = stored(TABLE_KEY);
+  return data.collections.map(
+    (c: any) => TableMarshaller.instance.unmarshall(c).uuid,
+  );
+}
+
+function makeCollection(name: string, uuid: string): TableCollection {
+  return new TableCollection(
+    new Table(name, [new TableRow(new ValueResult(name + ' result'), 1)]),
+    'blurb',
+    'category',
+    uuid,
+  );
+}
+
+describe('store persistence', () => {
+  beforeEach(() => {
+    (globalThis.window as any).localStorage.clear();
+  });
+
+  describe('for saved constructs', () => {
+    test('SAVE_CONSTRUCT_TO_LOCAL_STORAGE persists the record list', () => {
+      store.dispatch(
+        saveCharacterToLocalStorage(
+          Character.createMainCharacter(
+            CharacterType.Starfleet,
+            Era.NextGeneration,
+            2,
+          ),
+        ),
+      );
+      const data = stored(CONSTRUCTS_KEY);
+      expect(data.records).toHaveLength(1);
+      expect(data.records[0].type).toBe('Character');
+    });
+  });
+
+  describe('for context', () => {
+    test('SET_SOURCES replaces and persists the source list', () => {
+      store.dispatch(setSources([Source.Core, Source.AlphaQuadrant]));
+      expect(stored(CONTEXT_KEY).sources).toEqual(['Core', 'AlphaQuadrant']);
+    });
+
+    test('ADD_SOURCE persists the appended source', () => {
+      store.dispatch(setSources([Source.Core]));
+      store.dispatch(addSource(Source.AlphaQuadrant));
+      expect(stored(CONTEXT_KEY).sources).toEqual(['Core', 'AlphaQuadrant']);
+    });
+
+    test('REMOVE_SOURCE persists the remaining source', () => {
+      store.dispatch(setSources([Source.Core, Source.AlphaQuadrant]));
+      store.dispatch(removeSource(Source.AlphaQuadrant));
+      expect(stored(CONTEXT_KEY).sources).toEqual(['Core']);
+    });
+
+    test('SET_ERA does not persist', () => {
+      store.dispatch(setEra(Era.Enterprise));
+      expect(stored(CONTEXT_KEY)).toBeNull();
+    });
+
+    test('talent-allowance flags do not persist', () => {
+      store.dispatch(setAllowCrossSpeciesTalents(true));
+      store.dispatch(setAllowEsotericTalents(true));
+      expect(stored(CONTEXT_KEY)).toBeNull();
+    });
+  });
+
+  describe('for table', () => {
+    test('ADD_TABLE_COLLECTION persists the collections', () => {
+      store.dispatch(addTableCollection(makeCollection('New', 'uuid-add')));
+      expect(persistedTableUuids()).toContain('uuid-add');
+    });
+
+    test('IMPORT_TABLE_COLLECTION persists the collections', () => {
+      store.dispatch(
+        importTableCollection(makeCollection('Imported', 'uuid-import')),
+      );
+      expect(persistedTableUuids()).toContain('uuid-import');
+    });
+
+    test('DELETE_TABLE_COLLECTION persists the trimmed collections', () => {
+      const a = makeCollection('A', 'uuid-a');
+      store.dispatch(addTableCollection(a));
+      store.dispatch(deleteTableCollection(a));
+      expect(persistedTableUuids()).not.toContain('uuid-a');
+    });
+
+    test('REPLACE_TABLE_COLLECTION does not persist', () => {
+      const a = makeCollection('A', 'uuid-a');
+      store.dispatch(addTableCollection(a));
+      store.dispatch(
+        replaceTableCollection('uuid-a', makeCollection('R', 'uuid-r')),
+      );
+      expect(persistedTableUuids()).not.toContain('uuid-r');
+    });
+
+    test('SET_TABLE_COLLECTION_SELECTION does not persist', () => {
+      store.dispatch(
+        setTableCollectionSelection(makeCollection('S', 'uuid-s')),
+      );
+      expect(stored(TABLE_KEY)).toBeNull();
+    });
+
+    test('SET_TABLE_FOR_EDITING does not persist', () => {
+      store.dispatch(setTableForEditing(makeCollection('E', 'uuid-e')));
+      expect(stored(TABLE_KEY)).toBeNull();
+    });
+  });
+
+  describe('hydration at store build', () => {
+    test('loads saved constructs, context, and table from storage', async () => {
+      (globalThis.window as any).localStorage.setItem(
+        CONSTRUCTS_KEY,
+        JSON.stringify({
+          records: [{ hash: 1, name: 'H', type: 'Character' }],
+        }),
+      );
+      (globalThis.window as any).localStorage.setItem(
+        CONTEXT_KEY,
+        JSON.stringify({ sources: ['Core', 'AlphaQuadrant'] }),
+      );
+
+      jest.resetModules();
+      const freshStore = (await import('../../src/state/store')).store;
+
+      expect(freshStore.getState().savedConstructReducer.records).toEqual([
+        { hash: 1, name: 'H', type: 'Character' },
+      ]);
+      expect(freshStore.getState().context.sources).toContain(
+        Source.AlphaQuadrant,
+      );
+    });
+  });
+});

--- a/WebTools/tests/state/tableReducer.test.ts
+++ b/WebTools/tests/state/tableReducer.test.ts
@@ -1,11 +1,10 @@
-import { test, expect, describe, beforeAll, beforeEach } from '@jest/globals';
+import { test, expect, describe, beforeAll } from '@jest/globals';
 import {
   Table,
   TableCollection,
   TableRow,
   ValueResult,
 } from '../../src/table/model/table';
-import { TableMarshaller } from '../../src/table/model/tableMarshaller';
 import { tableReducer } from '../../src/state/tableReducer';
 import {
   addTableCollection,
@@ -15,8 +14,6 @@ import {
   setTableCollectionSelection,
   setTableForEditing,
 } from '../../src/state/tableActions';
-
-const STORAGE_KEY = 'settings.tableData';
 
 function createLocalStorageMock(): Storage {
   const storage = new Map<string, string>();
@@ -54,18 +51,7 @@ function makeCollection(name: string, uuid: string): TableCollection {
   );
 }
 
-function storedCollections() {
-  const data = JSON.parse(
-    (globalThis.window as any).localStorage.getItem(STORAGE_KEY),
-  );
-  return data.collections;
-}
-
 describe('tableReducer', () => {
-  beforeEach(() => {
-    (globalThis.window as any).localStorage.clear();
-  });
-
   test('returns the two built-in deployments for an unknown action', () => {
     const result = tableReducer(undefined, { type: 'UNKNOWN' });
     expect(result.selection).toBeNull();
@@ -78,17 +64,13 @@ describe('tableReducer', () => {
     );
   });
 
-  test('ADD_TABLE_COLLECTION appends a collection and persists it', () => {
+  test('ADD_TABLE_COLLECTION appends a collection', () => {
     const added = makeCollection('New Collection', 'uuid-new');
     const result = tableReducer(
       { selection: null, collections: [] },
       addTableCollection(added),
     );
     expect(result.collections).toEqual([added]);
-    expect(storedCollections()).toHaveLength(1);
-    expect(
-      TableMarshaller.instance.unmarshall(storedCollections()[0]).uuid,
-    ).toBe('uuid-new');
   });
 
   test('IMPORT_TABLE_COLLECTION behaves like ADD_TABLE_COLLECTION', () => {
@@ -98,10 +80,6 @@ describe('tableReducer', () => {
       importTableCollection(imported),
     );
     expect(result.collections).toEqual([imported]);
-    expect(storedCollections()).toHaveLength(1);
-    expect(
-      TableMarshaller.instance.unmarshall(storedCollections()[0]).uuid,
-    ).toBe('uuid-import');
   });
 
   test('SET_TABLE_COLLECTION_SELECTION stores the selected collection', () => {
@@ -122,7 +100,7 @@ describe('tableReducer', () => {
     expect(updated.editing).toBe(editing);
   });
 
-  test('DELETE_TABLE_COLLECTION removes the matching uuid and persists', () => {
+  test('DELETE_TABLE_COLLECTION removes the matching uuid', () => {
     const first = makeCollection('First', 'uuid-1');
     const second = makeCollection('Second', 'uuid-2');
     const result = tableReducer(
@@ -130,10 +108,6 @@ describe('tableReducer', () => {
       deleteTableCollection(first),
     );
     expect(result.collections).toEqual([second]);
-    expect(storedCollections()).toHaveLength(1);
-    expect(
-      TableMarshaller.instance.unmarshall(storedCollections()[0]).uuid,
-    ).toBe('uuid-2');
   });
 
   test('REPLACE_TABLE_COLLECTION removes the old uuid and appends the new', () => {
@@ -145,18 +119,5 @@ describe('tableReducer', () => {
       replaceTableCollection(first.uuid, replacement),
     );
     expect(result.collections.map((c) => c.uuid)).toEqual(['uuid-2', 'uuid-3']);
-  });
-
-  test('persisted collections unmarshall back to the same collections', () => {
-    const added = makeCollection('Round Trip', 'uuid-roundtrip');
-    tableReducer(
-      { selection: null, collections: [] },
-      addTableCollection(added),
-    );
-    const reparsed = TableMarshaller.instance.unmarshall(
-      storedCollections()[0],
-    );
-    expect(reparsed.uuid).toBe('uuid-roundtrip');
-    expect(reparsed.mainTable.name).toBe('Round Trip');
   });
 });


### PR DESCRIPTION
Two commits on refactor/redux-persistence, base sta-complete.

Commit 1 (124543e6): add store-level persistence integration tests. New tests/state/storePersistence.test.ts dispatches against the real store and locks the exact persistence contract: SAVE_CONSTRUCT_TO_LOCAL_STORAGE, SET_SOURCES/ADD_SOURCE/REMOVE_SOURCE, and IMPORT/ADD/DELETE_TABLE_COLLECTION persist; SET_ERA, the talent-allowance flags, and replaceTableCollection/setTableCollectionSelection/setTableForEditing do not. Includes a store-build hydration test via jest.resetModules.

Commit 2 (068672db): migrate persistence out of the three reducers (savedConstruct, context, table) into a single createListenerMiddleware in persistenceMiddleware.ts, wired into store.ts with .prepend(). Reducers become pure (no localStorage side effects); hydration via slice getInitialData is unchanged. RootState is now exported from store.ts (type-only import in the middleware, no circular dependency).

The reducer unit tests dropped their now-invalid direct-persistence assertions; storage-write coverage lives in the store-level test.